### PR TITLE
Fix double throw of captured exception in thread group.

### DIFF
--- a/arbor/execution_context.cpp
+++ b/arbor/execution_context.cpp
@@ -2,14 +2,13 @@
 #include <memory>
 
 #include <arbor/context.hpp>
-#include <arbor/version.hpp>
 
 #include "gpu_context.hpp"
 #include "distributed_context.hpp"
 #include "execution_context.hpp"
 #include "threading/threading.hpp"
 
-#ifdef ARB_MPI_ENABLED
+#ifdef ARB_HAVE_MPI
 #include <mpi.h>
 #endif
 
@@ -34,7 +33,7 @@ context make_context(const proc_allocation& p) {
     return context(new execution_context(p), [](execution_context* p){delete p;});
 }
 
-#ifdef ARB_MPI_ENABLED
+#ifdef ARB_HAVE_MPI
 template <>
 execution_context::execution_context(const proc_allocation& resources, MPI_Comm comm):
     distributed(make_mpi_context(comm)),


### PR DESCRIPTION
Fixes #603.

* Clear exception pointer in exception_state helper class after move of state.
* Rename exception_state::get() method to reset().
* Call std::terminate() if task_group is destroyed before tasks are collected with wait().
* Do not attempt to collect tasks in destructor for task_group.
* Do not attempt to rethrow exception in destructor for exception_state.
* Add unit test to verify correct exception behaviour when a task_group is runs and waits on a series of tasks.
* Add unit test for terminate behaviour as above.

Code quality fix ups:
* Remove unused warning variable warning in threading exception tests.
* Address if-statement spacing in threading.hpp.
* Use ARB_HAVE_MPI in execution_context.cpp instead of introducing a dependency on generated version header via feature macro ARB_MPI_ENABLED.