### PR TITLE
Extend ring

### DIFF
--- a/example/ring/parameters.hpp
+++ b/example/ring/parameters.hpp
@@ -25,7 +25,6 @@ struct cell_parameters {
 
     // The number of synapses per cell.
     unsigned synapses = 1;
-    bool hh_dend = false;
 };
 
 struct ring_params {
@@ -70,7 +69,6 @@ ring_params read_options(int argc, char** argv) {
     param_from_json(params.cell.compartments, "compartments", json);
     param_from_json(params.cell.lengths, "lengths", json);
     param_from_json(params.cell.synapses, "synapses", json);
-    param_from_json(params.cell.hh_dend, "hh-dendrites", json);
 
     if (!json.empty()) {
         for (auto it=json.begin(); it!=json.end(); ++it) {

--- a/example/ring/parameters.hpp
+++ b/example/ring/parameters.hpp
@@ -22,6 +22,10 @@ struct cell_parameters {
     std::array<double,2> branch_probs = {1.0, 0.5}; //  Probability of a branch occuring.
     std::array<unsigned,2> compartments = {20, 2};  //  Compartment count on a branch.
     std::array<double,2> lengths = {200, 20};       //  Length of branch in μm.
+
+    // The number of synapses per cell.
+    unsigned synapses = 1;
+    bool hh_dend = false;
 };
 
 struct ring_params {
@@ -65,6 +69,8 @@ ring_params read_options(int argc, char** argv) {
     param_from_json(params.cell.branch_probs, "branch-probs", json);
     param_from_json(params.cell.compartments, "compartments", json);
     param_from_json(params.cell.lengths, "lengths", json);
+    param_from_json(params.cell.synapses, "synapses", json);
+    param_from_json(params.cell.hh_dend, "hh-dendrites", json);
 
     if (!json.empty()) {
         for (auto it=json.begin(); it!=json.end(); ++it) {

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -109,7 +109,7 @@ private:
     cell_size_type num_cells_;
     cell_parameters cell_params_;
     double min_delay_;
-    float event_weight_ = 0.01;
+    float event_weight_ = 0.05;
 };
 
 struct cell_stats {
@@ -324,12 +324,7 @@ arb::mc_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) 
                     sec_ids.push_back(nsec++);
                     auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
                     dend->set_compartments(nc);
-                    if (params.hh_dend) {
-                        dend->add_mechanism("hh");
-                    }
-                    else {
-                        dend->add_mechanism("pas");
-                    }
+                    dend->add_mechanism("pas");
                     dend->rL = 100;
                 }
             }

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -86,7 +86,7 @@ public:
     std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
         std::vector<arb::event_generator> gens;
         if (!gid) {
-            gens.push_back(arb::explicit_generator(arb::pse_vector{{{0, 0}, 0.1, 1.0}}));
+            gens.push_back(arb::explicit_generator(arb::pse_vector{{{0, 0}, event_weight_, 1.0}}));
         }
         return gens;
     }
@@ -324,7 +324,12 @@ arb::mc_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) 
                     sec_ids.push_back(nsec++);
                     auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
                     dend->set_compartments(nc);
-                    dend->add_mechanism("pas");
+                    if (params.hh_dend) {
+                        dend->add_mechanism("hh");
+                    }
+                    else {
+                        dend->add_mechanism("pas");
+                    }
                     dend->rL = 100;
                 }
             }
@@ -340,6 +345,11 @@ arb::mc_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) 
 
     // Add a synapse to the mid point of the first dendrite.
     cell.add_synapse({1, 0.5}, "expsyn");
+
+    // Add additional synapses that will not be connected to anything.
+    for (unsigned i=1u; i<params.synapses; ++i) {
+        cell.add_synapse({1, 0.5}, "expsyn");
+    }
 
     return cell;
 }


### PR DESCRIPTION
Extend the ring benchmark to have an optional number of synapses attached to each cell, instead of a fixed count of one synapse per cell.

This doesn't change the behavior of the model: only the first synapse is used for communication.

The other synapses only effect is to increase the per-cell computational overheads, to more effectively mimic real world performance.