### PR TITLE
fix weights in ring benchmark

### DIFF
--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -86,7 +86,7 @@ public:
     std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
         std::vector<arb::event_generator> gens;
         if (!gid) {
-            gens.push_back(arb::explicit_generator(arb::pse_vector{{{0, 0}, event_weight_, 1.0}}));
+            gens.push_back(arb::explicit_generator(arb::pse_vector{{{0, 0}, 1.0, event_weight_}}));
         }
         return gens;
     }


### PR DESCRIPTION
Fix potential numeric instabilities in the ring benchmark caused by passing arguments to an event generator in the wrong order.