### PR TITLE
forward cuda header paths to host compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,6 @@ if(ARB_WITH_GPU)
     target_compile_options(arbor-private-deps INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_37,code=sm_37>)
     target_compile_options(arbor-private-deps INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_60,code=sm_60>)
     target_compile_options(arbor-private-deps INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_70,code=sm_70>)
-
 endif()
 
 # Use libunwind if available for pretty printing stack traces

--- a/arbor/CMakeLists.txt
+++ b/arbor/CMakeLists.txt
@@ -92,6 +92,10 @@ add_library(arbor-private-headers INTERFACE)
 target_include_directories(arbor-private-headers INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 
+if(ARB_WITH_GPU)
+    target_include_directories(arbor-private-headers INTERFACE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+endif()
+
 install(TARGETS arbor-private-headers EXPORT arbor-targets)
 
 # Mechanisms, generated from .mod files; sets arbor_mechanism_sources


### PR DESCRIPTION
Forwared the gloriously-named CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES to the host compiler.

Fixes #651 