### PR TITLE
Fix thread-GPU affinity bug.

### DIFF
--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -114,6 +114,14 @@ private:
     static unsigned dt_steps(value_type t0, value_type t1, value_type dt) {
         return t0>=t1? 0: 1+(unsigned)((t1-t0)/dt);
     }
+
+    // Sets the GPU used for CUDA calls from the thread that calls it.
+    // The GPU will be the one in the execution context context_.
+    // If not called, the thread may attempt to launch on a different GPU,
+    // leading to crashes.
+    void set_gpu() {
+        if (context_.gpu->has_gpu()) context_.gpu->set_gpu();
+    }
 };
 
 template <typename Backend>
@@ -151,6 +159,8 @@ fvm_integration_result fvm_lowered_cell_impl<Backend>::integrate(
     std::vector<sample_event> staged_samples)
 {
     using util::as_const;
+
+    set_gpu();
 
     // Integration setup
     PE(advance_integrate_setup);
@@ -300,6 +310,8 @@ void fvm_lowered_cell_impl<B>::initialize(
     using util::make_span;
     using util::value_by_key;
     using util::keys;
+
+    set_gpu();
 
     std::vector<mc_cell> cells;
     const std::size_t ncell = gids.size();

--- a/arbor/gpu_context.hpp
+++ b/arbor/gpu_context.hpp
@@ -17,6 +17,9 @@ public:
     bool has_atomic_double() const;
     void synchronize_for_managed_access() const;
     bool has_gpu() const;
+    // Calls cudaSetDevice(id), so that GPU calls from the calling thread will
+    // be executed on the GPU.
+    void set_gpu() const;
 };
 
 using gpu_context_handle = std::shared_ptr<gpu_context>;

--- a/arbor/memory/cuda_wrappers.cpp
+++ b/arbor/memory/cuda_wrappers.cpp
@@ -11,7 +11,7 @@
 #include <cuda_runtime.h>
 
 #define HANDLE_CUDA_ERROR(error, msg)\
-throw arbor_exception("memory:: "+std::string(__func__)+" "+std::string((msg))+": "+cudaGetErrorString(error));
+throw arbor_exception("CUDA memory:: "+std::string(__func__)+" "+std::string((msg))+": "+cudaGetErrorString(error));
 
 namespace arb {
 namespace memory {
@@ -21,21 +21,18 @@ using std::to_string;
 void cuda_memcpy_d2d(void* dest, const void* src, std::size_t n) {
     if (auto error = cudaMemcpy(dest, src, n, cudaMemcpyDeviceToDevice)) {
         HANDLE_CUDA_ERROR(error, "n="+to_string(n));
-        abort();
     }
 }
 
 void cuda_memcpy_d2h(void* dest, const void* src, std::size_t n) {
     if (auto error = cudaMemcpy(dest, src, n, cudaMemcpyDeviceToHost)) {
         HANDLE_CUDA_ERROR(error, "n="+to_string(n));
-        abort();
     }
 }
 
 void cuda_memcpy_h2d(void* dest, const void* src, std::size_t n) {
     if (auto error = cudaMemcpy(dest, src, n, cudaMemcpyHostToDevice)) {
         HANDLE_CUDA_ERROR(error, "n="+to_string(n));
-        abort();
     }
 }
 

--- a/arbor/memory/cuda_wrappers.cpp
+++ b/arbor/memory/cuda_wrappers.cpp
@@ -1,6 +1,8 @@
 #include <cstdlib>
 #include <string>
 
+#include <arbor/arbexcept.hpp>
+
 #include "util.hpp"
 
 #ifdef ARB_HAVE_GPU
@@ -8,8 +10,8 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#define LOG_CUDA_ERROR(error, msg)\
-LOG_ERROR("memory:: "+std::string(__func__)+" "+std::string((msg))+": "+cudaGetErrorString(error))
+#define HANDLE_CUDA_ERROR(error, msg)\
+throw arbor_exception("memory:: "+std::string(__func__)+" "+std::string((msg))+": "+cudaGetErrorString(error));
 
 namespace arb {
 namespace memory {
@@ -18,29 +20,28 @@ using std::to_string;
 
 void cuda_memcpy_d2d(void* dest, const void* src, std::size_t n) {
     if (auto error = cudaMemcpy(dest, src, n, cudaMemcpyDeviceToDevice)) {
-        LOG_CUDA_ERROR(error, "n="+to_string(n));
+        HANDLE_CUDA_ERROR(error, "n="+to_string(n));
         abort();
     }
 }
 
 void cuda_memcpy_d2h(void* dest, const void* src, std::size_t n) {
     if (auto error = cudaMemcpy(dest, src, n, cudaMemcpyDeviceToHost)) {
-        LOG_CUDA_ERROR(error, "n="+to_string(n));
+        HANDLE_CUDA_ERROR(error, "n="+to_string(n));
         abort();
     }
 }
 
 void cuda_memcpy_h2d(void* dest, const void* src, std::size_t n) {
     if (auto error = cudaMemcpy(dest, src, n, cudaMemcpyHostToDevice)) {
-        LOG_CUDA_ERROR(error, "n="+to_string(n));
+        HANDLE_CUDA_ERROR(error, "n="+to_string(n));
         abort();
     }
 }
 
 void* cuda_host_register(void* ptr, std::size_t size) {
     if (auto error = cudaHostRegister(ptr, size, cudaHostRegisterPortable)) {
-        LOG_CUDA_ERROR(error, "unable to register host memory");
-        return nullptr;
+        HANDLE_CUDA_ERROR(error, "unable to register host memory");
     }
     return ptr;
 }
@@ -53,8 +54,7 @@ void* cuda_malloc(std::size_t n) {
     void* ptr;
 
     if (auto error = cudaMalloc(&ptr, n)) {
-        LOG_CUDA_ERROR(error, "unable to allocate "+to_string(n)+" bytes");
-        ptr = nullptr;
+        HANDLE_CUDA_ERROR(error, "unable to allocate "+to_string(n)+" bytes");
     }
     return ptr;
 }
@@ -63,15 +63,14 @@ void* cuda_malloc_managed(std::size_t n) {
     void* ptr;
 
     if (auto error = cudaMallocManaged(&ptr, n)) {
-        LOG_CUDA_ERROR(error, "unable to allocate "+to_string(n)+" bytes");
-        ptr = nullptr;
+        HANDLE_CUDA_ERROR(error, "unable to allocate "+to_string(n)+" bytes of managed memory");
     }
     return ptr;
 }
 
 void cuda_free(void* ptr) {
     if (auto error = cudaFree(ptr)) {
-        LOG_CUDA_ERROR(error, "");
+        HANDLE_CUDA_ERROR(error, "");
     }
 }
 


### PR DESCRIPTION
Ensure that all threads use the same GPU, which wasn't the case before.

* add `gpu_context::set_gpu()` method that will set all subsequent GPU calls from the calling thread run on the GPU of `gpu_context`.
* `fvm_lowered_cell_impl` now calls the `set_gpu` method on construction and `advance`.
* Also changed GPU memory allocation errors in `arb::memory` to throw `arb_exception` instead of calling `std::terminate` on error. Now errors due to poor GPU configuration can be caught by the calling application, and unit tests fail gracefully and allow other tests to run.

Fixes #655 