### PR TITLE
Wrap std::function for sup::on_scope_exit.

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -94,6 +94,7 @@ set(unit_sources
     test_schedule.cpp
     test_spike_source.cpp
     test_local_context.cpp
+    test_scope_exit.cpp
     test_simd.cpp
     test_span.cpp
     test_spikes.cpp

--- a/test/unit/test_scope_exit.cpp
+++ b/test/unit/test_scope_exit.cpp
@@ -1,0 +1,49 @@
+#include <functional>
+
+#include "../gtest.h"
+
+#include <sup/scope_exit.hpp>
+
+using sup::on_scope_exit;
+
+TEST(scope_exit, basic) {
+    bool a = false;
+    {
+        auto guard = on_scope_exit([&a] { a = true; });
+        EXPECT_FALSE(a);
+    }
+    EXPECT_TRUE(a);
+}
+
+TEST(scope_exit, noexceptcall) {
+    auto guard1 = on_scope_exit([] {});
+    using G1 = decltype(guard1);
+    EXPECT_FALSE(noexcept(guard1.~G1()));
+
+    auto guard2 = on_scope_exit([]() noexcept {});
+    using G2 = decltype(guard2);
+    EXPECT_TRUE(noexcept(guard2.~G2()));
+}
+
+TEST(scope_exit, function) {
+    // on_scope_exit has a special overload for std::function
+    // to work around its non-noexcept move ctor.
+    bool a = false;
+    std::function<void ()> setter = [&a] { a = true; };
+
+    {
+        auto guard = on_scope_exit(setter);
+        EXPECT_FALSE(a);
+    }
+    EXPECT_TRUE(a);
+
+    a = false;
+    std::function<int ()> setter2 = [&a] { a = true; return 3; };
+
+    {
+        auto guard = on_scope_exit(setter2);
+        EXPECT_FALSE(a);
+    }
+    EXPECT_TRUE(a);
+}
+


### PR DESCRIPTION
* Provide a helper wrapper for use behind the scenes in the implementation of `sup::on_scope_exit` so that we can work around `std::function` not being nothrow move constructible (and maintaining the nothrow move on the `sup::scope_exit` structure).

Fixes #664.