### PR TITLE
Optimize vectorized compound_indexed_add

### DIFF
--- a/include/arbor/simd/simd.hpp
+++ b/include/arbor/simd/simd.hpp
@@ -220,8 +220,15 @@ namespace simd_detail {
                     scalar_type a[width];
                     Impl::copy_to(s, a);
 
+                    scalar_type temp = 0;
                     for (unsigned i = 0; i<width; ++i) {
-                            p[o[i]] += a[i];
+                        unsigned curr_index_ = o[i];
+                        unsigned next_index_ = i == width - 1 ? o[i]+1 : o[i+1];
+                        temp += a[i];
+                        if(curr_index_ != next_index_) {
+                            p[curr_index_] += temp;
+                            temp = 0;
+                        }
                     }
                 }
                 break;

--- a/include/arbor/simd/simd.hpp
+++ b/include/arbor/simd/simd.hpp
@@ -221,15 +221,14 @@ namespace simd_detail {
                     Impl::copy_to(s, a);
 
                     scalar_type temp = 0;
-                    for (unsigned i = 0; i<width; ++i) {
-                        unsigned curr_index_ = o[i];
-                        unsigned next_index_ = i == width - 1 ? o[i]+1 : o[i+1];
+                    for (unsigned i = 0; i<width-1; ++i) {
                         temp += a[i];
-                        if(curr_index_ != next_index_) {
-                            p[curr_index_] += temp;
+                        if (o[i] != o[i+1]) {
+                            p[o[i]] += temp;
                             temp = 0;
                         }
                     }
+                    p[o[width-1]] = temp;
                 }
                 break;
             case index_constraint::independent:


### PR DESCRIPTION
Optimize "none" index_constraint specialization of compound_indexed_add. 
Only read/write each distinct memory index once per vector. 
Related to issue #637