### PR TITLE
Remove special gid arithmetic ops from cell_member_type.

### DIFF
--- a/arbor/communication/dry_run_context.cpp
+++ b/arbor/communication/dry_run_context.cpp
@@ -29,7 +29,7 @@ struct dry_run_context_impl {
 
         for (count_type i = 0; i < num_ranks_; i++) {
             for (count_type j = i*local_size; j < (i+1)*local_size; j++){
-                gathered_spikes[j].source += num_cells_per_tile_*i;
+                gathered_spikes[j].source.gid += num_cells_per_tile_*i;
             }
         }
 

--- a/arbor/include/arbor/common_types.hpp
+++ b/arbor/include/arbor/common_types.hpp
@@ -47,28 +47,6 @@ using cell_local_size_type = std::make_unsigned_t<cell_lid_type>;
 struct cell_member_type {
     cell_gid_type gid;
     cell_lid_type index;
-
-    cell_member_type& operator= (cell_gid_type inc) {
-        gid = inc;
-        return *this;
-    }
-
-    cell_member_type& operator+= (cell_gid_type inc) {
-        gid += inc;
-        return *this;
-    }
-
-    friend cell_member_type operator+ (const cell_member_type& lhs, const cell_gid_type rhs) {
-        cell_member_type result = lhs;
-        result.gid += rhs;
-        return result;
-    }
-
-    friend cell_member_type operator% (const cell_member_type& lhs, const cell_gid_type rhs) {
-        cell_member_type result = lhs;
-        result.gid %= rhs;
-        return result;
-    }
 };
 
 ARB_DEFINE_LEXICOGRAPHIC_ORDERING(cell_member_type,(a.gid,a.index),(b.gid,b.index))

--- a/arbor/include/arbor/symmetric_recipe.hpp
+++ b/arbor/include/arbor/symmetric_recipe.hpp
@@ -67,8 +67,8 @@ public:
         std::vector<cell_connection> conns = tiled_recipe_->connections_on(i % n_local);
 
         for (unsigned j = 0; j < conns.size(); j++) {
-            conns[j].source = (conns[j].source + offset) % n_global;
-            conns[j].dest = (conns[j].dest + offset) % n_global;
+            conns[j].source.gid = (conns[j].source.gid + offset) % n_global;
+            conns[j].dest.gid = (conns[j].dest.gid + offset) % n_global;
         }
         return conns;
     }


### PR DESCRIPTION
Somewhere along the line, some extensions were made to `cell_member_type` to facilitate some arithmetic on the `gid` field. These operations tend to blur the distinction between a gid and a `cell_member_type` value, and are besides used only in a couple of places.

* Remove `cell_member_type` arithmetic with `gid` methods/functions.
* Replace usage of these short cuts with explicit use of `gid` field in `dry_run_context_impl` and `symmetric_recipe`.