### PR TITLE
Add exception for cross-group GJ error.

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -26,11 +26,16 @@ bad_probe_id::bad_probe_id(cell_member_type probe_id):
     probe_id(probe_id)
 {}
 
+gj_unsupported_domain_decomposition::gj_unsupported_domain_decomposition(cell_gid_type gid_0, cell_gid_type gid_1):
+    arbor_exception(pprintf("No support for gap junctions across domain decomposition groups for gid {} and {}", gid_0, gid_1)),
+    gid_0(gid_0),
+    gid_1(gid_1)
+{}
 
 gj_kind_mismatch::gj_kind_mismatch(cell_gid_type gid_0, cell_gid_type gid_1):
-        arbor_exception(pprintf("Cells on gid {} and {} connected via gap junction have different cell kinds", gid_0, gid_1)),
-        gid_0(gid_0),
-        gid_1(gid_1)
+    arbor_exception(pprintf("Cells on gid {} and {} connected via gap junction have different cell kinds", gid_0, gid_1)),
+    gid_0(gid_0),
+    gid_1(gid_1)
 {}
 
 bad_event_time::bad_event_time(time_type event_time, time_type sim_time):

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -50,6 +50,13 @@ struct gj_kind_mismatch: arbor_exception {
     cell_gid_type gid_0, gid_1;
 };
 
+// Domain decomposition errors:
+
+struct gj_unsupported_domain_decomposition: arbor_exception {
+    gj_unsupported_domain_decomposition(cell_gid_type gid_0, cell_gid_type gid_1);
+    cell_gid_type gid_0, gid_1;
+};
+
 // Simulation errors:
 
 struct bad_event_time: arbor_exception {

--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -90,8 +90,7 @@ void mc_cell_group::generate_deps_gids(const recipe& rec, std::vector<cell_gid_t
                         throw bad_cell_description(cell_kind::cable1d_neuron, g);
 
                 if (!gid_to_loc.count(peer)) {
-                    // actually an error in the domain decomposition...
-                    throw bad_cell_description(cell_kind::cable1d_neuron, g);
+                    throw gj_unsupported_domain_decomposition(g, peer);
                 }
 
                 if (!visited.count(peer)) {


### PR DESCRIPTION
* Add derived `gj_unsupported_domain_decomposition` exception, and throw it when an `mc_cell_group` cell set is not closed under GJ connection.