### PR TITLE
Less verbosity in arb::simd namespaces

### DIFF
--- a/arbor/include/arbor/simd/approx.hpp
+++ b/arbor/include/arbor/simd/approx.hpp
@@ -14,7 +14,7 @@
 
 namespace arb {
 namespace simd {
-namespace simd_detail {
+namespace detail {
 
 // Exponential:
 //
@@ -81,6 +81,6 @@ constexpr double Q2log = 8.29875266912776603211e1;
 constexpr double Q3log = 4.52279145837532221105e1;
 constexpr double Q4log = 1.12873587189167450590e1;
 
-} // namespace simd_detail
+} // namespace detail
 } // namespace simd
 } // namespace arb

--- a/arbor/include/arbor/simd/avx.hpp
+++ b/arbor/include/arbor/simd/avx.hpp
@@ -13,7 +13,7 @@
 
 namespace arb {
 namespace simd {
-namespace simd_detail {
+namespace detail {
 
 struct avx_int4;
 struct avx_double4;
@@ -968,19 +968,19 @@ protected:
 };
 #endif // defined(__AVX2__) && defined(__FMA__)
 
-} // namespace simd_detail
+} // namespace detail
 
 namespace simd_abi {
     template <typename T, unsigned N> struct avx;
 
-    template <> struct avx<int, 4> { using type = simd_detail::avx_int4; };
-    template <> struct avx<double, 4> { using type = simd_detail::avx_double4; };
+    template <> struct avx<int, 4> { using type = detail::avx_int4; };
+    template <> struct avx<double, 4> { using type = detail::avx_double4; };
 
 #if defined(__AVX2__) && defined(__FMA__)
     template <typename T, unsigned N> struct avx2;
 
-    template <> struct avx2<int, 4> { using type = simd_detail::avx2_int4; };
-    template <> struct avx2<double, 4> { using type = simd_detail::avx2_double4; };
+    template <> struct avx2<int, 4> { using type = detail::avx2_int4; };
+    template <> struct avx2<double, 4> { using type = detail::avx2_double4; };
 #endif
 } // namespace simd_abi
 

--- a/arbor/include/arbor/simd/avx512.hpp
+++ b/arbor/include/arbor/simd/avx512.hpp
@@ -13,7 +13,7 @@
 
 namespace arb {
 namespace simd {
-namespace simd_detail {
+namespace detail {
 
 struct avx512_double8;
 struct avx512_int8;
@@ -742,12 +742,12 @@ protected:
     }
 };
 
-} // namespace simd_detail
+} // namespace detail
 
 namespace simd_abi {
     template <typename T, unsigned N> struct avx512;
-    template <> struct avx512<double, 8> { using type = simd_detail::avx512_double8; };
-    template <> struct avx512<int, 8> { using type = simd_detail::avx512_int8; };
+    template <> struct avx512<double, 8> { using type = detail::avx512_double8; };
+    template <> struct avx512<int, 8> { using type = detail::avx512_int8; };
 } // namespace simd_abi
 
 } // namespace simd

--- a/arbor/include/arbor/simd/generic.hpp
+++ b/arbor/include/arbor/simd/generic.hpp
@@ -8,7 +8,7 @@
 
 namespace arb {
 namespace simd {
-namespace simd_detail {
+namespace detail {
 
 template <typename T, unsigned N>
 struct generic;
@@ -54,12 +54,12 @@ struct generic: implbase<generic<T, N>> {
     }
 };
 
-} // namespace simd_detail
+} // namespace detail
 
 namespace simd_abi {
 
     template <typename T, unsigned N> struct generic {
-        using type = simd_detail::generic<T, N>;
+        using type = detail::generic<T, N>;
     };
 
 } // namespace simd_abi

--- a/arbor/include/arbor/simd/implbase.hpp
+++ b/arbor/include/arbor/simd/implbase.hpp
@@ -4,7 +4,7 @@
 // classes, with default implementations based on
 // copy_to/copy_from.
 //
-// Also provides simd_detail::simd_traits type map.
+// Also provides detail::simd_traits type map.
 //
 // Maths functions are implemented in terms of
 // arithmetic primitives or lane-wise invocation of
@@ -66,7 +66,7 @@ enum class index_constraint {
     constant     // k[i]==k[j] ∀ i, j
 };
 
-namespace simd_detail {
+namespace detail {
 
 // The simd_traits class provides the mapping between a concrete SIMD
 // implementation I and its associated classes. This must be specialized
@@ -534,6 +534,6 @@ struct implbase {
     }
 };
 
-} // namespace simd_detail
+} // namespace detail
 } // namespace simd
 } // namespace arb

--- a/arbor/include/arbor/simd/neon.hpp
+++ b/arbor/include/arbor/simd/neon.hpp
@@ -13,7 +13,7 @@
 
 namespace arb {
 namespace simd {
-namespace simd_detail {
+namespace detail {
 
 struct neon_double2;
 struct neon_int2;
@@ -642,7 +642,7 @@ struct neon_double2 : implbase<neon_double2> {
     }
 };
 
-}  // namespace simd_detail
+}  // namespace detail
 
 namespace simd_abi {
 template <typename T, unsigned N>
@@ -650,11 +650,11 @@ struct neon;
 
 template <>
 struct neon<double, 2> {
-    using type = simd_detail::neon_double2;
+    using type = detail::neon_double2;
 };
 template <>
 struct neon<int, 2> {
-    using type = simd_detail::neon_int2;
+    using type = detail::neon_int2;
 };
 
 }  // namespace simd_abi

--- a/arbor/include/arbor/simd/simd.hpp
+++ b/arbor/include/arbor/simd/simd.hpp
@@ -11,7 +11,7 @@
 namespace arb {
 namespace simd {
 
-namespace simd_detail {
+namespace detail {
     template <typename Impl>
     struct simd_impl;
 
@@ -19,7 +19,7 @@ namespace simd_detail {
     struct simd_mask_impl;
 }
 
-namespace simd_detail {
+namespace detail {
     template <typename Impl, typename V>
     struct indirect_expression {
         V* p;
@@ -615,7 +615,7 @@ namespace simd_detail {
             return a;
         }
     };
-} // namespace simd_detail
+} // namespace detail
 
 namespace simd_abi {
     // Note: `simd_abi::native` template class defined in `simd/native.hpp`,
@@ -631,7 +631,7 @@ namespace simd_abi {
 }
 
 template <typename Value, unsigned N, template <class, unsigned> class Abi = simd_abi::default_abi>
-using simd = simd_detail::simd_impl<typename Abi<Value, N>::type>;
+using simd = detail::simd_impl<typename Abi<Value, N>::type>;
 
 template <typename Value, unsigned N>
 using simd_mask = typename simd<Value, N>::simd_mask;
@@ -648,14 +648,14 @@ template <typename>
 struct is_simd: std::false_type {};
 
 template <typename Impl>
-struct is_simd<simd_detail::simd_impl<Impl>>: std::true_type {};
+struct is_simd<detail::simd_impl<Impl>>: std::true_type {};
 
 // Casting is dispatched to simd_cast_impl in order to handle conversions to
 // and from std::array.
 
 template <typename To, typename From>
 To simd_cast(const From& s) {
-    return simd_detail::simd_cast_impl<To>::cast(s);
+    return detail::simd_cast_impl<To>::cast(s);
 }
 
 // Gather/scatter indexed memory specification.
@@ -665,12 +665,12 @@ template <
     typename PtrLike,
     typename V = std::remove_reference_t<decltype(*std::declval<PtrLike>())>
 >
-simd_detail::indirect_expression<IndexImpl, V> indirect(
+detail::indirect_expression<IndexImpl, V> indirect(
     PtrLike p,
-    const simd_detail::simd_impl<IndexImpl>& index,
+    const detail::simd_impl<IndexImpl>& index,
     index_constraint constraint = index_constraint::none)
 {
-    return simd_detail::indirect_expression<IndexImpl, V>(p, index, constraint);
+    return detail::indirect_expression<IndexImpl, V>(p, index, constraint);
 }
 
 

--- a/arbor/include/arbor/simd/simd_io.hpp
+++ b/arbor/include/arbor/simd/simd_io.hpp
@@ -8,7 +8,7 @@
 
 namespace arb {
 namespace simd {
-namespace simd_detail {
+namespace detail {
 
 template <typename Impl>
 std::ostream& operator<<(std::ostream& o, const simd_impl<Impl>& s) {
@@ -23,6 +23,6 @@ std::ostream& operator<<(std::ostream& o, const simd_impl<Impl>& s) {
     return o;
 }
 
-} // namespace simd_detail
+} // namespace detail
 } // namespace simd
 } // namespace arb

--- a/doc/simd_api.rst
+++ b/doc/simd_api.rst
@@ -74,18 +74,18 @@ Three user-facing template classes are provided:
 
    The result of a ``where`` expression, used for masked assignment.
 
-There is, in addition, a templated class ``simd_detail::indirect_expression``
+There is, in addition, a templated class ``detail::indirect_expression``
 that holds the result of an `indirect(...)` expression. These arise in
 gather and scatter operations, and are detailed below.
 
 Implementation typemaps live in the ``simd_abi`` namespace, while concrete
-implementation classes live in ``simd_detail``. A particular specialization
+implementation classes live in ``detail``. A particular specialization
 for an architecture, for example 4-wide double on AVX, then requires:
 
-*  A concrete implementation class, e.g. ``simd_detail::avx_double4``.
+*  A concrete implementation class, e.g. ``detail::avx_double4``.
 
 *  A specialization of its ABI map, so that ``simd_abi::avx<double, 4>::type``
-   is an alias for ``simd_detail::avx_double4``.
+   is an alias for ``detail::avx_double4``.
 
 *  A specialization of the native ABI map, so that
    ``simd_abi::native<double, 4>::type`` is an alias for ``simd_abi::avx<double, 4>::type``.
@@ -124,8 +124,8 @@ promises certain guarantees on the index values in *k*:
 Class ``simd``
 ^^^^^^^^^^^^^^
 
-The class ``simd<V, N, I>`` is an alias for ``simd_detail::simd_impl<I<V, N>::type>``;
-the class ``simd_detail::simd_impl<C>`` provides the public interface and
+The class ``simd<V, N, I>`` is an alias for ``detail::simd_impl<I<V, N>::type>``;
+the class ``detail::simd_impl<C>`` provides the public interface and
 arithmetic operators for a concrete implementation class `C`.
 
 In the following:
@@ -331,9 +331,9 @@ Class ``simd_mask``
 ^^^^^^^^^^^^^^^^^^^
 
 ``simd_mask<V, N, I>`` is an alias for ``simd<V, N, I>::simd_mask``, which in turn
-will be an alias for a class ``simd_detail::simd_mask_impl<D>``, where *D* is
+will be an alias for a class ``detail::simd_mask_impl<D>``, where *D* is
 a concrete implementation class for the SIMD mask representation. ``simd_mask_impl<D>``
-inherits from, and is implemented in terms of, ``simd_detail::simd_impl<D>``,
+inherits from, and is implemented in terms of, ``detail::simd_impl<D>``,
 but note that the concrete implementation class *D* may or may not be the same
 as the concrete implementation class ``I<V, N>::type`` used by ``simd<V, N, I>``.
 
@@ -592,14 +592,14 @@ Each specific architecture is represented by a templated class *I*, with
 ``I<V, N>::type`` being the concrete implementation for an *N*-wide
 SIMD value with ``scalar_type`` *V*.
 
-A concrete implementation class *C* inherits from ``simd_detail::implbase<C>``,
+A concrete implementation class *C* inherits from ``detail::implbase<C>``,
 which provides (via CRTP) generic implementations of most of the SIMD
 functionality. The base class ``implbase<C>`` in turn relies upon
-``simd_detail::simd_traits<C>`` to look up the SIMD width, and associated types.
+``detail::simd_traits<C>`` to look up the SIMD width, and associated types.
 
 All the required SIMD operations are given by static member functions of *C*.
 
-Some arguments to static member functions use a tag class (``simd_detail::tag``)
+Some arguments to static member functions use a tag class (``detail::tag``)
 parameterized on a concrete implementation class for dispatch purposes.
 
 Minimal implementation
@@ -609,7 +609,7 @@ In the following, let *C* be the concrete implementation class for a
 *N*-wide vector of scalar_type *V*, with low-level representation
 ``archvec``.
 
-The specialization of ``simd_detail::simd_traits<C>`` then exposes these
+The specialization of ``detail::simd_traits<C>`` then exposes these
 types and values, and also provides the concrete implementation class *M*
 for masks associated with *C*:
 
@@ -627,9 +627,9 @@ for masks associated with *C*:
 
 
 The mask implementation class *M* may or may not be the same as *C*.
-For example, ``simd_detail::avx_double4`` provides both the arithmetic operations and mask
+For example, ``detail::avx_double4`` provides both the arithmetic operations and mask
 operations for an AVX 4 × double SIMD vector, while the mask
-implementation for ``simd_detail::avx512_double8`` is ``simd_detail::avx512_mask8``.
+implementation for ``detail::avx512_double8`` is ``detail::avx512_mask8``.
 
 The concrete implementation class must provide at minimum implementations
 of ``copy_to`` and ``copy_from`` (see the section below for semantics):
@@ -1053,7 +1053,7 @@ Implementation of vector transcendental functions
 -------------------------------------------------
 
 When building with the Intel C++ compiler, transcendental
-functions on SIMD values in ``simd<double, 8, simd_detail::avx512>``
+functions on SIMD values in ``simd<double, 8, detail::avx512>``
 wrap calls to the Intel scalar vector mathematics library (SVML).
 
 Outside of this case, the functions *exp*, *log*, *expm1* and


### PR DESCRIPTION
Rename namespace simd::simd_detail to simd::detail.

Fixes #468