### PR TITLE
Fix reduce-by-key CUDA

### DIFF
--- a/arbor/backends/gpu/reduce_by_key.hpp
+++ b/arbor/backends/gpu/reduce_by_key.hpp
@@ -34,7 +34,7 @@ unsigned roundup_power_of_2(std::uint32_t i) {
     return 1u<<(32u - __clz(i));
 }
 
-// run_length_type Stores information about a run length.
+// run_length Stores information about a run length.
 //
 // A run length is a set of identical adjacent indexes in an index array.
 //
@@ -46,7 +46,7 @@ unsigned roundup_power_of_2(std::uint32_t i) {
 // and the threads work cooperatively using warp shuffles to determine
 // their run length information, so that each thread will have unique
 // information that describes its run length and its position therein.
-struct run_length_type {
+struct run_length {
     unsigned left;
     unsigned right;
     unsigned shift;
@@ -58,9 +58,8 @@ struct run_length_type {
         return left == lane_id;
     }
 
-    template <typename I1>
     __device__
-    run_length_type(I1 idx) {
+    run_length(int idx) {
         lane_id = threadIdx.x%threads_per_warp();
         __syncwarp();
         // TODO: calculate key mask directly from array sizes (outside main loop)
@@ -96,7 +95,7 @@ struct run_length_type {
 template <typename T, typename I>
 __device__ __inline__
 void reduce_by_key(T contribution, T* target, I i) {
-    impl::run_length_type run(i);
+    impl::run_length run(i);
 
     unsigned shift = run.shift;
     const unsigned key_lane = run.lane_id - run.left;

--- a/test/unit/test_reduce_by_key.cu
+++ b/test/unit/test_reduce_by_key.cu
@@ -106,7 +106,7 @@ TEST(reduce_by_key, scatter)
 
 // 'reduce_twice' added to isolate a thread desynchronization issue on V100.
 
-#if true
+#if 1
 template <typename T, typename I>
 __global__
 void reduce_twice_kernel(const T* src, T* dst, const I* index, int n) {

--- a/test/unit/test_reduce_by_key.cu
+++ b/test/unit/test_reduce_by_key.cu
@@ -106,7 +106,6 @@ TEST(reduce_by_key, scatter)
 
 // 'reduce_twice' added to isolate a thread desynchronization issue on V100.
 
-#if 1
 template <typename T, typename I>
 __global__
 void reduce_twice_kernel(const T* src, T* dst, const I* index, int n) {
@@ -117,20 +116,6 @@ void reduce_twice_kernel(const T* src, T* dst, const I* index, int n) {
         gpu::reduce_by_key(src[tid], dst, index[tid]);
     }
 }
-#else
-template <typename T, typename I>
-__global__
-void reduce_twice_kernel(const T* src, T* dst, const I* index, int n) {
-    if (n==0) return;
-    unsigned tid = threadIdx.x + blockIdx.x*blockDim.x;
-
-    T value = tid<n? src[tid]: 0;
-    I idx = tid<n? index[tid]: index[n-1];
-
-    gpu::reduce_by_key(value, dst, idx);
-    gpu::reduce_by_key(value, dst, idx);
-}
-#endif
 
 template <typename T>
 std::vector<T> reduce_twice(const std::vector<T>& in, size_t n_out, const std::vector<int>& index, unsigned block_dim=128) {

--- a/test/unit/test_reduce_by_key.cu
+++ b/test/unit/test_reduce_by_key.cu
@@ -9,11 +9,6 @@
 
 using namespace arb;
 
-unsigned make_mask(unsigned bits) {
-    unsigned m = 0xFFFFFFFF;
-    return m>>(32-bits);
-}
-
 template <typename T, typename I>
 __global__
 void reduce_kernel(const T* src, T* dst, const I* index, int n) {
@@ -97,7 +92,6 @@ TEST(reduce_by_key, scatter)
     std::vector<double> expected = {3., 1., 4., 2., 0., 0., 0., 5., 0., 0., 0., 1.};
 
     unsigned m = index.size();
-    auto mask = make_mask(m);
 
     EXPECT_EQ(n, expected.size());
 
@@ -109,10 +103,8 @@ TEST(reduce_by_key, scatter)
     //  * thread blocks that are not a multiple of 32
     //  * thread blocks that are less than 32
 
-    /*
     out = reduce(in, n, index, 7);
     EXPECT_EQ(expected, out);
-    */
 }
 
 // Test kernels that perform more than one reduction in a single invokation.
@@ -161,7 +153,6 @@ TEST(reduce_by_key, scatter_twice)
     std::vector<double> expected = {6., 2., 4., 2., 0., 0., 0., 6., 0., 0., 0., 2.};
 
     unsigned m = index.size();
-    auto mask = make_mask(m);
 
     EXPECT_EQ(n, expected.size());
 


### PR DESCRIPTION
Fix bug in CUDA `reduce_by_key` implementation on V100 or later GPUs.

The bug was not triggered for current use cases of the algorithm in Arbor, though it will be a problem when more than one reduction is to be performed in a single kernel invocation, which is required for accumulating both current and conductance values.

Fixes  #736.