### PR TITLE
fix spurious compile time assertionsin GPU matrix solver

### DIFF
--- a/arbor/algorithms.hpp
+++ b/arbor/algorithms.hpp
@@ -96,9 +96,10 @@ bool is_strictly_monotonic_decreasing(C const& c)
     );
 }
 
-// check if c[0] == 0 and c[i] < 0 holds for i != 0
-// this means that children of a node always have larger indices than their
-// parent
+// Check if c[0] == 0 and c[i] < 0 holds for i != 0
+// Also handle the valid case of c[0]==value_type(-1)
+// This means that children of a node always have larger indices than their
+// parent.
 template <
     typename C,
     typename = typename std::enable_if<std::is_integral<typename C::value_type>::value>
@@ -115,7 +116,7 @@ bool is_minimal_degree(C const& c)
     }
 
     using value_type = typename C::value_type;
-    if (c[0] != value_type(0)) {
+    if (!(c[0]==value_type(0) || c[0]==value_type(-1))) {
         return false;
     }
     auto i = value_type(1);

--- a/arbor/backends/gpu/forest.cpp
+++ b/arbor/backends/gpu/forest.cpp
@@ -1,4 +1,5 @@
 #include "backends/gpu/forest.hpp"
+#include "tree.hpp"
 #include "util/span.hpp"
 
 namespace arb {

--- a/arbor/backends/gpu/matrix_state_fine.hpp
+++ b/arbor/backends/gpu/matrix_state_fine.hpp
@@ -149,9 +149,6 @@ public:
 
         max_branches_per_level = 128;
 
-        // for now we have single cell per cell group
-        arb_assert(cell_cv_divs.size()==2);
-
         num_cells = cell_cv_divs.size()-1;
 
         forest trees(p, cell_cv_divs);


### PR DESCRIPTION
There were run time assertions thrown when compiled with `ARB_WITH_ASSERTIONS` and `ARB_WITH_GPU` set. These were spurious, and it was clear that it has been a long time since the GPU version was last run with assertions enabled :worried: 