### PR TITLE
Python: mpi4py communicators as first class citizens

### DIFF
--- a/python/mpi.cpp
+++ b/python/mpi.cpp
@@ -20,19 +20,35 @@
 namespace pyarb {
 
 #ifdef ARB_MPI_ENABLED
+
+// Convert a Python object an MPI Communicator.
+// Used to construct mpi_comm_shim from arbitrary Python types.
+// Currently only supports mpi4py communicators, but could be extended to
+// other types.
+MPI_Comm convert_to_mpi_comm(pybind11::object o) {
 #ifdef ARB_WITH_MPI4PY
-
-mpi_comm_shim comm_from_mpi4py(pybind11::object& o) {
     import_mpi4py();
-
-    // If object is already a mpi4py communicator, return
     if (PyObject_TypeCheck(o.ptr(), &PyMPIComm_Type)) {
-        return mpi_comm_shim(*PyMPIComm_Get(o.ptr()));
+        return *PyMPIComm_Get(o.ptr());
     }
-    throw arb::mpi_error(MPI_ERR_OTHER, "The argument is not an mpi4py communicator");
+#endif
+    throw arb::mpi_error(MPI_ERR_OTHER, "Unable to convert to an MPI Communicatior.");
 }
 
+mpi_comm_shim::mpi_comm_shim(pybind11::object o) {
+    comm = convert_to_mpi_comm(o);
+}
+
+// Test if a Python object can be converted to an mpi_comm_shim.
+bool can_convert_to_mpi_comm(pybind11::object o) {
+#ifdef ARB_WITH_MPI4PY
+    import_mpi4py();
+    if (PyObject_TypeCheck(o.ptr(), &PyMPIComm_Type)) {
+        return true;
+    }
 #endif
+    return false;
+}
 
 // Some helper functions for initializing and finalizing MPI.
 // Arbor requires at least MPI_THREAD_SERIALIZED, because the communication task
@@ -83,6 +99,7 @@ void register_mpi(pybind11::module& m) {
     pybind11::class_<mpi_comm_shim> mpi_comm(m, "mpi_comm");
     mpi_comm
         .def(pybind11::init<>())
+        .def(pybind11::init([](pybind11::object o){return mpi_comm_shim(o);}))
         .def("__str__", &mpi_comm_string)
         .def("__repr__", &mpi_comm_string);
 
@@ -90,10 +107,6 @@ void register_mpi(pybind11::module& m) {
     m.def("mpi_finalize", &mpi_finalize, "Finalize MPI (calls MPI_Finalize)");
     m.def("mpi_is_initialized", &mpi_is_initialized, "Check if MPI is initialized.");
     m.def("mpi_is_finalized", &mpi_is_finalized, "Check if MPI is finalized.");
-
-    #ifdef ARB_WITH_MPI4PY
-    m.def("mpi_comm_from_mpi4py", comm_from_mpi4py);
-    #endif
 }
 #endif
 } // namespace pyarb

--- a/python/mpi.hpp
+++ b/python/mpi.hpp
@@ -13,7 +13,12 @@ struct mpi_comm_shim {
 
     mpi_comm_shim() = default;
     mpi_comm_shim(MPI_Comm c): comm(c) {}
+
+    mpi_comm_shim(pybind11::object o);
 };
+
+bool can_convert_to_mpi_comm(pybind11::object o);
+MPI_Comm convert_to_mpi_comm(pybind11::object o);
 
 } // namespace pyarb
 #endif

--- a/python/test/unit_distributed/runner.py
+++ b/python/test/unit_distributed/runner.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         arb.mpi_init()
 
     if mpi4py_enabled:
-        comm = arb.mpi_comm_from_mpi4py(mpi.COMM_WORLD)
+        comm = arb.mpi_comm(mpi.COMM_WORLD)
     elif mpi_enabled:
         comm = arb.mpi_comm()
 

--- a/python/test/unit_distributed/test_contexts_arbmpi.py
+++ b/python/test/unit_distributed/test_contexts_arbmpi.py
@@ -67,10 +67,10 @@ class Contexts_arbmpi(unittest.TestCase):
         alloc = arb.proc_allocation()
 
         with self.assertRaisesRegex(RuntimeError,
-            "mpi must be None, or an MPI communicator."):
+            "mpi must be None, or an MPI communicator"):
             arb.context(mpi='MPI_COMM_WORLD')
         with self.assertRaisesRegex(RuntimeError,
-            "mpi must be None, or an MPI communicator."):
+            "mpi must be None, or an MPI communicator"):
             arb.context(alloc, mpi=0)
 
     def test_finalized_arbmpi(self):

--- a/python/test/unit_distributed/test_contexts_mpi4py.py
+++ b/python/test/unit_distributed/test_contexts_mpi4py.py
@@ -34,20 +34,20 @@ class Contexts_mpi4py(unittest.TestCase):
         self.assertTrue(mpi.Is_initialized())
 
     def test_communicator_mpi4py(self):
-        comm = arb.mpi_comm_from_mpi4py(mpi.COMM_WORLD)
+        comm = arb.mpi_comm(mpi.COMM_WORLD)
 
         # test that set communicator is MPI_COMM_WORLD
         self.assertEqual(str(comm), '<mpi_comm: MPI_COMM_WORLD>')
 
     def test_context_mpi4py(self):
-        comm = arb.mpi_comm_from_mpi4py(mpi.COMM_WORLD)
+        comm = arb.mpi_comm(mpi.COMM_WORLD)
 
         # test context with mpi
         ctx = arb.context(mpi=comm)
         self.assertTrue(ctx.has_mpi)
 
     def test_context_allocation_mpi4py(self):
-        comm = arb.mpi_comm_from_mpi4py(mpi.COMM_WORLD)
+        comm = arb.mpi_comm(mpi.COMM_WORLD)
 
         # test context with alloc and mpi
         alloc = arb.proc_allocation()
@@ -60,10 +60,10 @@ class Contexts_mpi4py(unittest.TestCase):
         alloc = arb.proc_allocation()
 
         with self.assertRaisesRegex(RuntimeError,
-            "mpi must be None, or an MPI communicator."):
+            "mpi must be None, or an MPI communicator"):
             arb.context(mpi='MPI_COMM_WORLD')
         with self.assertRaisesRegex(RuntimeError,
-            "mpi must be None, or an MPI communicator."):
+            "mpi must be None, or an MPI communicator"):
             arb.context(alloc, mpi=0)
 
     def test_finalized_mpi4py(self):


### PR DESCRIPTION
Use mpi4py communicators directly in context and mpi communicator shim construction. With these changes the following script
```python
import arbor as arb 
arb.mpi_init()
import mpi4py.MPI as mpi 
comm = arb.mpi_comm(mpi.COMM_WORLD)
ctx1 = arb.context(threads=2, mpi=comm)
ctx2 = arb.context(threads=2, mpi=mpi.COMM_WORLD)
if (mpi.COMM_WORLD.rank==0):
    print(comm)
    print(ctx1)
    print(ctx2)
arb.mpi_finalize() 
```
generates the following output
```
bcumming@arapiles:test > mpirun -n 2 python ampi.py 
<mpi_comm: MPI_COMM_WORLD>
<context: threads 2, gpu None, distributed MPI ranks 2>
<context: threads 2, gpu None, distributed MPI ranks 2>
bcumming@arapiles:test > mpirun -n 4 python ampi.py 
<mpi_comm: MPI_COMM_WORLD>
<context: threads 2, gpu None, distributed MPI ranks 4>
<context: threads 2, gpu None, distributed MPI ranks 4>
```