### PR TITLE
Fix build with libunwind (fix up for ad1c78ab)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ endif()
 find_package(Unwind)
 if(Unwind_FOUND)
     target_link_libraries(arbor-private-deps INTERFACE Unwind::unwind)
-    target_compile_definitions(arbor-private-deps ARB_WITH_UNWIND)
+    target_compile_definitions(arbor-private-deps INTERFACE WITH_UNWIND)
 
     list(APPEND arbor_export_dependencies "Unwind")
 endif()

--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -34,7 +34,7 @@ if(NOT Unwind_FOUND)
         PATH_SUFFIXES lib64 lib
     )
 
-    find_library(_unwind_library_target unwind-${libunwind_arch}
+    find_library(_unwind_library_target unwind-${_libunwind_arch}
         HINTS ${Unwind_SEARCH_DIR}
         PATH_SUFFIXES lib64 lib
     )


### PR DESCRIPTION
* `cmake/FindUnwind.cmake` used the wrong variable (caused by commit ad1c78ab)
* `CMakeLists.txt` seems to use wrong syntax for providing a compiler define
  of `WITH_UNWIND` (used in `arbor/util/unwind.cpp`)

I'm no expert in cmake, so please have a deeper look into this → I only verified that my build used `-DWITH_UNWIND` for the g++ commands but nothing else (i.e. I did not try to get stack traces).

@w-klijn That's what I mentioned yesterday (when I tried to build arbor using spack).