### PR TITLE
Fix modcc unit test for new ion representation.

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -76,6 +76,10 @@ progress "C++ unit tests"
 make unit -j4                || error "building unit tests"
 ./bin/unit --gtest_color=no  || error "running unit tests"
 
+progress "C++ modcc unit testss"
+make unit-modcc -j4                || error "building modcc unit tests"
+./bin/unit-modcc --gtest_color=no  || error "running modcc unit tests"
+
 progress "C++ distributed unit tests (local)"
 make unit-local -j4          || error "building local distributed unit tests"
 ./bin/unit-local             || error "running local distributed unit tests"

--- a/test/unit-modcc/test_parser.cpp
+++ b/test/unit-modcc/test_parser.cpp
@@ -164,13 +164,13 @@ TEST(Parser, parse_conductance) {
 
     EXPECT_TRUE(check_parse(s, &Parser::parse_conductance, "CONDUCTANCE g USEION na"));
     if (s) {
-        EXPECT_EQ(s->ion_channel(), ionKind::Na);
+        EXPECT_EQ(s->ion_channel(), "na");
         EXPECT_EQ(s->name(), "g");
     }
 
     EXPECT_TRUE(check_parse(s, &Parser::parse_conductance, "CONDUCTANCE gnda"));
     if (s) {
-        EXPECT_EQ(s->ion_channel(), ionKind::nonspecific);
+        EXPECT_EQ(s->ion_channel(), "");
         EXPECT_EQ(s->name(), "gnda");
     }
 }


### PR DESCRIPTION
* Change occurances of 'ionKind' to corresponding string values in test_parser.cpp.
* Add unit-modcc to travis script.

Fixes #775.