### PR TITLE
Implement mechanism ion rebinding.

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -72,6 +72,16 @@ invalid_parameter_value::invalid_parameter_value(const std::string& mech_name, c
     value(value)
 {}
 
+invalid_ion_remap::invalid_ion_remap(const std::string& mech_name):
+    arbor_exception(pprintf("invalid ion parameter remapping for mechanism {}", mech_name))
+{}
+
+invalid_ion_remap::invalid_ion_remap(const std::string& mech_name, const std::string& from_ion = "", const std::string& to_ion = ""):
+    arbor_exception(pprintf("invalid ion parameter remapping for mechanism {}: {} -> {}", mech_name, from_ion, to_ion)),
+    from_ion(from_ion),
+    to_ion(to_ion)
+{}
+
 no_such_implementation::no_such_implementation(const std::string& mech_name):
     arbor_exception(pprintf("missing implementation for mechanism {} in catalogue", mech_name)),
     mech_name(mech_name)

--- a/arbor/backends/gpu/mechanism.hpp
+++ b/arbor/backends/gpu/mechanism.hpp
@@ -46,7 +46,7 @@ public:
         return s;
     }
 
-    void instantiate(fvm_size_type id, backend::shared_state& shared, const layout& w) override;
+    void instantiate(fvm_size_type id, backend::shared_state& shared, const mechanism_overrides&, const mechanism_layout&) override;
 
     void deliver_events() override {
         // Delegate to derived class, passing in event queue state.
@@ -54,8 +54,6 @@ public:
     }
 
     void set_parameter(const std::string& key, const std::vector<fvm_value_type>& values) override;
-
-    void set_global(const std::string& key, fvm_value_type value) override;
 
     void initialize() override;
 

--- a/arbor/backends/multicore/mechanism.hpp
+++ b/arbor/backends/multicore/mechanism.hpp
@@ -55,7 +55,7 @@ public:
         return s;
     }
 
-    void instantiate(fvm_size_type id, backend::shared_state& shared, const layout& w) override;
+    void instantiate(fvm_size_type id, backend::shared_state& shared, const mechanism_overrides&, const mechanism_layout&) override;
     void initialize() override;
 
     void deliver_events() override {
@@ -64,8 +64,6 @@ public:
     }
 
     void set_parameter(const std::string& key, const std::vector<fvm_value_type>& values) override;
-
-    void set_global(const std::string& key, fvm_value_type value) override;
 
 protected:
     size_type width_ = 0;        // Instance width (number of CVs/sites)

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -396,7 +396,7 @@ void fvm_lowered_cell_impl<B>::initialize(
 
     unsigned data_alignment = util::max_value(
         util::transform_view(keys(mech_data.mechanisms),
-            [&](const std::string& name) { return mech_instance(name)->data_alignment(); }));
+            [&](const std::string& name) { return mech_instance(name).mech->data_alignment(); }));
 
     state_ = std::make_unique<shared_state>(num_intdoms, cv_to_intdom, gj_vector, data_alignment? data_alignment: 1u);
 
@@ -420,7 +420,7 @@ void fvm_lowered_cell_impl<B>::initialize(
         auto& config = m.second;
         unsigned mech_id = mechanisms_.size();
 
-        mechanism::layout layout;
+        mechanism_layout layout;
         layout.cv = config.cv;
         layout.multiplicity = config.multiplicity;
         layout.weight.resize(layout.cv.size());
@@ -462,13 +462,13 @@ void fvm_lowered_cell_impl<B>::initialize(
             }
         }
 
-        auto mech = mech_instance(name);
-        mech->instantiate(mech_id, *state_, layout);
+        auto minst = mech_instance(name);
+        minst.mech->instantiate(mech_id, *state_, minst.overrides, layout);
 
         for (auto& pv: config.param_values) {
-            mech->set_parameter(pv.first, pv.second);
+            minst.mech->set_parameter(pv.first, pv.second);
         }
-        mechanisms_.push_back(mechanism_ptr(mech.release()));
+        mechanisms_.push_back(mechanism_ptr(minst.mech.release()));
     }
 
     // Collect detectors, probe handles.

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -95,6 +95,13 @@ struct invalid_parameter_value: arbor_exception {
     double value;
 };
 
+struct invalid_ion_remap: arbor_exception {
+    explicit invalid_ion_remap(const std::string& mech_name);
+    invalid_ion_remap(const std::string& mech_name, const std::string& from_ion, const std::string& to_ion);
+    std::string from_ion;
+    std::string to_ion;
+};
+
 struct no_such_implementation: arbor_exception {
     explicit no_such_implementation(const std::string& mech_name);
     std::string mech_name;

--- a/arbor/include/arbor/mechanism.hpp
+++ b/arbor/include/arbor/mechanism.hpp
@@ -23,15 +23,6 @@ public:
     mechanism() = default;
     mechanism(const mechanism&) = delete;
 
-    // Description of layout of mechanism across cell group: used as parameter in
-    // `concrete_mechanism<B>::instantiate` (v.i.)
-    struct layout {
-        std::vector<fvm_index_type> cv;     // Maps in-instance index to CV index.
-        std::vector<fvm_value_type> weight; // Maps in-instance index to compartment contribution.
-        std::vector<fvm_index_type> multiplicity; // Number of logical point processes at in-instance index;
-                                                  // if empty point processes are not coalesced, all multipliers are 1
-    };
-
     // Return fingerprint of mechanism dynamics source description for validation/replication.
     virtual const mechanism_fingerprint& fingerprint() const = 0;
 
@@ -54,9 +45,6 @@ public:
     // Cloning makes a new object of the derived concrete mechanism type, but does not
     // copy any state.
     virtual mechanism_ptr clone() const = 0;
-
-    // Parameter setting
-    virtual void set_global(const std::string& param, fvm_value_type value) = 0;
 
     // Non-global parameters can be set post-instantiation:
     virtual void set_parameter(const std::string& key, const std::vector<fvm_value_type>& values) = 0;
@@ -81,6 +69,31 @@ protected:
 
 // Backend-specific implementations provide mechanisms that are derived from `concrete_mechanism<Backend>`,
 // likely via an intermediate class that captures common behaviour for that backend.
+//
+// `concrete_mechanism` provides the `instantiate` method, which takes the backend-specific shared state,
+// together with a layout derived from the discretization, and any global parameter overrides.
+
+struct mechanism_layout {
+    // Maps in-instance index to CV index.
+    std::vector<fvm_index_type> cv;
+
+    // Maps in-instance index to compartment contribution.
+    std::vector<fvm_value_type> weight;
+
+    // Number of logical point processes at in-instance index;
+    // if empty, point processes are not coalesced and all multipliers are 1.
+    std::vector<fvm_index_type> multiplicity;
+};
+
+struct mechanism_overrides {
+    // Global scalar parameters (any value down-conversion to fvm_value_type is the
+    // responsibility of the concrete mechanism).
+    std::unordered_map<std::string, double> globals;
+
+    // Ion renaming: keys are ion dependency names as
+    // reported by the mechanism info.
+    std::unordered_map<std::string, std::string> ion_rebind;
+};
 
 template <typename Backend>
 class concrete_mechanism: public mechanism {
@@ -88,7 +101,7 @@ public:
     using backend = Backend;
 
     // Instantiation: allocate per-instance state; set views/pointers to shared data.
-    virtual void instantiate(unsigned  id, typename backend::shared_state&, const layout&) = 0;
+    virtual void instantiate(unsigned  id, typename backend::shared_state&, const mechanism_overrides&, const mechanism_layout&) = 0;
 };
 
 

--- a/arbor/include/arbor/mechinfo.hpp
+++ b/arbor/include/arbor/mechinfo.hpp
@@ -30,17 +30,17 @@ struct mechanism_field_spec {
 };
 
 struct ion_dependency {
-    bool write_concentration_int;
-    bool write_concentration_ext;
+    bool write_concentration_int = false;
+    bool write_concentration_ext = false;
 
-    bool read_reversal_potential;
-    bool write_reversal_potential;
+    bool read_reversal_potential = false;
+    bool write_reversal_potential = false;
 
-    bool read_ion_charge;
+    bool read_ion_charge = false;
 
     // Support for NMODL 'VALENCE n' construction.
-    bool verify_ion_charge;
-    int expected_ion_charge;
+    bool verify_ion_charge = false;
+    int expected_ion_charge = 0;
 };
 
 // A hash of the mechanism dynamics description is used to ensure that offline-compiled

--- a/arbor/include/arbor/util/optional.hpp
+++ b/arbor/include/arbor/util/optional.hpp
@@ -354,14 +354,17 @@ struct optional<X&>: detail::optional_base<X&> {
         return assert_set(), ref();
     }
 
-    template <typename T>
-    X& value_or(T& alternative) {
-        return set? ref(): static_cast<X&>(alternative);
+    X& value_or(X& alternative) & {
+        return set? ref(): alternative;
+    }
+
+    const X& value_or(const X& alternative) const& {
+        return set? ref(): alternative;
     }
 
     template <typename T>
-    const X& value_or(const T& alternative) const {
-        return set? ref(): static_cast<const X&>(alternative);
+    const X value_or(const T& alternative) && {
+        return set? ref(): static_cast<X>(alternative);
     }
 };
 

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -7,7 +7,49 @@
 #include <arbor/mechcat.hpp>
 
 #include "util/maputil.hpp"
-#include "io/trace.hpp"
+
+/* Notes on implementation:
+ *
+ * The catalogue maintains the following data:
+ *
+ * 1. impl_map_
+ *
+ *    This contains the mapping between mechanism names and concrete mechanisms
+ *    for a specific backend that have been registered with
+ *    register_implementation().
+ *
+ *    It is a two-level map, first indexed by name, and then by the back-end
+ *    type (using std::type_index).
+ *
+ * 2. info_map_
+ *
+ *    Contains the mechanism_info metadata for a mechanism, as given to the
+ *    catalogue via the add() method.
+ *
+ * 3. derived_map_
+ *
+ *    A 'derived' mechanism is one that shares the same metadata schema as its
+ *    parent, but with possible overrides to its global scalar parameters and
+ *    to the bindings of its ion names.
+ *
+ *    The derived_map_ entry for a given mechanism gives: the parent mechanism
+ *    from which it is derived (which might also be a derived mechanism); the
+ *    set of changes to global parameters relative to its parent; the set of
+ *    ion rebindings relative to its parent; and an updated copy of the
+ *    mechanism_info metadata that reflects those changes.
+ *
+ * The derived_map_ and info_map_ together constitute a forest: info_map_ has
+ * an entry for each un-derived mechanism in the catalogue, while for any
+ * derived mechanism, the parent field in derived_map_ provides the parent in
+ * the derivation tree, or a root mechanism which is catalogued in info_map_.
+ *
+ * When an instance of the mechanism is requested from the catalogue, the
+ * instance_impl_() function walks up the derivation tree to find the first
+ * entry which has an associated implementation. It then accumulates the set of
+ * global parameter and ion overrides that need to be applied, starting from
+ * the top-most (least-derived) ancestor and working down to the requested derived
+ * mechanism.
+ */
 
 namespace arb {
 
@@ -58,9 +100,11 @@ void mechanism_catalogue::derive(const std::string& name, const std::string& par
         throw no_such_mechanism(parent);
     }
 
-    std::unordered_map<std::string, std::string> ion_remap_map(ion_remap_vec.begin(), ion_remap_vec.end());
+    string_map<std::string> ion_remap_map(ion_remap_vec.begin(), ion_remap_vec.end());
     derivation deriv = {parent, {}, ion_remap_map, nullptr};
     mechanism_info_ptr info = mechanism_info_ptr(new mechanism_info((*this)[deriv.parent]));
+
+    // Update global parameter values in info for derived mechanism.
 
     for (const auto& kv: global_params) {
         const auto& param = kv.first;
@@ -85,7 +129,9 @@ void mechanism_catalogue::derive(const std::string& name, const std::string& par
         }
     }
 
-    std::unordered_map<std::string, ion_dependency> new_ions;
+    // Update ion dependencies in info to reflect the requested ion remapping.
+
+    string_map<ion_dependency> new_ions;
     for (const auto& kv: info->ions) {
         if (auto new_ion = value_by_key(ion_remap_map, kv.first)) {
             if (!new_ions.insert({*new_ion, kv.second}).second) {
@@ -94,7 +140,7 @@ void mechanism_catalogue::derive(const std::string& name, const std::string& par
         }
         else {
             if (!new_ions.insert(kv).second) {
-                // find offending remap to report in exception
+                // (find offending remap to report in exception)
                 for (const auto& entry: ion_remap_map) {
                     if (entry.second==kv.first) {
                         throw invalid_ion_remap(name, kv.first, entry.second);
@@ -168,6 +214,10 @@ mechanism_catalogue::instance_impl(std::type_index tidx, const std::string& name
 
     mech.first = prototype->clone();
 
+    // Recurse up the derivation tree to find the most distant ancestor;
+    // accumulate global parameter settings and ion remappings down to the
+    // requested mechanism.
+
     auto apply_globals = [this](auto& self, const std::string& name, mechanism_overrides& over) -> void {
         if (auto p = value_by_key(derived_map_, name)) {
             self(self, p->parent, over);
@@ -177,7 +227,7 @@ mechanism_catalogue::instance_impl(std::type_index tidx, const std::string& name
             }
 
             if (!p->ion_remap.empty()) {
-                std::unordered_map<std::string, std::string> new_rebind = p->ion_remap;
+                string_map<std::string> new_rebind = p->ion_remap;
                 for (auto& kv: over.ion_rebind) {
                     if (auto opt_v = value_by_key(p->ion_remap, kv.second)) {
                         new_rebind.erase(kv.second);

--- a/test/simple_recipes.hpp
+++ b/test/simple_recipes.hpp
@@ -50,6 +50,10 @@ public:
         return catalogue_;
     }
 
+    void add_ion(const char* name, int charge, double iconc, double econc) {
+        cell_gprop_.ion_default[name] = {charge, iconc, econc};
+    }
+
 protected:
     std::unordered_map<cell_gid_type, std::vector<probe_info>> probes_;
     cable_cell_global_properties cell_gprop_;

--- a/test/unit/mod/test_ca_read_valence.mod
+++ b/test/unit/mod/test_ca_read_valence.mod
@@ -10,11 +10,11 @@ PARAMETER {}
 ASSIGNED {}
 
 STATE {
-    record_zca
+    record_z
 }
 
 INITIAL {
-    record_zca = zca
+    record_z = zca
 }
 
 BREAKPOINT  {

--- a/test/unit/test_mech_temperature.cpp
+++ b/test/unit/test_mech_temperature.cpp
@@ -25,17 +25,21 @@ void run_celsius_test() {
     std::vector<fvm_index_type> cv_to_intdom(ncv, 0);
 
     std::vector<fvm_gap_junction> gj = {};
-    auto celsius_test = cat.instance<backend>("celsius_test");
+    auto instance = cat.instance<backend>("celsius_test");
+    auto& celsius_test = instance.mech;
+
     auto shared_state = std::make_unique<typename backend::shared_state>(
         ncell, cv_to_intdom, gj, celsius_test->data_alignment());
 
-    mechanism::layout layout;
+    mechanism_layout layout;
+    mechanism_overrides overrides;
+
     layout.weight.assign(ncv, 1.);
     for (fvm_size_type i = 0; i<ncv; ++i) {
         layout.cv.push_back(i);
     }
 
-    celsius_test->instantiate(0, *shared_state, layout);
+    celsius_test->instantiate(0, *shared_state, overrides, layout);
 
     double temperature_K = 300.;
     double temperature_C = temperature_K-273.15;

--- a/test/unit/test_mechcat.cpp
+++ b/test/unit/test_mechcat.cpp
@@ -34,7 +34,7 @@ mechanism_info burble_info = {
      {"xyzzy", {field_kind::global, "mV", 5.1, -20, 20.}}},
     {},
     {},
-    {},
+    {{"x", {}}},
     "burbleprint"
 };
 
@@ -43,7 +43,7 @@ mechanism_info fleeb_info = {
      {"norf",  {field_kind::global, "mGy", 0.1,  0, 5000.}}},
     {},
     {},
-    {},
+    {{"a", {}}, {"b", {}}, {"c", {}}, {"d", {}}},
     "fleebprint"
 };
 
@@ -51,12 +51,21 @@ mechanism_info fleeb_info = {
 
 template <typename B>
 struct common_impl: concrete_mechanism<B> {
-    void instantiate(fvm_size_type id, typename B::shared_state& state, const mechanism::layout& l) override {
+    void instantiate(fvm_size_type id, typename B::shared_state& state, const mechanism_overrides& o, const mechanism_layout& l) override {
         width_ = l.cv.size();
         // Write mechanism global values to shared state to test instatiation call and catalogue global
         // variable overrides.
-        for (auto& kv: overrides_) {
+        for (auto& kv: o.globals) {
             state.overrides.insert(kv);
+        }
+
+        for (auto& ion: mech_ions) {
+            if (o.ion_rebind.count(ion)) {
+                ion_bindings_[ion] = state.ions.at(o.ion_rebind.at(ion));
+            }
+            else {
+                ion_bindings_[ion] = state.ions.at(ion);
+            }
         }
     }
 
@@ -65,23 +74,37 @@ struct common_impl: concrete_mechanism<B> {
 
     void set_parameter(const std::string& key, const std::vector<fvm_value_type>& vs) override {}
 
-    void set_global(const std::string& key, fvm_value_type v) override {
-        overrides_[key] = v;
-    }
-
     void initialize() override {}
     void nrn_state() override {}
     void nrn_current() override {}
     void deliver_events() override {}
     void write_ions() override {}
 
-    std::unordered_map<std::string, fvm_value_type> overrides_;
     std::size_t width_ = 0;
+
+    std::vector<std::string> mech_ions;
+
+    std::unordered_map<std::string, std::string> ion_bindings_;
 };
+
+template <typename B>
+std::string ion_binding(const std::unique_ptr<concrete_mechanism<B>>& mech, const char* ion) {
+    const common_impl<B>& impl = dynamic_cast<const common_impl<B>&>(*mech.get());
+    return impl.ion_bindings_.count(ion)? impl.ion_bindings_.at(ion): "";
+}
+
 
 struct foo_backend {
     struct shared_state {
         std::unordered_map<std::string, fvm_value_type> overrides;
+        std::unordered_map<std::string, std::string> ions = {
+            { "a", "foo_ion_a" },
+            { "b", "foo_ion_b" },
+            { "c", "foo_ion_c" },
+            { "d", "foo_ion_d" },
+            { "e", "foo_ion_e" },
+            { "f", "foo_ion_f" }
+        };
     };
 };
 
@@ -90,6 +113,14 @@ using foo_mechanism = common_impl<foo_backend>;
 struct bar_backend {
     struct shared_state {
         std::unordered_map<std::string, fvm_value_type> overrides;
+        std::unordered_map<std::string, std::string> ions = {
+            { "a", "bar_ion_a" },
+            { "b", "bar_ion_b" },
+            { "c", "bar_ion_c" },
+            { "d", "bar_ion_d" },
+            { "e", "bar_ion_e" },
+            { "f", "bar_ion_f" }
+        };
     };
 };
 
@@ -98,6 +129,10 @@ using bar_mechanism = common_impl<bar_backend>;
 // Fleeb implementations:
 
 struct fleeb_foo: foo_mechanism {
+    fleeb_foo() {
+        this->mech_ions = {"a", "b", "c", "d"};
+    }
+
     const mechanism_fingerprint& fingerprint() const override {
         static mechanism_fingerprint hash = "fleebprint";
         return hash;
@@ -109,6 +144,10 @@ struct fleeb_foo: foo_mechanism {
 };
 
 struct special_fleeb_foo: foo_mechanism {
+    special_fleeb_foo() {
+        this->mech_ions = {"a", "b", "c", "d"};
+    }
+
     const mechanism_fingerprint& fingerprint() const override {
         static mechanism_fingerprint hash = "fleebprint";
         return hash;
@@ -120,6 +159,10 @@ struct special_fleeb_foo: foo_mechanism {
 };
 
 struct fleeb_bar: bar_mechanism {
+    fleeb_bar() {
+        this->mech_ions = {"a", "b", "c", "d"};
+    }
+
     const mechanism_fingerprint& fingerprint() const override {
         static mechanism_fingerprint hash = "fleebprint";
         return hash;
@@ -174,9 +217,10 @@ mechanism_catalogue build_fake_catalogue() {
 
     // Add derived versions with global overrides:
 
-    cat.derive("fleeb1",        "fleeb",         {{"plugh", 1.0}});
+    cat.derive("fleeb1",        "fleeb",         {{"plugh", 1.0}}, {{"a", "b"}, {"b", "a"}});
     cat.derive("special_fleeb", "fleeb",         {{"plugh", 2.0}});
     cat.derive("fleeb2",        "special_fleeb", {{"norf", 11.0}});
+    cat.derive("fleeb3",        "fleeb1",        {}, {{"b", "c"}, {"c", "b"}});
     cat.derive("bleeble",       "burble",        {{"quux",  10.}, {"xyzzy", -20.}});
 
     // Attach implementations:
@@ -252,33 +296,33 @@ TEST(mechcat, instance) {
 
     // All fleebs on the bar backend have the same implementation:
 
-    auto fleeb_bar_mech = cat.instance<bar_backend>("fleeb");
-    auto fleeb1_bar_mech = cat.instance<bar_backend>("fleeb1");
-    auto special_fleeb_bar_mech = cat.instance<bar_backend>("special_fleeb");
-    auto fleeb2_bar_mech = cat.instance<bar_backend>("fleeb2");
+    auto fleeb_bar_inst = cat.instance<bar_backend>("fleeb");
+    auto fleeb1_bar_inst = cat.instance<bar_backend>("fleeb1");
+    auto special_fleeb_bar_inst = cat.instance<bar_backend>("special_fleeb");
+    auto fleeb2_bar_inst = cat.instance<bar_backend>("fleeb2");
 
-    EXPECT_EQ(typeid(fleeb_bar), typeid(*fleeb_bar_mech.get()));
-    EXPECT_EQ(typeid(fleeb_bar), typeid(*fleeb1_bar_mech.get()));
-    EXPECT_EQ(typeid(fleeb_bar), typeid(*special_fleeb_bar_mech.get()));
-    EXPECT_EQ(typeid(fleeb_bar), typeid(*fleeb2_bar_mech.get()));
+    EXPECT_EQ(typeid(fleeb_bar), typeid(*fleeb_bar_inst.mech.get()));
+    EXPECT_EQ(typeid(fleeb_bar), typeid(*fleeb1_bar_inst.mech.get()));
+    EXPECT_EQ(typeid(fleeb_bar), typeid(*special_fleeb_bar_inst.mech.get()));
+    EXPECT_EQ(typeid(fleeb_bar), typeid(*fleeb2_bar_inst.mech.get()));
 
-    EXPECT_EQ("fleeb"s, fleeb2_bar_mech->internal_name());
+    EXPECT_EQ("fleeb"s, fleeb2_bar_inst.mech->internal_name());
 
     // special_fleeb and fleeb2 (deriving from special_fleeb) have a specialized
     // implementation:
 
-    auto fleeb_foo_mech = cat.instance<foo_backend>("fleeb");
-    auto fleeb1_foo_mech = cat.instance<foo_backend>("fleeb1");
-    auto special_fleeb_foo_mech = cat.instance<foo_backend>("special_fleeb");
-    auto fleeb2_foo_mech = cat.instance<foo_backend>("fleeb2");
+    auto fleeb_foo_inst = cat.instance<foo_backend>("fleeb");
+    auto fleeb1_foo_inst = cat.instance<foo_backend>("fleeb1");
+    auto special_fleeb_foo_inst = cat.instance<foo_backend>("special_fleeb");
+    auto fleeb2_foo_inst = cat.instance<foo_backend>("fleeb2");
 
-    EXPECT_EQ(typeid(fleeb_foo), typeid(*fleeb_foo_mech.get()));
-    EXPECT_EQ(typeid(fleeb_foo), typeid(*fleeb1_foo_mech.get()));
-    EXPECT_EQ(typeid(special_fleeb_foo), typeid(*special_fleeb_foo_mech.get()));
-    EXPECT_EQ(typeid(special_fleeb_foo), typeid(*fleeb2_foo_mech.get()));
+    EXPECT_EQ(typeid(fleeb_foo), typeid(*fleeb_foo_inst.mech.get()));
+    EXPECT_EQ(typeid(fleeb_foo), typeid(*fleeb1_foo_inst.mech.get()));
+    EXPECT_EQ(typeid(special_fleeb_foo), typeid(*special_fleeb_foo_inst.mech.get()));
+    EXPECT_EQ(typeid(special_fleeb_foo), typeid(*fleeb2_foo_inst.mech.get()));
 
-    EXPECT_EQ("fleeb"s, fleeb1_foo_mech->internal_name());
-    EXPECT_EQ("special fleeb"s, fleeb2_foo_mech->internal_name());
+    EXPECT_EQ("fleeb"s, fleeb1_foo_inst.mech->internal_name());
+    EXPECT_EQ("special fleeb"s, fleeb2_foo_inst.mech->internal_name());
 }
 
 TEST(mechcat, instantiate) {
@@ -286,18 +330,76 @@ TEST(mechcat, instantiate) {
     // write its specialized global variables to shared state, but we do in
     // these tests for testing purposes.
 
-    mechanism::layout layout = {{0u, 1u, 2u}, {1., 2., 1.}, {1u, 1u, 1u}};
+    mechanism_layout layout = {{0u, 1u, 2u}, {1., 2., 1.}, {1u, 1u, 1u}};
     bar_backend::shared_state bar_state;
 
     auto cat = build_fake_catalogue();
 
-    cat.instance<bar_backend>("fleeb")->instantiate(0, bar_state, layout);
+    auto fleeb = cat.instance<bar_backend>("fleeb");
+    fleeb.mech->instantiate(0, bar_state, fleeb.overrides, layout);
     EXPECT_TRUE(bar_state.overrides.empty());
 
     bar_state.overrides.clear();
-    cat.instance<bar_backend>("fleeb2")->instantiate(0, bar_state, layout);
+    auto fleeb2 = cat.instance<bar_backend>("fleeb2");
+    fleeb2.mech->instantiate(0, bar_state, fleeb2.overrides, layout);
     EXPECT_EQ(2.0,  bar_state.overrides.at("plugh"));
     EXPECT_EQ(11.0, bar_state.overrides.at("norf"));
+
+    // Check ion rebinding:
+    // fleeb1 should have ions 'a' and 'b' swapped;
+    // fleeb2 should swap 'b' and 'c' relative to fleeb1, so that
+    // 'b' maps to the state 'c' ion, 'c' maps to the state 'a' ion,
+    // and 'a' maps to the state 'b' ion.
+
+    EXPECT_EQ("bar_ion_a", ion_binding(fleeb.mech, "a"));
+    EXPECT_EQ("bar_ion_b", ion_binding(fleeb.mech, "b"));
+    EXPECT_EQ("bar_ion_c", ion_binding(fleeb.mech, "c"));
+    EXPECT_EQ("bar_ion_d", ion_binding(fleeb.mech, "d"));
+
+    auto fleeb3 = cat.instance<bar_backend>("fleeb3");
+    fleeb3.mech->instantiate(0, bar_state, fleeb3.overrides, layout);
+
+    foo_backend::shared_state foo_state;
+    auto fleeb1 = cat.instance<foo_backend>("fleeb1");
+    fleeb1.mech->instantiate(0, foo_state, fleeb1.overrides, layout);
+
+    EXPECT_EQ("foo_ion_b", ion_binding(fleeb1.mech, "a"));
+    EXPECT_EQ("foo_ion_a", ion_binding(fleeb1.mech, "b"));
+    EXPECT_EQ("foo_ion_c", ion_binding(fleeb1.mech, "c"));
+    EXPECT_EQ("foo_ion_d", ion_binding(fleeb1.mech, "d"));
+
+    EXPECT_EQ("bar_ion_c", ion_binding(fleeb3.mech, "a"));
+    EXPECT_EQ("bar_ion_a", ion_binding(fleeb3.mech, "b"));
+    EXPECT_EQ("bar_ion_b", ion_binding(fleeb3.mech, "c"));
+    EXPECT_EQ("bar_ion_d", ion_binding(fleeb3.mech, "d"));
+}
+
+TEST(mechcat, bad_ion_rename) {
+    auto cat = build_fake_catalogue();
+
+    // missing ion
+    EXPECT_THROW(cat.derive("ono", "fleeb", {}, {{"nosuchion", "x"}}), invalid_ion_remap);
+
+    // two ions with the same name, the original 'b', and the renamed 'a'
+    EXPECT_THROW(cat.derive("alas", "fleeb", {}, {{"a", "b"}}), invalid_ion_remap);
+}
+
+TEST(mechcat, parameterize_over_ion) {
+    auto cat = build_fake_catalogue();
+
+    // Can only use parametrize_over_ion with mechanisms that depend on exactly
+    // one ion.
+
+    EXPECT_THROW(parameterize_over_ion(cat, "fleeb", "nope"), invalid_ion_remap);
+
+    parameterize_over_ion(cat, "burble", "one");
+    parameterize_over_ion(cat, "burble", "two");
+
+    auto b1 = cat["burble/one"];
+    EXPECT_EQ("one", b1.ions.begin()->first);
+
+    auto b2 = cat["burble/two"];
+    EXPECT_EQ("two", b2.ions.begin()->first);
 }
 
 TEST(mechcat, copy) {
@@ -306,10 +408,10 @@ TEST(mechcat, copy) {
 
     EXPECT_EQ(cat["fleeb2"], cat2["fleeb2"]);
 
-    auto fleeb2_instance = cat.instance<foo_backend>("fleeb2");
-    auto fleeb2_instance2 = cat2.instance<foo_backend>("fleeb2");
+    auto fleeb2_inst = cat.instance<foo_backend>("fleeb2");
+    auto fleeb2_inst2 = cat2.instance<foo_backend>("fleeb2");
 
-    EXPECT_EQ(typeid(*fleeb2_instance.get()), typeid(*fleeb2_instance.get()));
+    EXPECT_EQ(typeid(*fleeb2_inst.mech.get()), typeid(*fleeb2_inst2.mech.get()));
 }
 
 

--- a/test/unit/test_synapses.cpp
+++ b/test/unit/test_synapses.cpp
@@ -79,10 +79,10 @@ TEST(synapses, syn_basic_state) {
     int num_comp = 4;
     int num_intdom = 1;
 
-    auto expsyn = unique_cast<multicore::mechanism>(global_default_catalogue().instance<backend>("expsyn"));
+    auto expsyn = unique_cast<multicore::mechanism>(global_default_catalogue().instance<backend>("expsyn").mech);
     ASSERT_TRUE(expsyn);
 
-    auto exp2syn = unique_cast<multicore::mechanism>(global_default_catalogue().instance<backend>("exp2syn"));
+    auto exp2syn = unique_cast<multicore::mechanism>(global_default_catalogue().instance<backend>("exp2syn").mech);
     ASSERT_TRUE(exp2syn);
 
     std::vector<fvm_gap_junction> gj = {};
@@ -98,8 +98,8 @@ TEST(synapses, syn_basic_state) {
     std::vector<index_type> syn_mult(num_syn, 1);
     std::vector<value_type> syn_weight(num_syn, 1.0);
 
-    expsyn->instantiate(0, state, {syn_cv, syn_weight, syn_mult});
-    exp2syn->instantiate(1, state, {syn_cv, syn_weight, syn_mult});
+    expsyn->instantiate(0, state, {}, {syn_cv, syn_weight, syn_mult});
+    exp2syn->instantiate(1, state, {}, {syn_cv, syn_weight, syn_mult});
 
     // Parameters initialized to default values?
 


### PR DESCRIPTION
* Make global parameters and ion rebindings part of the instantiate interface, rather than insist that all concrete mechanisms implement these as methods.
* Mechanism catalogue instance() returns a pair, comprising the concrete mechanism for the requested backend, together with the override data.
* Extend catalgoue derive() method to take a list of old ion name -> new ion name remappings for a mechanism.
* Add exceptions for ion remapping errors, and check for these errors.
* Add convenience function for reparameterizing a mechanism with a single ion dependency over other ions. (This will be used for the future nernst pre-supplied mechanism.)
* Add unit tests for: chained renamings of ion names across multiple derivations; correct shared state ion assignment after renamings; ion remapping exceptions; parameterize_over_ion.