### PR TITLE
 Fix modcc printing for namespaces.

### DIFF
--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -196,13 +196,13 @@ std::string emit_cpp_source(const Module& module_, const printer_options& opt) {
     out <<
         "class " << class_name << ": public base {\n"
         "public:\n" << indent <<
-        "const mechanism_fingerprint& fingerprint() const override {\n" << indent <<
-        "static mechanism_fingerprint hash = " << quote(fingerprint) << ";\n"
+        "const ::arb::mechanism_fingerprint& fingerprint() const override {\n" << indent <<
+        "static ::arb::mechanism_fingerprint hash = " << quote(fingerprint) << ";\n"
         "return hash;\n" << popindent <<
         "}\n"
         "std::string internal_name() const override { return " << quote(name) << "; }\n"
-        "mechanismKind kind() const override { return " << module_kind_str(module_) << "; }\n"
-        "mechanism_ptr clone() const override { return mechanism_ptr(new " << class_name << "()); }\n"
+        "::arb::mechanismKind kind() const override { return " << module_kind_str(module_) << "; }\n"
+        "::arb::mechanism_ptr clone() const override { return ::arb::mechanism_ptr(new " << class_name << "()); }\n"
         "\n"
         "void nrn_init() override;\n"
         "void nrn_state() override;\n"

--- a/modcc/printer/cudaprinter.cpp
+++ b/modcc/printer/cudaprinter.cpp
@@ -89,13 +89,13 @@ std::string emit_cuda_cpp_source(const Module& module_, const printer_options& o
         "\n"
         "class " << class_name << ": public ::arb::gpu::mechanism {\n"
         "public:\n" << indent <<
-        "const mechanism_fingerprint& fingerprint() const override {\n" << indent <<
-        "static mechanism_fingerprint hash = " << quote(fingerprint) << ";\n"
+        "const ::arb::mechanism_fingerprint& fingerprint() const override {\n" << indent <<
+        "static ::arb::mechanism_fingerprint hash = " << quote(fingerprint) << ";\n"
         "return hash;\n" << popindent <<
         "}\n\n"
         "std::string internal_name() const override { return " << quote(name) << "; }\n"
-        "mechanismKind kind() const override { return " << module_kind_str(module_) << "; }\n"
-        "mechanism_ptr clone() const override { return mechanism_ptr(new " << class_name << "()); }\n"
+        "::arb::mechanismKind kind() const override { return " << module_kind_str(module_) << "; }\n"
+        "::arb::mechanism_ptr clone() const override { return ::arb::mechanism_ptr(new " << class_name << "()); }\n"
         "\n"
         "void nrn_init() override {\n" << indent <<
         class_name << "_nrn_init_(pp_);\n" << popindent <<
@@ -252,9 +252,9 @@ std::string emit_cuda_cu_source(const Module& module_, const printer_options& op
 
     out << "namespace {\n\n"; // place inside an anonymous namespace
 
-    out << "using arb::gpu::exprelr;\n";
-    out << "using arb::gpu::min;\n";
-    out << "using arb::gpu::max;\n\n";
+    out << "using ::arb::gpu::exprelr;\n";
+    out << "using ::arb::gpu::min;\n";
+    out << "using ::arb::gpu::max;\n\n";
 
     // Procedures as __device__ functions.
     auto emit_procedure_kernel = [&] (ProcedureExpression* e) {
@@ -452,7 +452,7 @@ void emit_state_update_cu(std::ostream& out, Symbol* from,
     }
 
     if (is_point_proc) {
-        out << "arb::gpu::reduce_by_key(";
+        out << "::arb::gpu::reduce_by_key(";
         is_minus && out << "-";
         out << from->name()
             << ", params_." << d.data_var << ", " << index_i_name(d.index_var) << ", lane_mask_);\n";

--- a/modcc/printer/cudaprinter.cpp
+++ b/modcc/printer/cudaprinter.cpp
@@ -323,7 +323,7 @@ std::string emit_cuda_cu_source(const Module& module_, const printer_options& op
             << "\n" << indent
             << "auto n = p.width_;\n"
             << "unsigned block_dim = 128;\n"
-            << "unsigned grid_dim = gpu::impl::block_count(n, block_dim);\n"
+            << "unsigned grid_dim = ::arb::gpu::impl::block_count(n, block_dim);\n"
             << e->name() << "<<<grid_dim, block_dim>>>(p);\n"
             << popindent;
 
@@ -340,7 +340,7 @@ std::string emit_cuda_cu_source(const Module& module_, const printer_options& op
         << ppack_name << "& p, deliverable_event_stream_state events) {\n" << indent
         << "auto n = events.n;\n"
         << "unsigned block_dim = 128;\n"
-        << "unsigned grid_dim = gpu::impl::block_count(n, block_dim);\n"
+        << "unsigned grid_dim = ::arb::gpu::impl::block_count(n, block_dim);\n"
         << "deliver_events<<<grid_dim, block_dim>>>(mech_id, p, events);\n"
         << popindent << "}\n\n";
 

--- a/modcc/printer/infoprinter.cpp
+++ b/modcc/printer/infoprinter.cpp
@@ -88,7 +88,7 @@ std::string build_info_header(const Module& m, const printer_options& opt) {
         "using spec = ::arb::mechanism_field_spec;\n";
 
    out <<
-        "static mechanism_info info = {\n"
+        "static ::arb::mechanism_info info = {\n"
         << indent <<
         "// globals\n"
         "{\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -19,7 +19,7 @@ build_modules(
     SOURCE_DIR mod
     DEST_DIR "${test_mech_dir}"
     ${external_modcc}
-    MODCC_FLAGS -t cpu -t gpu ${ARB_MODCC_FLAGS}
+    MODCC_FLAGS -t cpu -t gpu ${ARB_MODCC_FLAGS} -N testing
     GENERATES .hpp _cpu.cpp _gpu.cpp _gpu.cu
     TARGET build_test_mods
 )

--- a/test/unit/unit_test_catalogue.cpp
+++ b/test/unit/unit_test_catalogue.cpp
@@ -15,13 +15,13 @@
 
 #ifndef ARB_GPU_ENABLED
 #define ADD_MECH(c, x)\
-c.add(#x, mechanism_##x##_info());\
-c.register_implementation(#x, make_mechanism_##x<multicore::backend>());
+c.add(#x, testing::mechanism_##x##_info());\
+c.register_implementation(#x, testing::make_mechanism_##x<multicore::backend>());
 #else
 #define ADD_MECH(c, x)\
-c.add(#x, mechanism_##x##_info());\
-c.register_implementation(#x, make_mechanism_##x<multicore::backend>());\
-c.register_implementation(#x, make_mechanism_##x<gpu::backend>());
+c.add(#x, testing::mechanism_##x##_info());\
+c.register_implementation(#x, testing::make_mechanism_##x<multicore::backend>());\
+c.register_implementation(#x, testing::make_mechanism_##x<gpu::backend>());
 #endif
 
 using namespace arb;


### PR DESCRIPTION
* Correctly decorate required names from arb:: namespace.
* Put the unit test mechanisms in the 'testing::' namespace, to exercise this functionality.

Fixes #791. 