### PR TITLE
Fix import error for python2/validation scripts.

### DIFF
--- a/validation/ref/neuron/ball_and_squiggle.py
+++ b/validation/ref/neuron/ball_and_squiggle.py
@@ -4,7 +4,11 @@
 import json
 import math
 import nrn_validation as V
-from builtins import range
+
+try:
+    from builtins import range
+except ImportError:
+    from __builtin__ import range
 
 V.override_defaults_from_args()
 

--- a/validation/ref/neuron/nrn_validation.py
+++ b/validation/ref/neuron/nrn_validation.py
@@ -8,7 +8,11 @@ import re
 import numpy as np
 import neuron
 from neuron import h
-from builtins import range
+
+try:
+    from builtins import range
+except ImportError:
+    from __builtin__ import range
 
 # This is super annoying: without neuron.gui, need
 # to explicit load 'standard' hoc routines like 'run',


### PR DESCRIPTION
Building validation data with python2 can raise an import error for `builtins`.

* Catch import error, and import from `__builtin__` instead.