### PR TITLE
Python wrapper: complete schedule by adding events(t0,t1)

### DIFF
--- a/doc/py_recipe.rst
+++ b/doc/py_recipe.rst
@@ -193,6 +193,10 @@ Event Generator and Schedules
         No events delivered after this time [ms].
         Must be non-negative or ``None``.
 
+    .. function:: events(t0, t1)
+
+        Returns a view of monotonically increasing time values in the half-open interval [t0, t1).
+
 .. class:: explicit_schedule
 
     Describes an explicit schedule at a predetermined (sorted) sequence of :attr:`times`.
@@ -206,6 +210,10 @@ Event Generator and Schedules
     .. attribute:: times
 
         The list of non-negative times [ms].
+
+    .. function:: events(t0, t1)
+
+        Returns a view of monotonically increasing time values in the half-open interval [t0, t1).
 
 .. class:: poisson_schedule
 
@@ -229,6 +237,10 @@ Event Generator and Schedules
     .. attribute:: seed
 
         The seed for the random number generator.
+
+    .. function:: events(t0, t1)
+
+        Returns a view of monotonically increasing time values in the half-open interval [t0, t1).
 
 An example of an event generator reads as follows:
 

--- a/python/schedule.cpp
+++ b/python/schedule.cpp
@@ -81,18 +81,13 @@ arb::schedule regular_schedule_shim::schedule() const {
             tstop.value_or(arb::terminal_time));
 }
 
-std::vector<arb::time_type> regular_schedule_shim::events(pybind11::object t0, pybind11::object t1) {
-    regular_schedule_shim::opt_time_type t0_opt = py2optional<time_type>(t0,
-        "t0 must be a non-negative number, or None", is_nonneg());
-    regular_schedule_shim::opt_time_type t1_opt = py2optional<time_type>(t1,
-        "t1 must be a non-negative number, or None", is_nonneg());
-
-    arb::time_type t0_time = t0_opt.value_or(arb::terminal_time);
-    arb::time_type t1_time = t1_opt.value_or(arb::terminal_time);
+std::vector<arb::time_type> regular_schedule_shim::events(arb::time_type t0, arb::time_type t1) {
+    pyarb::assert_throw(is_nonneg()(t0), "t0 must be a non-negative number");
+    pyarb::assert_throw(is_nonneg()(t1), "t1 must be a non-negative number");
 
     arb::schedule sched = regular_schedule_shim::schedule();
 
-    return as_vector(sched.events(t0_time, t1_time));
+    return as_vector(sched.events(t0, t1));
 }
 
 //

--- a/python/schedule.hpp
+++ b/python/schedule.hpp
@@ -36,7 +36,7 @@ struct regular_schedule_shim {
 
     arb::schedule schedule() const;
 
-    std::list<arb::time_type> events(pybind11::object t0, pybind11::object t1);
+    std::vector<arb::time_type> events(pybind11::object t0, pybind11::object t1);
 };
 
 // A Python shim for arb::explicit_schedule.
@@ -55,7 +55,7 @@ struct explicit_schedule_shim {
 
     arb::schedule schedule() const;
 
-    std::list<arb::time_type> events(arb::time_type t0, arb::time_type t1);
+    std::vector<arb::time_type> events(arb::time_type t0, arb::time_type t1);
 };
 
 // A Python shim for arb::poisson_schedule.
@@ -80,7 +80,7 @@ struct poisson_schedule_shim {
 
     arb::schedule schedule() const;
 
-    std::list<arb::time_type> events(arb::time_type t0, arb::time_type t1);
+    std::vector<arb::time_type> events(arb::time_type t0, arb::time_type t1);
 };
 
 }

--- a/python/schedule.hpp
+++ b/python/schedule.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <arbor/schedule.hpp>
 #include <arbor/common_types.hpp>
@@ -34,6 +35,8 @@ struct regular_schedule_shim {
     opt_time_type get_tstop()  const;
 
     arb::schedule schedule() const;
+
+    std::list<arb::time_type> events(pybind11::object t0, pybind11::object t1);
 };
 
 // A Python shim for arb::explicit_schedule.
@@ -51,6 +54,8 @@ struct explicit_schedule_shim {
     std::vector<arb::time_type> get_times() const;
 
     arb::schedule schedule() const;
+
+    std::list<arb::time_type> events(arb::time_type t0, arb::time_type t1);
 };
 
 // A Python shim for arb::poisson_schedule.
@@ -74,6 +79,8 @@ struct poisson_schedule_shim {
     arb::time_type get_freq() const;
 
     arb::schedule schedule() const;
+
+    std::list<arb::time_type> events(arb::time_type t0, arb::time_type t1);
 };
 
 }

--- a/python/schedule.hpp
+++ b/python/schedule.hpp
@@ -36,7 +36,7 @@ struct regular_schedule_shim {
 
     arb::schedule schedule() const;
 
-    std::vector<arb::time_type> events(pybind11::object t0, pybind11::object t1);
+    std::vector<arb::time_type> events(arb::time_type t0, arb::time_type t1);
 };
 
 // A Python shim for arb::explicit_schedule.

--- a/python/test/unit/test_schedules.py
+++ b/python/test/unit/test_schedules.py
@@ -42,8 +42,8 @@ class RegularSchedule(unittest.TestCase):
         expected = [0, 0.25, 0.5, 0.75, 1.0]
         rs = arb.regular_schedule(tstart = 0., dt = 0.25, tstop = 1.25)
         self.assertEqual(expected, rs.events(0., 1.25))
-        self.assertEqual(expected, rs.events(0., None))
-        self.assertEqual([], rs.events(None, None))
+        self.assertEqual(expected, rs.events(0., 5.))
+        self.assertEqual([], rs.events(5., 10.))
 
     def test_exceptions_regular_schedule(self):
         with self.assertRaisesRegex(RuntimeError,
@@ -60,11 +60,11 @@ class RegularSchedule(unittest.TestCase):
             "tstop must be a non-negative number, or None"):
             arb.regular_schedule(tstop = 'tstop')
         with self.assertRaisesRegex(RuntimeError,
-            "t0 must be a non-negative number, or None"):
+            "t0 must be a non-negative number"):
             rs = arb.regular_schedule(0., 1., 10.)
-            rs.events(-1, None)
+            rs.events(-1, 0)
         with self.assertRaisesRegex(RuntimeError,
-            "t1 must be a non-negative number, or None"):
+            "t1 must be a non-negative number"):
             rs = arb.regular_schedule(0., 1., 10.)
             rs.events(0, -10)
 

--- a/python/test/unit/test_schedules.py
+++ b/python/test/unit/test_schedules.py
@@ -35,8 +35,15 @@ class RegularSchedule(unittest.TestCase):
         rs.dt = 0.5
         rs.tstop = 42.
         self.assertEqual(rs.tstart, 17.)
-        self.assertAlmostEqual(rs.dt, 0.5)
+        self.assertAlmostEqual(rs.dt, 0.5, places = 1)
         self.assertEqual(rs.tstop, 42.)
+
+    def test_events_regular_schedule(self):
+        expected = [0, 0.25, 0.5, 0.75, 1.0]
+        rs = arb.regular_schedule(tstart = 0., dt = 0.25, tstop = 1.25)
+        self.assertEqual(expected, rs.events(0., 1.25))
+        self.assertEqual(expected, rs.events(0., None))
+        self.assertEqual([], rs.events(None, None))
 
     def test_exceptions_regular_schedule(self):
         with self.assertRaisesRegex(RuntimeError,
@@ -52,6 +59,14 @@ class RegularSchedule(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError,
             "tstop must be a non-negative number, or None"):
             arb.regular_schedule(tstop = 'tstop')
+        with self.assertRaisesRegex(RuntimeError,
+            "t0 must be a non-negative number, or None"):
+            rs = arb.regular_schedule(0., 1., 10.)
+            rs.events(-1, None)
+        with self.assertRaisesRegex(RuntimeError,
+            "t1 must be a non-negative number, or None"):
+            rs = arb.regular_schedule(0., 1., 10.)
+            rs.events(0, -10)
 
 class ExplicitSchedule(unittest.TestCase):
     def test_times_contor_explicit_schedule(self):
@@ -63,6 +78,16 @@ class ExplicitSchedule(unittest.TestCase):
         es.times = [42, 43, 44, 55.5, 100]
         self.assertEqual(es.times, [42, 43, 44, 55.5, 100])
 
+    def test_events_explicit_schedule(self):
+        times = [0.1, 0.3, 1.0, 2.2, 1.25, 1.7]
+        expected = [0.1, 0.3, 1.0]
+        es = arb.explicit_schedule(times)
+        for i in range(len(expected)):
+            self.assertAlmostEqual(expected[i], es.events(0., 1.25)[i], places = 2)
+        expected = [0.3, 1.0, 1.25, 1.7]
+        for i in range(len(expected)):
+            self.assertAlmostEqual(expected[i], es.events(0.3, 1.71)[i], places = 2)
+
     def test_exceptions_explicit_schedule(self):
         with self.assertRaisesRegex(RuntimeError,
             "explicit time schedule cannot contain negative values"):
@@ -73,6 +98,14 @@ class ExplicitSchedule(unittest.TestCase):
             arb.explicit_schedule([None])
         with self.assertRaises(TypeError):
             arb.explicit_schedule([[1,2,3]])
+        with self.assertRaisesRegex(RuntimeError,
+            "t0 must be a non-negative number"):
+            rs = arb.regular_schedule()
+            rs.events(-1., 1.)
+        with self.assertRaisesRegex(RuntimeError,
+            "t1 must be a non-negative number"):
+            rs = arb.regular_schedule()
+            rs.events(1., -1.)
 
 class PoissonSchedule(unittest.TestCase):
     def test_freq_seed_contor_poisson_schedule(self):
@@ -95,6 +128,15 @@ class PoissonSchedule(unittest.TestCase):
         self.assertAlmostEqual(ps.freq, 5.5)
         self.assertEqual(ps.seed, 83)
 
+    def test_events_poisson_schedule(self):
+        expected = [17.4107, 502.074, 506.111, 597.116]
+        ps = arb.poisson_schedule(0., 10., 0)
+        for i in range(len(expected)):
+            self.assertAlmostEqual(expected[i], ps.events(0., 600.)[i], places = 3)
+        expected = [5030.22, 5045.75, 5069.84, 5091.56, 5182.17, 5367.3, 5566.73, 5642.13, 5719.85, 5796, 5808.33]
+        for i in range(len(expected)):
+            self.assertAlmostEqual(expected[i], ps.events(5000., 6000.)[i], places = 2)
+
     def test_exceptions_poisson_schedule(self):
         with self.assertRaisesRegex(RuntimeError,
             "tstart must be a non-negative number"):
@@ -116,6 +158,14 @@ class PoissonSchedule(unittest.TestCase):
             arb.poisson_schedule(seed = 'seed')
         with self.assertRaises(TypeError):
             arb.poisson_schedule(seed = None)
+        with self.assertRaisesRegex(RuntimeError,
+            "t0 must be a non-negative number"):
+            ps = arb.poisson_schedule()
+            ps.events(-1., 1.)
+        with self.assertRaisesRegex(RuntimeError,
+            "t1 must be a non-negative number"):
+            ps = arb.poisson_schedule()
+            ps.events(1., -1.)
 
 def suite():
     # specify class and test functions in tuple (here: all tests starting with 'test' from classes RegularSchedule, ExplicitSchedule and PoissonSchedule


### PR DESCRIPTION
- Add `events(t0, t1)` to schedules
- No need for `reset()` anymore, since new interface asks for values between a range
- No need for `empty_schedule`, since of no use for python user

Fixes #770
Addresses #799
