### PR TITLE
Fix examples to use new cable cell API.

### DIFF
--- a/arbor/include/arbor/segment.hpp
+++ b/arbor/include/arbor/segment.hpp
@@ -83,11 +83,6 @@ public:
         return false;
     }
 
-    // Approximate frequency-dependent length constant lower bound.
-    virtual value_type length_constant(value_type freq_Hz) const {
-        return 0;
-    }
-
     util::optional<mechanism_desc&> mechanism(const std::string& name) {
         auto it = std::find_if(mechanisms_.begin(), mechanisms_.end(),
             [&](mechanism_desc& m) { return m.name()==name; });

--- a/example/dryrun/dryrun.cpp
+++ b/example/dryrun/dryrun.cpp
@@ -68,6 +68,12 @@ public:
         return cell_kind::cable;
     }
 
+    arb::util::any get_global_properties(arb::cell_kind) const override {
+        arb::cable_cell_global_properties gprop;
+        gprop.default_parameters = arb::neuron_parameter_defaults;
+        return gprop;
+    }
+
     // Each cell has one spike detector (at the soma).
     cell_size_type num_sources(cell_gid_type gid) const override {
         return 1;
@@ -304,10 +310,10 @@ double interp(const std::array<T,2>& r, unsigned i, unsigned n) {
 
 arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) {
     arb::cable_cell cell;
+    cell.default_parameters.axial_resistivity = 100; // [Ω·cm]
 
     // Add soma.
     auto soma = cell.add_soma(12.6157/2.0); // For area of 500 μm².
-    soma->rL = 100;
     soma->add_mechanism("hh");
 
     std::vector<std::vector<unsigned>> levels;
@@ -336,7 +342,6 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
                     auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
                     dend->set_compartments(nc);
                     dend->add_mechanism("pas");
-                    dend->rL = 100;
                 }
             }
         }

--- a/example/gap_junctions/gap_junctions.cpp
+++ b/example/gap_junctions/gap_junctions.cpp
@@ -97,7 +97,8 @@ public:
 
     arb::util::any get_global_properties(cell_kind k) const override {
         arb::cable_cell_global_properties a;
-        a.temperature_K = 308.15;
+        a.default_parameters = arb::neuron_parameter_defaults;
+        a.default_parameters.temperature_K = 308.15;
         return a;
     }
 
@@ -321,6 +322,8 @@ void write_trace_json(const std::vector<arb::trace_data<double>>& trace, unsigne
 
 arb::cable_cell gj_cell(cell_gid_type gid, unsigned ncell, double stim_duration) {
     arb::cable_cell cell;
+    cell.default_parameters.axial_resistivity = 100;       // [Ω·cm]
+    cell.default_parameters.membrane_capacitance = 0.018;  // [F/m²]
 
     arb::mechanism_desc nax("nax");
     arb::mechanism_desc kdrmt("kdrmt");
@@ -337,8 +340,6 @@ arb::cable_cell gj_cell(cell_gid_type gid, unsigned ncell, double stim_duration)
     };
 
     auto setup_seg = [&](auto seg) {
-        seg->rL = 100;
-        seg->cm = 0.018;
         seg->add_mechanism(nax);
         seg->add_mechanism(kdrmt);
         seg->add_mechanism(kamt);

--- a/example/generators/event_gen.cpp
+++ b/example/generators/event_gen.cpp
@@ -65,6 +65,12 @@ public:
         return cell_kind::cable;
     }
 
+    arb::util::any get_global_properties(arb::cell_kind) const override {
+        arb::cable_cell_global_properties gprop;
+        gprop.default_parameters = arb::neuron_parameter_defaults;
+        return gprop;
+    }
+
     // The cell has one target synapse, which receives both inhibitory and exchitatory inputs.
     cell_size_type num_targets(cell_gid_type gid) const override {
         arb_assert(gid==0); // There is only one cell in the model

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -301,10 +301,10 @@ double interp(const std::array<T,2>& r, unsigned i, unsigned n) {
 
 arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) {
     arb::cable_cell cell;
+    cell.default_parameters.axial_resistivity = 100; // [Ω·cm]
 
     // Add soma.
     auto soma = cell.add_soma(12.6157/2.0); // For area of 500 μm².
-    soma->rL = 100;
     soma->add_mechanism("hh");
 
     std::vector<std::vector<unsigned>> levels;
@@ -333,7 +333,6 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
                     auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
                     dend->set_compartments(nc);
                     dend->add_mechanism("pas");
-                    dend->rL = 100;
                 }
             }
         }


### PR DESCRIPTION
* Also remove vestigial segment::length_constant() virtual function.

Fixes #831.