### PR TITLE
Fix gpu unit test

### DIFF
--- a/test/unit/test_mc_cell_group_gpu.cpp
+++ b/test/unit/test_mc_cell_group_gpu.cpp
@@ -30,10 +30,15 @@ namespace {
 
 TEST(mc_cell_group, gpu_test)
 {
-    mc_cell_group group({0}, cable1d_recipe(make_cell()), lowered_cell());
+    auto rec = cable1d_recipe(make_cell());
+    rec.nernst_ion("na");
+    rec.nernst_ion("ca");
+    rec.nernst_ion("k");
+
+    mc_cell_group group{{0}, rec, lowered_cell()};
     group.advance(epoch(0, 50), 0.01, {});
 
-    // the model is expected to generate 4 spikes as a result of the
+    // The model is expected to generate 4 spikes as a result of the
     // fixed stimulus over 50 ms
     EXPECT_EQ(4u, group.spikes().size());
 }


### PR DESCRIPTION
Fix `mc_cell_group.gpu_test`: use the nerst equations for the reversal potential calculation for `na`, `ca` and `k`