### PR TITLE
Cable cell

### DIFF
--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -450,10 +450,10 @@ cable_cell make_cable_cell(const morphology& m,
                            bool compartments_from_discretization)
 {
     using point3d = cable_cell::point_type;
-    cable_cell newcell;
+    cable_cell cell;
 
     if (!m.num_branches()) {
-        return newcell;
+        return cell;
     }
 
     // Add the soma.
@@ -461,7 +461,7 @@ cable_cell make_cable_cell(const morphology& m,
 
     // If there is no spherical root/soma use a zero-radius soma.
     double srad = m.spherical_root()? loc.radius: 0.;
-    newcell.add_soma(srad, point3d(loc.x, loc.y, loc.z));
+    cell.add_soma(srad, point3d(loc.x, loc.y, loc.z));
 
     auto& samples = m.samples();
     for (auto i: util::make_span(1, m.num_branches())) {
@@ -496,7 +496,7 @@ cable_cell make_cable_cell(const morphology& m,
         if (!m.spherical_root()) {
             pid = pid==mnpos? 0: pid+1;
         }
-        auto cable = newcell.add_cable(pid, make_segment<cable_segment>(kind, radii, points));
+        auto cable = cell.add_cable(pid, make_segment<cable_segment>(kind, radii, points));
         if (compartments_from_discretization) {
             cable->as_cable()->set_compartments(radii.size()-1);
         }
@@ -510,15 +510,17 @@ cable_cell make_cable_cell(const morphology& m,
     for (auto r: dictionary.regions()) {
         regions[r.first] = thingify(r.second, em);
     }
-    newcell.set_regions(std::move(regions));
+    cell.set_regions(std::move(regions));
 
     std::unordered_map<std::string, mlocation_list> locsets;
     for (auto l: dictionary.locsets()) {
         locsets[l.first] = thingify(l.second, em);
     }
-    newcell.set_locsets(std::move(locsets));
+    cell.set_locsets(std::move(locsets));
 
-    return newcell;
+    cell.set_morphology(std::move(em));
+
+    return cell;
 }
 
 } // namespace arb

--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -20,11 +20,11 @@ namespace arb {
 // Pair of indexes that describe range of local indices.
 // Returned by cable_cell::place() calls, so that the caller can
 // refer to targets, detectors, etc on the cell.
-struct locrange {
-    cell_lid_type first;
-    cell_lid_type last;
-    locrange(cell_lid_type first, cell_lid_type last):
-        first(first), last(last) {}
+struct lid_range {
+    cell_lid_type begin;
+    cell_lid_type end;
+    lid_range(cell_lid_type b, cell_lid_type e):
+        begin(b), end(e) {}
 };
 
 // Probe type for cell descriptions.
@@ -131,24 +131,24 @@ public:
     void paint(const std::string& target, mechanism_desc);
 
     // Synapses.
-    locrange place(const std::string& target, const mechanism_desc&);
-    locrange place(const mlocation&, const mechanism_desc&);  // LEGACY
-    //locrange place(const locset&, const mechanism_desc&);
+    lid_range place(const std::string& target, const mechanism_desc&);
+    lid_range place(const mlocation&, const mechanism_desc&);  // LEGACY
+    //lid_range place(const locset&, const mechanism_desc&);
 
     // Stimuli.
-    locrange place(const std::string& target, const i_clamp&);
-    locrange place(const mlocation&, const i_clamp&);  // LEGACY
-    //locrange place(const locset&, const i_clamp&);
+    lid_range place(const std::string& target, const i_clamp&);
+    lid_range place(const mlocation&, const i_clamp&);  // LEGACY
+    //lid_range place(const locset&, const i_clamp&);
 
     // Gap junctions.
-    locrange place(const std::string&, gap_junction_site);
-    locrange place(const mlocation& loc, gap_junction_site);  // LEGACY
-    //locrange place(const locset&, gap_junction_site);
+    lid_range place(const std::string&, gap_junction_site);
+    lid_range place(const mlocation& loc, gap_junction_site);  // LEGACY
+    //lid_range place(const locset&, gap_junction_site);
 
     // spike detectors
-    locrange place(const std::string&, const detector&);
-    locrange place(const mlocation&, const detector&);  // LEGACY
-    //locrange place(const locset&, const detector&);
+    lid_range place(const std::string&, const threshold_detector&);
+    lid_range place(const mlocation&, const threshold_detector&);  // LEGACY
+    //lid_range place(const locset&, const threshold_detector&);
 
     //
     // access to placed items

--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -131,20 +131,24 @@ public:
     void paint(const std::string& target, mechanism_desc);
 
     // Synapses.
-    locrange place(const std::string& target, mechanism_desc);
-    locrange place(mlocation, mechanism_desc);
+    locrange place(const std::string& target, const mechanism_desc&);
+    locrange place(const mlocation&, const mechanism_desc&);  // LEGACY
+    //locrange place(const locset&, const mechanism_desc&);
 
     // Stimuli.
-    locrange place(const std::string& target, i_clamp stim);
-    locrange place(mlocation, i_clamp stim);
+    locrange place(const std::string& target, const i_clamp&);
+    locrange place(const mlocation&, const i_clamp&);  // LEGACY
+    //locrange place(const locset&, const i_clamp&);
 
     // Gap junctions.
     locrange place(const std::string&, gap_junction_site);
-    locrange place(mlocation, gap_junction_site);
+    locrange place(const mlocation& loc, gap_junction_site);  // LEGACY
+    //locrange place(const locset&, gap_junction_site);
 
     // spike detectors
-    locrange place(const std::string&, detector);
-    locrange place(mlocation, detector);
+    locrange place(const std::string&, const detector&);
+    locrange place(const mlocation&, const detector&);  // LEGACY
+    //locrange place(const locset&, const detector&);
 
     //
     // access to placed items

--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -94,24 +94,31 @@ public:
     const class segment* parent(index_type index) const;
     const class segment* segment(index_type index) const;
 
-    /// access pointer to the soma
-    /// returns nullptr if the cell has no soma
+    // access pointer to the soma
+    // returns nullptr if the cell has no soma
+    // LEGACY
     soma_segment* soma();
     const soma_segment* soma() const;
 
-    /// access pointer to a cable segment
-    /// will throw an cable_cell_error exception if
-    /// the cable index is not valid
+    // access pointer to a cable segment
+    // will throw an cable_cell_error exception if
+    // the cable index is not valid
+    // LEGACY
     cable_segment* cable(index_type index);
     const cable_segment* cable(index_type index) const;
 
     const std::vector<segment_ptr>& segments() const;
 
-    /// the number of segments in the cell
+    // the number of segments in the cell
     size_type num_segments() const;
 
-    /// return a vector with the compartment count for each segment in the cell
+    // return a vector with the compartment count for each segment in the cell
+    // LEGACY
     std::vector<size_type> compartment_counts() const;
+
+    // The total number of compartments in the discretised cell.
+    // LEGACY
+    size_type num_compartments() const;
 
     //
     // Painters and placers.

--- a/arbor/include/arbor/cable_cell_param.hpp
+++ b/arbor/include/arbor/cable_cell_param.hpp
@@ -32,7 +32,7 @@ struct i_clamp {
 };
 
 // Threshold detector description.
-struct detector {
+struct threshold_detector {
     double threshold;
 };
 

--- a/arbor/include/arbor/cable_cell_param.hpp
+++ b/arbor/include/arbor/cable_cell_param.hpp
@@ -16,6 +16,30 @@ struct cable_cell_error: arbor_exception {
         arbor_exception("cable_cell: "+what) {}
 };
 
+// Current clamp description for stimulus specification.
+struct i_clamp {
+    using value_type = double;
+
+    value_type delay = 0;      // [ms]
+    value_type duration = 0;   // [ms]
+    value_type amplitude = 0;  // [nA]
+
+    i_clamp() = default;
+
+    i_clamp(value_type delay, value_type duration, value_type amplitude):
+        delay(delay), duration(duration), amplitude(amplitude)
+    {}
+};
+
+// Threshold detector description.
+struct detector {
+    double threshold;
+};
+
+// Tag type for dispatching cable_cell::place() calls that add gap junction sites.
+struct gap_junction_site {};
+
+
 // Mechanism description, viz. mechanism name and
 // (non-global) parameter settings. Used to assign
 // density and point mechanisms to segments and

--- a/arbor/include/arbor/morph/locset.hpp
+++ b/arbor/include/arbor/morph/locset.hpp
@@ -19,25 +19,6 @@ class em_morphology;
 
 class locset;
 
-namespace ls {
-
-// Location of a sample.
-locset location(mlocation);
-
-// Location of a sample.
-locset sample(msize_t);
-
-// Set of terminal nodes on a morphology.
-locset terminal();
-
-// The root node of a morphology.
-locset root();
-
-// The null (empty) set.
-locset nil();
-
-} // namespace ls
-
 class locset {
 public:
     template <typename Impl,
@@ -59,13 +40,11 @@ public:
         return *this;
     }
 
-    locset() {
-        *this = ls::nil();
-    }
+    // The default constructor creates an empty "nil" set.
+    locset();
 
-    locset(mlocation other) {
-        *this = ls::location(other);
-    }
+    // Construct an explicit location set with a single location.
+    locset(mlocation other);
 
     template <typename Impl,
               typename X=std::enable_if_t<!std::is_same<std::decay_t<Impl>, locset>::value>>
@@ -126,5 +105,24 @@ private:
         Impl wrapped;
     };
 };
+
+namespace ls {
+
+// Location of a sample.
+locset location(mlocation);
+
+// Location of a sample.
+locset sample(msize_t);
+
+// Set of terminal nodes on a morphology.
+locset terminal();
+
+// The root node of a morphology.
+locset root();
+
+// The null (empty) set.
+locset nil();
+
+} // namespace ls
 
 } // namespace arb

--- a/arbor/include/arbor/morph/locset.hpp
+++ b/arbor/include/arbor/morph/locset.hpp
@@ -17,10 +17,29 @@ namespace arb {
 // interface for concretising locsets.
 class em_morphology;
 
+class locset;
+
+namespace ls {
+
+// Location of a sample.
+locset location(mlocation);
+
+// Location of a sample.
+locset sample(msize_t);
+
+// Set of terminal nodes on a morphology.
+locset terminal();
+
+// The root node of a morphology.
+locset root();
+
+// The null (empty) set.
+locset nil();
+
+} // namespace ls
+
 class locset {
 public:
-    locset() = delete;
-
     template <typename Impl,
               typename X=std::enable_if_t<!std::is_same<std::decay_t<Impl>, locset>::value>>
     explicit locset(Impl&& impl):
@@ -38,6 +57,14 @@ public:
     locset& operator=(const locset& other) {
         impl_ = other.impl_->clone();
         return *this;
+    }
+
+    locset() {
+        *this = ls::nil();
+    }
+
+    locset(mlocation other) {
+        *this = ls::location(other);
     }
 
     template <typename Impl,
@@ -99,24 +126,5 @@ private:
         Impl wrapped;
     };
 };
-
-namespace ls {
-
-// Location of a sample.
-locset location(mlocation);
-
-// Location of a sample.
-locset sample(msize_t);
-
-// Set of terminal nodes on a morphology.
-locset terminal();
-
-// The root node of a morphology.
-locset root();
-
-// The null (empty) set.
-locset nil();
-
-} // namespace ls
 
 } // namespace arb

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -21,6 +21,7 @@ class morphology {
 public:
     morphology(sample_tree m, bool use_spherical_root);
     morphology(sample_tree m);
+    morphology();
 
     // Whether the root of the morphology is spherical.
     bool spherical_root() const;

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -10,7 +10,7 @@
 
 namespace arb {
 
-class morphology_impl;
+struct morphology_impl;
 
 using mindex_range = std::pair<const msize_t*, const msize_t*>;
 

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -19,8 +19,6 @@ class em_morphology;
 
 class region {
 public:
-    region() = delete;
-
     template <typename Impl,
               typename X=std::enable_if_t<!std::is_same<std::decay_t<Impl>, region>::value>>
     explicit region(Impl&& impl):
@@ -31,6 +29,9 @@ public:
         impl_(new wrap<Impl>(impl)) {}
 
     region(region&& other) = default;
+
+    // The default constructor creates an empty "nil" region.
+    region();
 
     region(const region& other):
         impl_(other.impl_->clone()) {}
@@ -109,6 +110,9 @@ private:
 };
 
 namespace reg {
+
+// An empty region.
+region nil();
 
 // An explicit cable section.
 region cable(mcable);

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -229,7 +229,8 @@ struct catalogue_state {
         const std::string* base = &name;
 
         if (!defined(name)) {
-            if (implicit_deriv = derive(name)) {
+            implicit_deriv = derive(name);
+            if (implicit_deriv) {
                 base = &implicit_deriv.first().parent;
             }
             else {

--- a/arbor/morph/em_morphology.cpp
+++ b/arbor/morph/em_morphology.cpp
@@ -24,6 +24,8 @@ em_morphology::em_morphology(const morphology& m):
     const auto ns = morph_.num_samples();
     const auto nb = morph_.num_branches();
 
+    if (!ns) return;
+
     // Cache distance of each sample from the root.
     dist2root_.resize(ns);
     dist2root_[0] = 0.;
@@ -51,7 +53,7 @@ em_morphology::em_morphology(const morphology& m):
         for (auto i: idx) {
             sample_locs_[i] = {msize_t(b), (dist2root_[i]-start)/len};
         }
-        // For ensure that all non-spherical branches have their last sample 
+        // Ensure that all non-spherical branches have their last sample 
         if (idx.size()>1u) {
             sample_locs_[idx.back()] = mlocation{msize_t(b), 1};
         }
@@ -70,6 +72,10 @@ em_morphology::em_morphology(const morphology& m):
         }
     }
 }
+
+em_morphology::em_morphology():
+    em_morphology(morphology())
+{}
 
 const morphology& em_morphology::morph() const {
     return morph_;

--- a/arbor/morph/em_morphology.hpp
+++ b/arbor/morph/em_morphology.hpp
@@ -19,6 +19,7 @@ class em_morphology {
     std::vector<double> branch_lengths_;
 
 public:
+    em_morphology();
     em_morphology(const morphology& m);
 
     const morphology& morph() const;

--- a/arbor/morph/label_dict.cpp
+++ b/arbor/morph/label_dict.cpp
@@ -24,16 +24,7 @@ void label_dict::set(const std::string& name, arb::locset ls) {
         throw morphology_error(util::pprintf(
                 "Attempt to add a locset \"{}\" to a label dictionary that already contains a region with the same name.", name));
     }
-    // First remove an entry with the same name if it exists.
-    // Has to be this way, because insert_or_assign() is C++17, and we
-    // can't use operator[] because locset is not default constructable.
-    auto it = locsets_.find(name);
-    if (it!=locsets_.end()) {
-        it->second = std::move(ls);
-    }
-    else {
-        locsets_.emplace(name, std::move(ls));
-    }
+    locsets_[name] = std::move(ls);
 }
 
 void label_dict::set(const std::string& name, arb::region reg) {
@@ -41,16 +32,7 @@ void label_dict::set(const std::string& name, arb::region reg) {
         throw morphology_error(util::pprintf(
                 "Attempt to add a region \"{}\" to a label dictionary that already contains a locset with the same name.", name));
     }
-    // First remove an entry with the same name if it exists.
-    // Has to be this way, because insert_or_assign() is C++17, and we
-    // can't use operator[] because region is not default constructable.
-    auto it = regions_.find(name);
-    if (it!=regions_.end()) {
-        it->second = std::move(reg);
-    }
-    else {
-        regions_.emplace(name, std::move(reg));
-    }
+    regions_[name] = std::move(reg);
 }
 
 util::optional<const region&> label_dict::region(const std::string& name) const {

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -244,4 +244,12 @@ locset sum(locset lhs, locset rhs) {
     return locset(ls::lsum(std::move(lhs), std::move(rhs)));
 }
 
+locset::locset() {
+    *this = ls::nil();
+}
+
+locset::locset(mlocation other) {
+    *this = ls::location(other);
+}
+
 } // namespace arb

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -182,6 +182,10 @@ morphology::morphology(sample_tree m):
     impl_(std::make_shared<const morphology_impl>(std::move(m)))
 {}
 
+morphology::morphology():
+    morphology(sample_tree())
+{}
+
 // The parent branch of branch b.
 msize_t morphology::branch_parent(msize_t b) const {
     return impl_->branch_parents_[b];

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -99,6 +99,23 @@ mcable_list remove_cover(mcable_list cables, const em_morphology& m) {
 }
 
 //
+// Null/empty region
+//
+struct nil_ {};
+
+region nil() {
+    return region{nil_{}};
+}
+
+mcable_list thingify_(const nil_& x, const em_morphology& m) {
+    return {};
+}
+
+std::ostream& operator<<(std::ostream& o, const nil_& x) {
+    return o << "nil";
+}
+
+//
 // Explicit cable section
 //
 
@@ -298,6 +315,10 @@ region intersect(region l, region r) {
 
 region join(region l, region r) {
     return region{reg::reg_or(std::move(l), std::move(r))};
+}
+
+region::region() {
+    *this = reg::nil();
 }
 
 } // namespace arb

--- a/example/dryrun/dryrun.cpp
+++ b/example/dryrun/dryrun.cpp
@@ -364,7 +364,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
             for (unsigned j=0; j<2; ++j) {
                 if (dis(gen)<bp) {
                     sec_ids.push_back(nsec++);
-                    auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
+                    auto dend = cell.add_cable(sec, arb::make_segment<arb::cable_segment>(arb::section_kind::dendrite, dend_radius, dend_radius, l));
                     dend->set_compartments(nc);
                     dend->add_mechanism("pas");
                 }
@@ -377,10 +377,10 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     }
 
     // Add spike threshold detector at the soma.
-    cell.add_detector({0,0}, 10);
+    cell.place(arb::mlocation{0,0}, arb::detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
-    cell.add_synapse({1, 0.5}, "expsyn");
+    cell.place(arb::mlocation{1, 0.5}, "expsyn");
 
     return cell;
 }

--- a/example/dryrun/dryrun.cpp
+++ b/example/dryrun/dryrun.cpp
@@ -377,7 +377,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     }
 
     // Add spike threshold detector at the soma.
-    cell.place(arb::mlocation{0,0}, arb::detector{10});
+    cell.place(arb::mlocation{0,0}, arb::threshold_detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
     cell.place(arb::mlocation{1, 0.5}, "expsyn");

--- a/example/gap_junctions/gap_junctions.cpp
+++ b/example/gap_junctions/gap_junctions.cpp
@@ -368,7 +368,7 @@ arb::cable_cell gj_cell(cell_gid_type gid, unsigned ncell, double stim_duration)
     set_reg_params();
     setup_seg(dend);
 
-    cell.place(arb::mlocation{0,0}, arb::detector{10});
+    cell.place(arb::mlocation{0,0}, arb::threshold_detector{10});
 
     cell.place(arb::mlocation{0, 1}, arb::gap_junction_site{});
     cell.place(arb::mlocation{1, 1}, arb::gap_junction_site{});

--- a/example/gap_junctions/gap_junctions.cpp
+++ b/example/gap_junctions/gap_junctions.cpp
@@ -363,23 +363,23 @@ arb::cable_cell gj_cell(cell_gid_type gid, unsigned ncell, double stim_duration)
     set_reg_params();
     setup_seg(soma);
 
-    auto dend = cell.add_cable(0, arb::section_kind::dendrite, 3.0/2.0, 3.0/2.0, 300); //cable 1
+    auto dend = cell.add_cable(0, arb::make_segment<arb::cable_segment>(arb::section_kind::dendrite, 3.0/2.0, 3.0/2.0, 300)); //cable 1
     dend->set_compartments(1);
     set_reg_params();
     setup_seg(dend);
 
-    cell.add_detector({0,0}, 10);
+    cell.place(arb::mlocation{0,0}, arb::detector{10});
 
-    cell.add_gap_junction({0, 1});
-    cell.add_gap_junction({1, 1});
+    cell.place(arb::mlocation{0, 1}, arb::gap_junction_site{});
+    cell.place(arb::mlocation{1, 1}, arb::gap_junction_site{});
 
     if (!gid) {
         arb::i_clamp stim(0, stim_duration, 0.4);
-        cell.add_stimulus({0, 0.5}, stim);
+        cell.place(arb::mlocation{0, 0.5}, stim);
     }
 
     // Add a synapse to the mid point of the first dendrite.
-    cell.add_synapse({1, 0.5}, "expsyn");
+    cell.place(arb::mlocation{1, 0.5}, "expsyn");
 
     return cell;
 }

--- a/example/generators/generators.cpp
+++ b/example/generators/generators.cpp
@@ -55,7 +55,7 @@ public:
         // Add one synapse at the soma.
         // This synapse will be the target for all events, from both
         // event_generators.
-        c.add_synapse({0, 0.5}, "expsyn");
+        c.place(arb::mlocation{0, 0.5}, "expsyn");
 
         return std::move(c);
     }

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -367,7 +367,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
             for (unsigned j=0; j<2; ++j) {
                 if (dis(gen)<bp) {
                     sec_ids.push_back(nsec++);
-                    auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
+                    auto dend = cell.add_cable(sec, arb::make_segment<arb::cable_segment>(arb::section_kind::dendrite, dend_radius, dend_radius, l));
                     dend->set_compartments(nc);
                     dend->add_mechanism("pas");
                 }
@@ -380,14 +380,14 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     }
 
     // Add spike threshold detector at the soma.
-    cell.add_detector({0,0}, 10);
+    cell.place(arb::mlocation{0,0}, arb::detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
-    cell.add_synapse({1, 0.5}, "expsyn");
+    cell.place(arb::mlocation{1, 0.5}, "expsyn");
 
     // Add additional synapses that will not be connected to anything.
     for (unsigned i=1u; i<params.synapses; ++i) {
-        cell.add_synapse({1, 0.5}, "expsyn");
+        cell.place(arb::mlocation{1, 0.5}, "expsyn");
     }
 
     return cell;

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -380,7 +380,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     }
 
     // Add spike threshold detector at the soma.
-    cell.place(arb::mlocation{0,0}, arb::detector{10});
+    cell.place(arb::mlocation{0,0}, arb::threshold_detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
     cell.place(arb::mlocation{1, 0.5}, "expsyn");

--- a/example/single/single.cpp
+++ b/example/single/single.cpp
@@ -77,7 +77,7 @@ struct single_recipe: public arb::recipe {
 
         arb::cell_lid_type last_segment = c.num_segments()-1;
         arb::mlocation end_last_segment = { last_segment, 1. };
-        c.add_synapse(end_last_segment, "exp2syn");
+        c.place(end_last_segment, "exp2syn");
 
         return c;
     }

--- a/modcc/solvers.cpp
+++ b/modcc/solvers.cpp
@@ -402,7 +402,7 @@ void SparseSolverVisitor::finalize() {
             }
         }
 
-        if (lhs_col==-1) {
+        if (lhs_col==unsigned(-1)) {
             throw std::logic_error("zero row in sparse solver matrix");
         }
 
@@ -493,7 +493,7 @@ void LinearSolverVisitor::finalize() {
             }
         }
 
-        if (lhs==-1) {
+        if (lhs==unsigned(-1)) {
             throw std::logic_error("zero row in linear solver matrix");
         }
 

--- a/modcc/solvers.cpp
+++ b/modcc/solvers.cpp
@@ -389,15 +389,14 @@ void SparseSolverVisitor::finalize() {
 
     // State variable updates given by rhs/diagonal for reduced matrix.
     Location loc;
-    for (unsigned i = 0; i<A_.nrow(); ++i) {
+    auto nrow = A_.nrow();
+    for (unsigned i = 0; i<nrow; ++i) {
         const symge::sym_row& row = A_[i];
         unsigned rhs_col = A_.augcol();
-        unsigned lhs_col;
-        for (unsigned r = 0; r < A_.nrow(); r++) {
-            if (row[r]) {
-                lhs_col = r;
-                break;
-            }
+        unsigned lhs_col = 0;
+        while (lhs_col<nrow && !row[lhs_col]) ++lhs_col;
+        if (lhs_col==nrow) {
+            error({"internal compiler error", loc});
         }
 
         auto expr =
@@ -475,23 +474,22 @@ void LinearSolverVisitor::finalize() {
 
     // State variable updates given by rhs/diagonal for reduced matrix.
     Location loc;
-    for (unsigned i = 0; i < A_.nrow(); ++i) {
+    auto nrow = A_.nrow();
+    for (unsigned i = 0; i < nrow; ++i) {
         const symge::sym_row& row = A_[i];
         unsigned rhs = A_.augcol();
-        unsigned lhs;
-        for (unsigned r = 0; r < A_.nrow(); r++) {
-            if (row[r]) {
-                lhs = r;
-                break;
-            }
+        unsigned lhs_col = 0;
+        while (lhs_col<nrow && !row[lhs_col]) ++lhs_col;
+        if (lhs_col==nrow) {
+            error({"internal compiler error", loc});
         }
 
         auto expr =
             make_expression<AssignmentExpression>(loc,
-                    make_expression<IdentifierExpression>(loc, dvars_[lhs]),
+                    make_expression<IdentifierExpression>(loc, dvars_[lhs_col]),
                     make_expression<DivBinaryExpression>(loc,
                             make_expression<IdentifierExpression>(loc, symge::name(A_[i][rhs])),
-                            make_expression<IdentifierExpression>(loc, symge::name(A_[i][lhs]))));
+                            make_expression<IdentifierExpression>(loc, symge::name(A_[i][lhs_col]))));
 
         statements_.push_back(std::move(expr));
     }

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -115,7 +115,7 @@ arb::cable_cell make_cable_cell(arb::cell_gid_type gid, const cell_parameters& p
             for (unsigned j=0; j<2; ++j) {
                 if (dis(gen)<bp) {
                     sec_ids.push_back(nsec++);
-                    auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
+                    auto dend = cell.add_cable(sec, arb::make_segment<arb::cable_segment>(arb::section_kind::dendrite, dend_radius, dend_radius, l));
                     dend->set_compartments(nc);
                     dend->add_mechanism("pas");
                 }
@@ -128,14 +128,14 @@ arb::cable_cell make_cable_cell(arb::cell_gid_type gid, const cell_parameters& p
     }
 
     // Add spike threshold detector at the soma.
-    cell.add_detector({0,0}, 10);
+    cell.place(arb::mlocation{0,0}, arb::detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
-    cell.add_synapse({1, 0.5}, "expsyn");
+    cell.place(arb::mlocation{1, 0.5}, "expsyn");
 
     // Add additional synapses.
     for (unsigned i=1u; i<params.synapses; ++i) {
-        cell.add_synapse({1, 0.5}, "expsyn");
+        cell.place(arb::mlocation{1, 0.5}, "expsyn");
     }
 
     return cell;

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -128,7 +128,7 @@ arb::cable_cell make_cable_cell(arb::cell_gid_type gid, const cell_parameters& p
     }
 
     // Add spike threshold detector at the soma.
-    cell.place(arb::mlocation{0,0}, arb::detector{10});
+    cell.place(arb::mlocation{0,0}, arb::threshold_detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
     cell.place(arb::mlocation{1, 0.5}, "expsyn");

--- a/test/common_cells.hpp
+++ b/test/common_cells.hpp
@@ -27,7 +27,7 @@ inline cable_cell make_cell_soma_only(bool with_stim = true) {
     soma->add_mechanism("hh");
 
     if (with_stim) {
-        c.add_stimulus({0,0.5}, {10., 100., 0.1});
+        c.place(mlocation{0,0.5}, i_clamp{10., 100., 0.1});
     }
 
     return c;
@@ -60,7 +60,7 @@ inline cable_cell make_cell_ball_and_stick(bool with_stim = true) {
     auto soma = c.add_soma(12.6157/2.0);
     soma->add_mechanism("hh");
 
-    c.add_cable(0, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+    c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 1.0/2, 1.0/2, 200.0));
 
     for (auto& seg: c.segments()) {
         if (seg->is_dendrite()) {
@@ -70,7 +70,7 @@ inline cable_cell make_cell_ball_and_stick(bool with_stim = true) {
     }
 
     if (with_stim) {
-        c.add_stimulus({1,1}, {5., 80., 0.3});
+        c.place(mlocation{1,1}, i_clamp{5., 80., 0.3});
     }
     return c;
 }
@@ -104,7 +104,7 @@ inline cable_cell make_cell_ball_and_taper(bool with_stim = true) {
     auto soma = c.add_soma(12.6157/2.0);
     soma->add_mechanism("hh");
 
-    c.add_cable(0, section_kind::dendrite, 1.0/2, 0.4/2, 200.0);
+    c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 1.0/2, 0.4/2, 200.0));
 
     for (auto& seg: c.segments()) {
         if (seg->is_dendrite()) {
@@ -114,7 +114,7 @@ inline cable_cell make_cell_ball_and_taper(bool with_stim = true) {
     }
 
     if (with_stim) {
-        c.add_stimulus({1,1}, {5., 80., 0.3});
+        c.place(mlocation{1,1}, i_clamp{5., 80., 0.3});
     }
     return c;
 }
@@ -172,7 +172,7 @@ inline cable_cell make_cell_ball_and_squiggle(bool with_stim = true) {
     }
 
     if (with_stim) {
-        c.add_stimulus({1,1}, {5., 80., 0.3});
+        c.place(mlocation{1,1}, i_clamp{5., 80., 0.3});
     }
     return c;
 }
@@ -207,9 +207,9 @@ inline cable_cell make_cell_ball_and_3stick(bool with_stim = true) {
     auto soma = c.add_soma(12.6157/2.0);
     soma->add_mechanism("hh");
 
-    c.add_cable(0, section_kind::dendrite, 0.5, 0.5, 100);
-    c.add_cable(1, section_kind::dendrite, 0.5, 0.5, 100);
-    c.add_cable(1, section_kind::dendrite, 0.5, 0.5, 100);
+    c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
+    c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
+    c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
 
     for (auto& seg: c.segments()) {
         if (seg->is_dendrite()) {
@@ -219,8 +219,8 @@ inline cable_cell make_cell_ball_and_3stick(bool with_stim = true) {
     }
 
     if (with_stim) {
-        c.add_stimulus({2,1}, {5.,  80., 0.45});
-        c.add_stimulus({3,1}, {40., 10.,-0.2});
+        c.place(mlocation{2,1}, i_clamp{5.,  80., 0.45});
+        c.place(mlocation{3,1}, i_clamp{40., 10.,-0.2});
     }
     return c;
 }
@@ -253,7 +253,7 @@ inline cable_cell make_cell_simple_cable(bool with_stim = true) {
     c.default_parameters.membrane_capacitance = 0.01;
 
     c.add_soma(0);
-    c.add_cable(0, section_kind::dendrite, 0.5, 0.5, 1000);
+    c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 1000));
 
     double gbar = 0.000025;
     double I = 0.1;
@@ -272,7 +272,7 @@ inline cable_cell make_cell_simple_cable(bool with_stim = true) {
     if (with_stim) {
         // stimulus in the middle of our zero-volume 'soma'
         // corresponds to proximal end of cable.
-        c.add_stimulus({0,0.5}, {0., INFINITY, I});
+        c.place(mlocation{0,0.5}, i_clamp{0., INFINITY, I});
     }
     return c;
 }

--- a/test/unit/test_cable_cell.cpp
+++ b/test/unit/test_cable_cell.cpp
@@ -234,8 +234,3 @@ TEST(cable_cell, clone) {
     EXPECT_NE(c.segment(1)->num_compartments(), d.segment(1)->num_compartments());
     EXPECT_EQ(c.segment(2)->num_compartments(), d.segment(2)->num_compartments());
 }
-
-TEST(cable_cell, get_kind) {
-    cable_cell c;
-    EXPECT_EQ(cell_kind::cable, c.get_cell_kind());
-}

--- a/test/unit/test_cable_cell.cpp
+++ b/test/unit/test_cable_cell.cpp
@@ -200,7 +200,7 @@ TEST(cable_cell, clone) {
     c.segment(2)->set_compartments(5);
 
     c.place(mlocation{1, 0.3}, "expsyn");
-    c.place(mlocation{0, 0.5}, detector{10.0});
+    c.place(mlocation{0, 0.5}, threshold_detector{10.0});
 
     // make clone
 

--- a/test/unit/test_cable_cell.cpp
+++ b/test/unit/test_cable_cell.cpp
@@ -2,6 +2,7 @@
 
 #include <arbor/cable_cell.hpp>
 #include <arbor/math.hpp>
+#include <arbor/morph/locset.hpp>
 
 #include "tree.hpp"
 
@@ -37,9 +38,6 @@ TEST(cable_cell, soma) {
         auto s = c.soma();
         EXPECT_EQ(s->radius(), soma_radius);
         EXPECT_EQ(s->center().is_set(), true);
-
-        // add expression template library for points
-        //EXPECT_EQ(s->center(), point<double>(0,0,1));
     }
 }
 
@@ -78,7 +76,7 @@ TEST(cable_cell, add_segment) {
 
         c.add_cable(
             0,
-            section_kind::dendrite, cable_radius, cable_radius, cable_length
+            make_segment<cable_segment>(section_kind::dendrite, cable_radius, cable_radius, cable_length)
         );
 
         EXPECT_EQ(c.num_segments(), 2u);
@@ -95,9 +93,9 @@ TEST(cable_cell, add_segment) {
 
         c.add_cable(
             0,
-            section_kind::dendrite,
-            std::vector<double>{cable_radius, cable_radius, cable_radius, cable_radius},
-            std::vector<double>{cable_length, cable_length, cable_length}
+            make_segment<cable_segment>(section_kind::dendrite,
+                                        std::vector<double>{cable_radius, cable_radius, cable_radius, cable_radius},
+                                        std::vector<double>{cable_length, cable_length, cable_length})
         );
 
         EXPECT_EQ(c.num_segments(), 2u);
@@ -196,14 +194,13 @@ TEST(cable_cell, clone) {
 
     cable_cell c;
     c.add_soma(2.1);
-    c.add_cable(0, section_kind::dendrite, 0.3, 0.2, 10);
+    c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 0.3, 0.2, 10));
     c.segment(1)->set_compartments(3);
-    c.add_cable(1, section_kind::dendrite, 0.2, 0.15, 20);
+    c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.2, 0.15, 20));
     c.segment(2)->set_compartments(5);
 
-    c.add_synapse({1, 0.3}, "expsyn");
-
-    c.add_detector({0, 0.5}, 10.0);
+    c.place(mlocation{1, 0.3}, "expsyn");
+    c.place(mlocation{0, 0.5}, detector{10.0});
 
     // make clone
 
@@ -230,13 +227,8 @@ TEST(cable_cell, clone) {
 
     // check clone is independent
 
-    c.add_cable(2, section_kind::dendrite, 0.15, 0.1, 20);
+    c.add_cable(2, make_segment<cable_segment>(section_kind::dendrite, 0.15, 0.1, 20));
     EXPECT_NE(c.num_segments(), d.num_segments());
-
-    d.detectors()[0].threshold = 13.0;
-    ASSERT_EQ(1u, c.detectors().size());
-    ASSERT_EQ(1u, d.detectors().size());
-    EXPECT_NE(c.detectors()[0].threshold, d.detectors()[0].threshold);
 
     c.segment(1)->set_compartments(7);
     EXPECT_NE(c.segment(1)->num_compartments(), d.segment(1)->num_compartments());

--- a/test/unit/test_domain_decomposition.cpp
+++ b/test/unit/test_domain_decomposition.cpp
@@ -66,7 +66,7 @@ namespace {
         arb::util::unique_any get_cell_description(cell_gid_type) const override {
             cable_cell c;
             c.add_soma(20);
-            c.add_gap_junction({0,1});
+            c.place(mlocation{0,1}, gap_junction_site{});
             return {std::move(c)};
         }
 

--- a/test/unit/test_event_delivery.cpp
+++ b/test/unit/test_event_delivery.cpp
@@ -29,9 +29,9 @@ struct test_recipe: public n_cable_cell_recipe {
     static cable_cell test_cell() {
         cable_cell c;
         c.add_soma(10.)->add_mechanism("pas");
-        c.add_synapse({0, 0.5}, "expsyn");
-        c.add_detector({0, 0.5}, -64);
-        c.add_gap_junction({0, 0.5});
+        c.place(mlocation{0, 0.5}, "expsyn");
+        c.place(mlocation{0, 0.5}, detector{-64});
+        c.place(mlocation{0, 0.5}, gap_junction_site{});
         return c;
     }
 

--- a/test/unit/test_event_delivery.cpp
+++ b/test/unit/test_event_delivery.cpp
@@ -30,7 +30,7 @@ struct test_recipe: public n_cable_cell_recipe {
         cable_cell c;
         c.add_soma(10.)->add_mechanism("pas");
         c.place(mlocation{0, 0.5}, "expsyn");
-        c.place(mlocation{0, 0.5}, detector{-64});
+        c.place(mlocation{0, 0.5}, threshold_detector{-64});
         c.place(mlocation{0, 0.5}, gap_junction_site{});
         return c;
     }

--- a/test/unit/test_fvm_layout.cpp
+++ b/test/unit/test_fvm_layout.cpp
@@ -99,17 +99,17 @@ namespace {
         s = c2.add_soma(14./2);
         s->add_mechanism("hh");
 
-        s = c2.add_cable(0, section_kind::dendrite, 1.0/2, 1.0/2, 200);
+        s = c2.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 1.0/2, 1.0/2, 200));
         s->parameters.membrane_capacitance = 0.017;
 
-        s = c2.add_cable(1, section_kind::dendrite, 0.8/2, 0.8/2, 300);
+        s = c2.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.8/2, 0.8/2, 300));
         s->parameters.membrane_capacitance = 0.013;
 
-        s = c2.add_cable(1, section_kind::dendrite, 0.7/2, 0.7/2, 180);
+        s = c2.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.7/2, 0.7/2, 180));
         s->parameters.membrane_capacitance = 0.018;
 
-        c2.add_stimulus({2,1}, {5.,  80., 0.45});
-        c2.add_stimulus({3,1}, {40., 10.,-0.2});
+        c2.place(mlocation{2,1}, i_clamp{5.,  80., 0.45});
+        c2.place(mlocation{3,1}, i_clamp{40., 10.,-0.2});
 
         for (auto& seg: c2.segments()) {
             if (seg->is_dendrite()) {
@@ -289,10 +289,10 @@ TEST(fvm_layout, mech_index) {
     check_two_cell_system(cells);
 
     // Add four synapses of two varieties across the cells.
-    cells[0].add_synapse({1, 0.4}, "expsyn");
-    cells[0].add_synapse({1, 0.4}, "expsyn");
-    cells[1].add_synapse({2, 0.4}, "exp2syn");
-    cells[1].add_synapse({3, 0.4}, "expsyn");
+    cells[0].place(mlocation{1, 0.4}, "expsyn");
+    cells[0].place(mlocation{1, 0.4}, "expsyn");
+    cells[1].place(mlocation{2, 0.4}, "exp2syn");
+    cells[1].place(mlocation{3, 0.4}, "expsyn");
 
     cable_cell_global_properties gprop;
     gprop.default_parameters = neuron_parameter_defaults;
@@ -367,10 +367,10 @@ TEST(fvm_layout, coalescing_synapses) {
         cable_cell cell = make_cell_ball_and_stick();
 
         // Add synapses of two varieties.
-        cell.add_synapse({1, 0.3}, "expsyn");
-        cell.add_synapse({1, 0.5}, "expsyn");
-        cell.add_synapse({1, 0.7}, "expsyn");
-        cell.add_synapse({1, 0.9}, "expsyn");
+        cell.place(mlocation{1, 0.3}, "expsyn");
+        cell.place(mlocation{1, 0.5}, "expsyn");
+        cell.place(mlocation{1, 0.7}, "expsyn");
+        cell.place(mlocation{1, 0.9}, "expsyn");
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -383,10 +383,10 @@ TEST(fvm_layout, coalescing_synapses) {
         cable_cell cell = make_cell_ball_and_stick();
 
         // Add synapses of two varieties.
-        cell.add_synapse({1, 0.3}, "expsyn");
-        cell.add_synapse({1, 0.5}, "exp2syn");
-        cell.add_synapse({1, 0.7}, "expsyn");
-        cell.add_synapse({1, 0.9}, "exp2syn");
+        cell.place(mlocation{1, 0.3}, "expsyn");
+        cell.place(mlocation{1, 0.5}, "exp2syn");
+        cell.place(mlocation{1, 0.7}, "expsyn");
+        cell.place(mlocation{1, 0.9}, "exp2syn");
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -402,10 +402,10 @@ TEST(fvm_layout, coalescing_synapses) {
     {
         cable_cell cell = make_cell_ball_and_stick();
 
-        cell.add_synapse({1, 0.3}, "expsyn");
-        cell.add_synapse({1, 0.5}, "expsyn");
-        cell.add_synapse({1, 0.7}, "expsyn");
-        cell.add_synapse({1, 0.9}, "expsyn");
+        cell.place(mlocation{1, 0.3}, "expsyn");
+        cell.place(mlocation{1, 0.5}, "expsyn");
+        cell.place(mlocation{1, 0.7}, "expsyn");
+        cell.place(mlocation{1, 0.9}, "expsyn");
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_no_coalesce, {cell}, D);
@@ -418,10 +418,10 @@ TEST(fvm_layout, coalescing_synapses) {
         cable_cell cell = make_cell_ball_and_stick();
 
         // Add synapses of two varieties.
-        cell.add_synapse({1, 0.3}, "expsyn");
-        cell.add_synapse({1, 0.5}, "exp2syn");
-        cell.add_synapse({1, 0.7}, "expsyn");
-        cell.add_synapse({1, 0.9}, "exp2syn");
+        cell.place(mlocation{1, 0.3}, "expsyn");
+        cell.place(mlocation{1, 0.5}, "exp2syn");
+        cell.place(mlocation{1, 0.7}, "expsyn");
+        cell.place(mlocation{1, 0.9}, "exp2syn");
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_no_coalesce, {cell}, D);
@@ -438,10 +438,10 @@ TEST(fvm_layout, coalescing_synapses) {
         cable_cell cell = make_cell_ball_and_stick();
 
         // Add synapses of two varieties.
-        cell.add_synapse({1, 0.3}, "expsyn");
-        cell.add_synapse({1, 0.3}, "expsyn");
-        cell.add_synapse({1, 0.7}, "expsyn");
-        cell.add_synapse({1, 0.7}, "expsyn");
+        cell.place(mlocation{1, 0.3}, "expsyn");
+        cell.place(mlocation{1, 0.3}, "expsyn");
+        cell.place(mlocation{1, 0.7}, "expsyn");
+        cell.place(mlocation{1, 0.7}, "expsyn");
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -454,10 +454,10 @@ TEST(fvm_layout, coalescing_synapses) {
         cable_cell cell = make_cell_ball_and_stick();
 
         // Add synapses of two varieties.
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn", 0, 0.2));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn", 0, 0.2));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn", 0.1, 0.2));
-        cell.add_synapse({1, 0.7}, syn_desc("expsyn", 0.1, 0.2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 0.2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 0.2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0.1, 0.2));
+        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 0.1, 0.2));
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -472,14 +472,14 @@ TEST(fvm_layout, coalescing_synapses) {
         cable_cell cell = make_cell_ball_and_stick();
 
         // Add synapses of two varieties.
-        cell.add_synapse({1, 0.7}, syn_desc("expsyn", 0, 3));
-        cell.add_synapse({1, 0.7}, syn_desc("expsyn", 1, 3));
-        cell.add_synapse({1, 0.7}, syn_desc("expsyn", 0, 3));
-        cell.add_synapse({1, 0.7}, syn_desc("expsyn", 1, 3));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn", 0, 2));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn", 1, 2));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn", 0, 2));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn", 1, 2));
+        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 0, 3));
+        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 1, 3));
+        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 0, 3));
+        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 1, 3));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 1, 2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 1, 2));
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -495,16 +495,16 @@ TEST(fvm_layout, coalescing_synapses) {
         cable_cell cell = make_cell_ball_and_stick();
 
         // Add synapses of two varieties.
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn",  1, 2));
-        cell.add_synapse({1, 0.3}, syn_desc_2("exp2syn", 4, 1));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn",  1, 2));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn",  5, 1));
-        cell.add_synapse({1, 0.3}, syn_desc_2("exp2syn", 1, 3));
-        cell.add_synapse({1, 0.3}, syn_desc("expsyn",  1, 2));
-        cell.add_synapse({1, 0.7}, syn_desc_2("exp2syn", 2, 2));
-        cell.add_synapse({1, 0.7}, syn_desc_2("exp2syn", 2, 1));
-        cell.add_synapse({1, 0.7}, syn_desc_2("exp2syn", 2, 1));
-        cell.add_synapse({1, 0.7}, syn_desc_2("exp2syn", 2, 2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  1, 2));
+        cell.place(mlocation{1, 0.3}, syn_desc_2("exp2syn", 4, 1));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  1, 2));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  5, 1));
+        cell.place(mlocation{1, 0.3}, syn_desc_2("exp2syn", 1, 3));
+        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  1, 2));
+        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 2));
+        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 1));
+        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 1));
+        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 2));
 
         fvm_discretization D = fvm_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -543,14 +543,14 @@ TEST(fvm_layout, synapse_targets) {
         return mechanism_desc(name).set("e", syn_e.at(idx));
     };
 
-    cells[0].add_synapse({1, 0.9}, syn_desc("expsyn", 0));
-    cells[0].add_synapse({0, 0.5}, syn_desc("expsyn", 1));
-    cells[0].add_synapse({1, 0.4}, syn_desc("expsyn", 2));
+    cells[0].place(mlocation{1, 0.9}, syn_desc("expsyn", 0));
+    cells[0].place(mlocation{0, 0.5}, syn_desc("expsyn", 1));
+    cells[0].place(mlocation{1, 0.4}, syn_desc("expsyn", 2));
 
-    cells[1].add_synapse({2, 0.4}, syn_desc("exp2syn", 3));
-    cells[1].add_synapse({1, 0.4}, syn_desc("exp2syn", 4));
-    cells[1].add_synapse({3, 0.4}, syn_desc("expsyn", 5));
-    cells[1].add_synapse({3, 0.7}, syn_desc("exp2syn", 6));
+    cells[1].place(mlocation{2, 0.4}, syn_desc("exp2syn", 3));
+    cells[1].place(mlocation{1, 0.4}, syn_desc("exp2syn", 4));
+    cells[1].place(mlocation{3, 0.4}, syn_desc("expsyn", 5));
+    cells[1].place(mlocation{3, 0.7}, syn_desc("exp2syn", 6));
 
     cable_cell_global_properties gprop;
     gprop.default_parameters = neuron_parameter_defaults;
@@ -639,9 +639,9 @@ TEST(fvm_layout, density_norm_area) {
     cable_cell& c = cells[0];
     auto soma = c.add_soma(12.6157/2.0);
 
-    c.add_cable(0, section_kind::dendrite, 0.5, 0.5, 100);
-    c.add_cable(1, section_kind::dendrite, 0.5, 0.1, 200);
-    c.add_cable(1, section_kind::dendrite, 0.4, 0.4, 150);
+    c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
+    c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.1, 200));
+    c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.4, 0.4, 150));
 
     auto& segs = c.segments();
 
@@ -803,9 +803,9 @@ TEST(fvm_layout, ion_weights) {
     auto construct_cell = [](cable_cell& c) {
         c.add_soma(5);
 
-        c.add_cable(0, section_kind::dendrite, 0.5, 0.5, 100);
-        c.add_cable(1, section_kind::dendrite, 0.5, 0.5, 200);
-        c.add_cable(1, section_kind::dendrite, 0.5, 0.5, 100);
+        c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
+        c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 200));
+        c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
 
         for (auto& s: c.segments()) s->set_compartments(1);
     };
@@ -875,9 +875,9 @@ TEST(fvm_layout, revpot) {
     auto construct_cell = [](cable_cell& c) {
         c.add_soma(5);
 
-        c.add_cable(0, section_kind::dendrite, 0.5, 0.5, 100);
-        c.add_cable(1, section_kind::dendrite, 0.5, 0.5, 200);
-        c.add_cable(1, section_kind::dendrite, 0.5, 0.5, 100);
+        c.add_cable(0, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
+        c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 200));
+        c.add_cable(1, make_segment<cable_segment>(section_kind::dendrite, 0.5, 0.5, 100));
 
         for (auto& s: c.segments()) s->set_compartments(1);
 

--- a/test/unit/test_fvm_lowered.cpp
+++ b/test/unit/test_fvm_lowered.cpp
@@ -262,7 +262,7 @@ TEST(fvm_lowered, target_handles) {
     cells[1].place(mlocation{2, 0.2}, "exp2syn");
     cells[1].place(mlocation{2, 0.8}, "expsyn");
 
-    cells[1].place(mlocation{0, 0}, detector{3.3});
+    cells[1].place(mlocation{0, 0}, threshold_detector{3.3});
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;

--- a/test/unit/test_mc_cell_group.cpp
+++ b/test/unit/test_mc_cell_group.cpp
@@ -23,7 +23,7 @@ namespace {
     cable_cell make_cell() {
         auto c = make_cell_ball_and_stick();
 
-        c.add_detector({0, 0}, 0);
+        c.place(mlocation{0, 0}, detector{0});
         c.segment(1)->set_compartments(101);
 
         return c;
@@ -63,7 +63,7 @@ TEST(mc_cell_group, sources) {
     for (int i=0; i<20; ++i) {
         cells.push_back(make_cell());
         if (i==0 || i==3 || i==17) {
-            cells.back().add_detector({1, 0.3}, 2.3);
+            cells.back().place(mlocation{1, 0.3}, detector{2.3});
         }
 
         EXPECT_EQ(1u + (i==0 || i==3 || i==17), cells.back().detectors().size());

--- a/test/unit/test_mc_cell_group.cpp
+++ b/test/unit/test_mc_cell_group.cpp
@@ -23,7 +23,7 @@ namespace {
     cable_cell make_cell() {
         auto c = make_cell_ball_and_stick();
 
-        c.place(mlocation{0, 0}, detector{0});
+        c.place(mlocation{0, 0}, threshold_detector{0});
         c.segment(1)->set_compartments(101);
 
         return c;
@@ -63,7 +63,7 @@ TEST(mc_cell_group, sources) {
     for (int i=0; i<20; ++i) {
         cells.push_back(make_cell());
         if (i==0 || i==3 || i==17) {
-            cells.back().place(mlocation{1, 0.3}, detector{2.3});
+            cells.back().place(mlocation{1, 0.3}, threshold_detector{2.3});
         }
 
         EXPECT_EQ(1u + (i==0 || i==3 || i==17), cells.back().detectors().size());

--- a/test/unit/test_mc_cell_group_gpu.cpp
+++ b/test/unit/test_mc_cell_group_gpu.cpp
@@ -21,7 +21,7 @@ namespace {
     cable_cell make_cell() {
         auto c = make_cell_ball_and_stick();
 
-        c.place(mlocation{0, 0}, detector{0});
+        c.place(mlocation{0, 0}, threshold_detector{0});
         c.segment(1)->set_compartments(101);
 
         return c;

--- a/test/unit/test_mc_cell_group_gpu.cpp
+++ b/test/unit/test_mc_cell_group_gpu.cpp
@@ -21,7 +21,7 @@ namespace {
     cable_cell make_cell() {
         auto c = make_cell_ball_and_stick();
 
-        c.add_detector({0, 0}, 0);
+        c.place(mlocation{0, 0}, detector{0});
         c.segment(1)->set_compartments(101);
 
         return c;

--- a/test/unit/test_probe.cpp
+++ b/test/unit/test_probe.cpp
@@ -24,7 +24,7 @@ TEST(probe, fvm_lowered_cell) {
     cable_cell bs = make_cell_ball_and_stick(false);
 
     i_clamp stim(0, 100, 0.3);
-    bs.add_stimulus({1, 1}, stim);
+    bs.place(mlocation{1, 1}, stim);
 
     cable1d_recipe rec(bs);
 

--- a/test/unit/test_synapses.cpp
+++ b/test/unit/test_synapses.cpp
@@ -38,9 +38,9 @@ TEST(synapses, add_to_cell) {
     auto soma = cell.add_soma(12.6157/2.0);
     soma->add_mechanism("hh");
 
-    cell.add_synapse({0, 0.1}, "expsyn");
-    cell.add_synapse({1, 0.2}, "exp2syn");
-    cell.add_synapse({0, 0.3}, "expsyn");
+    cell.place(mlocation{0, 0.1}, "expsyn");
+    cell.place(mlocation{0, 0.2}, "exp2syn");
+    cell.place(mlocation{0, 0.3}, "expsyn");
 
     EXPECT_EQ(3u, cell.synapses().size());
     const auto& syns = cell.synapses();
@@ -49,13 +49,16 @@ TEST(synapses, add_to_cell) {
     EXPECT_EQ(syns[0].location.pos, 0.1);
     EXPECT_EQ(syns[0].mechanism.name(), "expsyn");
 
-    EXPECT_EQ(syns[1].location.branch, 1u);
+    EXPECT_EQ(syns[1].location.branch, 0u);
     EXPECT_EQ(syns[1].location.pos, 0.2);
     EXPECT_EQ(syns[1].mechanism.name(), "exp2syn");
 
     EXPECT_EQ(syns[2].location.branch, 0u);
     EXPECT_EQ(syns[2].location.pos, 0.3);
     EXPECT_EQ(syns[2].mechanism.name(), "expsyn");
+
+    // adding a synapse to an invalid branch location should throw.
+    EXPECT_THROW(cell.place(mlocation{1, 0.3}, "expsyn"), arb::cable_cell_error);
 }
 
 template <typename Seq>


### PR DESCRIPTION
First step of refactoring `cable_cell` API.

* Hide implementation and state using PIMPL
* Consistent `place` methods for adding synapse, stimuls, gap junction site and spike detectors to `cable_cell`.
* Add default constructor for `region` and `locset` that create `nil` instances.

This is very much "work in progress", with another follow up PR to:
* Remove non-const interface for querying and adding soma/cable to a cell
* Move `make_cable_cell` functionality into `cable_cell` constructor such that all "morphology description" is performed before instantiation of a cable cell
* Add missing region/locations DSL features to support all examples currently implemented in Arbor.