### PR TITLE
Address Clang 8 warnings.

### DIFF
--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -340,7 +340,7 @@ fvm_discretization fvm_discretize(const std::vector<cable_cell>& cells, const ca
             }
             else {
                 auto opt_index = util::binary_search_index(D.segments, seg_info.parent_cv,
-                    [&D](const segment_info& seg_info) { return seg_info.distal_cv; });
+                    [](const segment_info& seg_info) { return seg_info.distal_cv; });
 
                 if (!opt_index) {
                     throw arbor_internal_error("fvm_layout: could not find parent segment");

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -10,7 +10,7 @@
 
 namespace arb {
 
-class morphology_impl;
+struct morphology_impl;
 
 using mindex_range = std::pair<const msize_t*, const msize_t*>;
 

--- a/arbor/io/trace.hpp
+++ b/arbor/io/trace.hpp
@@ -56,8 +56,6 @@ namespace impl {
             lock_(this->guard())
         {}
 
-        emit_nl_locked(emit_nl_locked&&) = default;
-
         ~emit_nl_locked() {
             if (rdbuf()) {
                 (*this) << std::endl;

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -229,7 +229,7 @@ struct catalogue_state {
         const std::string* base = &name;
 
         if (!defined(name)) {
-            if (implicit_deriv = derive(name)) {
+            if ((implicit_deriv = derive(name))) {
                 base = &implicit_deriv.first().parent;
             }
             else {

--- a/modcc/solvers.cpp
+++ b/modcc/solvers.cpp
@@ -1,5 +1,6 @@
 #include <map>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -392,12 +393,16 @@ void SparseSolverVisitor::finalize() {
     for (unsigned i = 0; i<A_.nrow(); ++i) {
         const symge::sym_row& row = A_[i];
         unsigned rhs_col = A_.augcol();
-        unsigned lhs_col;
-        for (unsigned r = 0; r < A_.nrow(); r++) {
+        unsigned lhs_col = -1;
+        for (unsigned r = 0; r<A_.nrow(); ++r) {
             if (row[r]) {
                 lhs_col = r;
                 break;
             }
+        }
+
+        if (lhs_col==-1) {
+            throw std::logic_error("zero row in sparse solver matrix");
         }
 
         auto expr =
@@ -478,12 +483,16 @@ void LinearSolverVisitor::finalize() {
     for (unsigned i = 0; i < A_.nrow(); ++i) {
         const symge::sym_row& row = A_[i];
         unsigned rhs = A_.augcol();
-        unsigned lhs;
-        for (unsigned r = 0; r < A_.nrow(); r++) {
+        unsigned lhs = -1;
+        for (unsigned r = 0; r < A_.nrow(); ++r) {
             if (row[r]) {
                 lhs = r;
                 break;
             }
+        }
+
+        if (lhs==-1) {
+            throw std::logic_error("zero row in linear solver matrix");
         }
 
         auto expr =


### PR DESCRIPTION
* Remove or implement move ctor/assign operations for ostream-derived classes.
* Add explicit test for a zero row in modcc's sparse and linear solver finalize routines.
* Forward declare `morphology_impl` as a struct.
* Remove redundant capture in a lambda expression in fvm_layout.cpp.
* Add extra parens in an assign-and-test condition in mechcat.cpp.

Fixes #866.