### PR TITLE
Python wrapper: thread safe recipe

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(pyarb MODULE
     config.cpp
     context.cpp
     domain_decomposition.cpp
+    error.cpp
     event_generator.cpp
     identifiers.cpp
     morphology.cpp

--- a/python/domain_decomposition.cpp
+++ b/python/domain_decomposition.cpp
@@ -10,6 +10,7 @@
 #include <arbor/load_balance.hpp>
 
 #include "context.hpp"
+#include "error.hpp"
 #include "recipe.hpp"
 #include "strprintf.hpp"
 
@@ -104,7 +105,13 @@ void register_domain_decomposition(pybind11::module& m) {
     // The Python recipe has to be shimmed for passing to the function that takes a C++ recipe.
     m.def("partition_load_balance",
         [](std::shared_ptr<py_recipe>& recipe, const context_shim& ctx, arb::partition_hint_map hint_map) {
-            return arb::partition_load_balance(py_recipe_shim(recipe), ctx.context, std::move(hint_map));
+            try {
+                return arb::partition_load_balance(py_recipe_shim(recipe), ctx.context, std::move(hint_map));
+            }
+            catch (...) {
+                py_reset_and_throw();
+                throw;
+            }
         },
         "Construct a domain_decomposition that distributes the cells in the model described by recipe\n"
         "over the distributed and local hardware resources described by context.\n"

--- a/python/error.cpp
+++ b/python/error.cpp
@@ -1,0 +1,18 @@
+#include <pybind11/pybind11.h>
+
+#include "error.hpp"
+
+namespace pyarb {
+
+std::exception_ptr py_exception;
+std::mutex py_callback_mutex;
+
+void py_reset_and_throw() {
+    if (py_exception) {
+        std::exception_ptr copy = py_exception;
+        py_exception = nullptr;
+        std::rethrow_exception(copy);
+    }
+}
+
+} // namespace pyarb

--- a/python/error.hpp
+++ b/python/error.hpp
@@ -23,6 +23,10 @@ void assert_throw(bool pred, const char* msg) {
     if (!pred) throw pyarb_error(msg);
 }
 
+// This function resets a python exception to nullptr
+// and rethrows a copy of the set python exception.
+// It should be used in serial code
+// just before handing control back to Python. 
 void py_reset_and_throw();
 
 template <typename L>
@@ -33,7 +37,7 @@ auto try_catch_pyexception(L func, const char* msg){
             return func();
         }
         else {
-            throw std::runtime_error(msg);
+            throw pyarb_error(msg);
         }
     }
     catch (pybind11::error_already_set& e) {

--- a/python/error.hpp
+++ b/python/error.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <mutex>
 #include <stdexcept>
 #include <string>
 
 namespace pyarb {
+
+extern std::exception_ptr py_exception;
+extern std::mutex py_callback_mutex;
 
 // Python wrapper errors
 
@@ -19,4 +23,22 @@ void assert_throw(bool pred, const char* msg) {
     if (!pred) throw pyarb_error(msg);
 }
 
+void py_reset_and_throw();
+
+template <typename L>
+auto try_catch_pyexception(L func, const char* msg){
+    std::lock_guard<std::mutex> g(py_callback_mutex);
+    try {
+        if(!py_exception) {
+            return func();
+        }
+        else {
+            throw std::runtime_error(msg);
+        }
+    }
+    catch (pybind11::error_already_set& e) {
+        py_exception = std::current_exception();
+        throw;
+    }
+}
 } // namespace pyarb

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -26,7 +26,7 @@ namespace pyarb {
 arb::util::unique_any py_recipe_shim::get_cell_description(arb::cell_gid_type gid) const {
     return try_catch_pyexception(
                 [&](){ return convert_cell(impl_->cell_description(gid)); },
-                "A Python error in cell_description() on a different thread");
+                "Python error already thrown");
 }
 
 arb::probe_info cable_probe(std::string kind, arb::cell_member_type id, arb::mlocation loc) {
@@ -76,7 +76,7 @@ std::vector<arb::event_generator> convert_gen(std::vector<pybind11::object> pyge
 std::vector<arb::event_generator> py_recipe_shim::event_generators(arb::cell_gid_type gid) const {
     return try_catch_pyexception(
                 [&](){ return convert_gen(impl_->event_generators(gid), gid); },
-                "A Python error in event_generators() on a different thread");
+                "Python error already thrown");
 }
 
 std::string con_to_string(const arb::cell_connection& c) {

--- a/python/recipe.hpp
+++ b/python/recipe.hpp
@@ -122,10 +122,10 @@ public:
 
     py_recipe_shim(std::shared_ptr<py_recipe> r): impl_(std::move(r)) {}
 
+    const char* msg = "Python error already thrown";
+
     arb::cell_size_type num_cells() const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->num_cells(); },
-                    "A Python error in num_cells() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->num_cells(); }, msg);
     }
 
     // The pyarb::recipe::cell_decription returns a pybind11::object, that is
@@ -133,53 +133,37 @@ public:
     arb::util::unique_any get_cell_description(arb::cell_gid_type gid) const override;
 
     arb::cell_kind get_cell_kind(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->cell_kind(gid); },
-                    "A Python error in cell_kind() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->cell_kind(gid); }, msg);
     }
 
     arb::cell_size_type num_sources(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->num_sources(gid); },
-                    "A Python error in num_sources() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->num_sources(gid); }, msg);
     }
 
     arb::cell_size_type num_targets(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->num_targets(gid); },
-                    "A Python error in num_targets() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->num_targets(gid); }, msg);
     }
 
     arb::cell_size_type num_gap_junction_sites(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->num_gap_junction_sites(gid); },
-                    "A Python error in num_gap_junction_sites() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->num_gap_junction_sites(gid); }, msg);
     }
 
     std::vector<arb::event_generator> event_generators(arb::cell_gid_type gid) const override;
 
     std::vector<arb::cell_connection> connections_on(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->connections_on(gid); },
-                    "A Python error in connections_on() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->connections_on(gid); }, msg);
     }
 
     std::vector<arb::gap_junction_connection> gap_junctions_on(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->gap_junctions_on(gid); },
-                    "A Python error in gap_junctions_on() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->gap_junctions_on(gid); }, msg);
     }
 
     arb::cell_size_type num_probes(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->num_probes(gid); },
-                    "A Python error in num_probes() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->num_probes(gid); }, msg);
     }
 
     arb::probe_info get_probe(arb::cell_member_type id) const override {
-        return try_catch_pyexception(
-                    [&](){ return impl_->get_probe(id); },
-                    "A Python error in get_probe() on a different thread");
+        return try_catch_pyexception([&](){ return impl_->get_probe(id); }, msg);
     }
 
     // TODO: wrap and make thread safe

--- a/python/recipe.hpp
+++ b/python/recipe.hpp
@@ -123,7 +123,9 @@ public:
     py_recipe_shim(std::shared_ptr<py_recipe> r): impl_(std::move(r)) {}
 
     arb::cell_size_type num_cells() const override {
-        return impl_->num_cells();
+        return try_catch_pyexception(
+                    [&](){ return impl_->num_cells(); },
+                    "A Python error in num_cells() on a different thread");
     }
 
     // The pyarb::recipe::cell_decription returns a pybind11::object, that is
@@ -131,40 +133,56 @@ public:
     arb::util::unique_any get_cell_description(arb::cell_gid_type gid) const override;
 
     arb::cell_kind get_cell_kind(arb::cell_gid_type gid) const override {
-        return impl_->cell_kind(gid);
+        return try_catch_pyexception(
+                    [&](){ return impl_->cell_kind(gid); },
+                    "A Python error in cell_kind() on a different thread");
     }
 
     arb::cell_size_type num_sources(arb::cell_gid_type gid) const override {
-        return impl_->num_sources(gid);
+        return try_catch_pyexception(
+                    [&](){ return impl_->num_sources(gid); },
+                    "A Python error in num_sources() on a different thread");
     }
 
     arb::cell_size_type num_targets(arb::cell_gid_type gid) const override {
-        return impl_->num_targets(gid);
+        return try_catch_pyexception(
+                    [&](){ return impl_->num_targets(gid); },
+                    "A Python error in num_targets() on a different thread");
     }
 
     arb::cell_size_type num_gap_junction_sites(arb::cell_gid_type gid) const override {
-        return impl_->num_gap_junction_sites(gid);
+        return try_catch_pyexception(
+                    [&](){ return impl_->num_gap_junction_sites(gid); },
+                    "A Python error in num_gap_junction_sites() on a different thread");
     }
 
     std::vector<arb::event_generator> event_generators(arb::cell_gid_type gid) const override;
 
     std::vector<arb::cell_connection> connections_on(arb::cell_gid_type gid) const override {
-        return impl_->connections_on(gid);
+        return try_catch_pyexception(
+                    [&](){ return impl_->connections_on(gid); },
+                    "A Python error in connections_on() on a different thread");
     }
 
     std::vector<arb::gap_junction_connection> gap_junctions_on(arb::cell_gid_type gid) const override {
-        return impl_->gap_junctions_on(gid);
+        return try_catch_pyexception(
+                    [&](){ return impl_->gap_junctions_on(gid); },
+                    "A Python error in gap_junctions_on() on a different thread");
     }
 
     arb::cell_size_type num_probes(arb::cell_gid_type gid) const override {
-        return impl_->num_probes(gid);
+        return try_catch_pyexception(
+                    [&](){ return impl_->num_probes(gid); },
+                    "A Python error in num_probes() on a different thread");
     }
 
     arb::probe_info get_probe(arb::cell_member_type id) const override {
-        return impl_->get_probe(id);
+        return try_catch_pyexception(
+                    [&](){ return impl_->get_probe(id); },
+                    "A Python error in get_probe() on a different thread");
     }
 
-    // TODO: wrap
+    // TODO: wrap and make thread safe
     arb::util::any get_global_properties(arb::cell_kind kind) const override {
         if (kind==arb::cell_kind::cable) {
             arb::cable_cell_global_properties gprop;

--- a/python/simulation.cpp
+++ b/python/simulation.cpp
@@ -22,7 +22,13 @@ void register_simulation(pybind11::module& m) {
         // before forwarding it to the arb::recipe constructor.
         .def(pybind11::init(
             [](std::shared_ptr<py_recipe>& rec, const arb::domain_decomposition& decomp, const context_shim& ctx) {
-                return new arb::simulation(py_recipe_shim(rec), decomp, ctx.context);
+                try {
+                    return new arb::simulation(py_recipe_shim(rec), decomp, ctx.context);
+                }
+                catch (...) {
+                    py_reset_and_throw();
+                    throw;
+                }
             }),
             // Release the python gil, so that callbacks into the python recipe don't deadlock.
             pybind11::call_guard<pybind11::gil_scoped_release>(),


### PR DESCRIPTION
Ensure that errors in Python callbacks that are called from multithreaded C++ code propogate the correct Python error back to the parent Python callback site, and that no callbacks are called from other threads if an error has already ocurred.
- protects each recipe callback with a mutex, stores python exception, catches and throws python exception if occured
- methods calling recipe (in simulation and partition_load_balance) are protected as well by try catch, resets and rethrows python exception (if occured) or else throws C++ exception

fixes #792