### PR TITLE
Modcc: Fix segmentation fault

### DIFF
--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -669,7 +669,7 @@ void Module::add_variables_to_symbols() {
 
     // then GLOBAL variables
     for(auto const& var : neuron_block_.globals) {
-        if(!symbols_[var.spelling]) {
+        if(!symbols_.count(var.spelling)) {
             error( yellow(var.spelling) +
                    " is declared as GLOBAL, but has not been declared in the" +
                    " ASSIGNED block",
@@ -689,7 +689,7 @@ void Module::add_variables_to_symbols() {
 
     // then RANGE variables
     for(auto const& var : neuron_block_.ranges) {
-        if(!symbols_[var.spelling]) {
+        if(!symbols_.count(var.spelling)) {
             error( yellow(var.spelling) +
                    " is declared as RANGE, but has not been declared in the" +
                    " ASSIGNED or PARAMETER block",


### PR DESCRIPTION
An element declared in `RANGE`, but in the `ASSIGNED` or `PARAMETER` block, caused a segmentation fault instead of error