### PR TITLE
Reinitialize mechanisms after updating the ion state

### DIFF
--- a/arbor/backends/gpu/shared_state.cpp
+++ b/arbor/backends/gpu/shared_state.cpp
@@ -53,7 +53,7 @@ ion_state::ion_state(
     const fvm_ion_config& ion_data,
     unsigned // alignment/padding ignored.
 ):
-    node_index_(make_const_view(cv)),
+    node_index_(make_const_view(ion_data.cv)),
     iX_(ion_data.cv.size(), NAN),
     eX_(ion_data.cv.size(), NAN),
     Xi_(ion_data.cv.size(), NAN),
@@ -62,7 +62,7 @@ ion_state::ion_state(
     init_Xo_(make_const_view(ion_data.init_econc)),
     reset_Xi_(make_const_view(ion_data.reset_iconc)),
     reset_Xo_(make_const_view(ion_data.reset_econc)),
-    init_eX_(make_const_view(ion_data.init_erev)),
+    init_eX_(make_const_view(ion_data.init_revpot)),
     charge(1u, charge)
 {
     arb_assert(node_index_.size()==init_Xi_.size());

--- a/arbor/backends/gpu/shared_state.cpp
+++ b/arbor/backends/gpu/shared_state.cpp
@@ -50,20 +50,19 @@ std::pair<fvm_value_type, fvm_value_type> minmax_value_impl(fvm_size_type n, con
 
 ion_state::ion_state(
     int charge,
-    const std::vector<fvm_index_type>& cv,
-    const std::vector<fvm_value_type>& init_iconc,
-    const std::vector<fvm_value_type>& init_econc,
-    const std::vector<fvm_value_type>& init_erev,
+    const fvm_ion_config& ion_data,
     unsigned // alignment/padding ignored.
 ):
     node_index_(make_const_view(cv)),
-    iX_(cv.size(), NAN),
-    eX_(cv.size(), NAN),
-    Xi_(cv.size(), NAN),
-    Xo_(cv.size(), NAN),
-    init_Xi_(make_const_view(init_iconc)),
-    init_Xo_(make_const_view(init_econc)),
-    init_eX_(make_const_view(init_erev)),
+    iX_(ion_data.cv.size(), NAN),
+    eX_(ion_data.cv.size(), NAN),
+    Xi_(ion_data.cv.size(), NAN),
+    Xo_(ion_data.cv.size(), NAN),
+    init_Xi_(make_const_view(ion_data.init_iconc)),
+    init_Xo_(make_const_view(ion_data.init_econc)),
+    reset_Xi_(make_const_view(ion_data.reset_iconc)),
+    reset_Xo_(make_const_view(ion_data.reset_econc)),
+    init_eX_(make_const_view(ion_data.init_erev)),
     charge(1u, charge)
 {
     arb_assert(node_index_.size()==init_Xi_.size());
@@ -82,7 +81,8 @@ void ion_state::zero_current() {
 
 void ion_state::reset() {
     zero_current();
-    init_concentration();
+    memory::copy(reset_Xi_, Xi_);
+    memory::copy(reset_Xo_, Xo_);
     memory::copy(init_eX_, eX_);
 }
 
@@ -120,14 +120,11 @@ shared_state::shared_state(
 void shared_state::add_ion(
     const std::string& ion_name,
     int charge,
-    const std::vector<fvm_index_type>& cv,
-    const std::vector<fvm_value_type>& init_iconc,
-    const std::vector<fvm_value_type>& init_econc,
-    const std::vector<fvm_value_type>& init_erev)
+    const fvm_ion_config& ion_info)
 {
     ion_data.emplace(std::piecewise_construct,
         std::forward_as_tuple(ion_name),
-        std::forward_as_tuple(charge, cv, init_iconc, init_econc, init_erev, 1u));
+        std::forward_as_tuple(charge, ion_info, 1u));
 }
 
 void shared_state::reset() {

--- a/arbor/backends/gpu/shared_state.hpp
+++ b/arbor/backends/gpu/shared_state.hpp
@@ -7,6 +7,8 @@
 
 #include <arbor/fvm_types.hpp>
 
+#include "fvm_layout.hpp"
+
 #include "backends/gpu/gpu_store_types.hpp"
 
 namespace arb {
@@ -33,6 +35,8 @@ struct ion_state {
 
     array init_Xi_;     // (mM) area-weighted initial internal concentration
     array init_Xo_;     // (mM) area-weighted initial external concentration
+    array reset_Xi_;    // (mM) area-weighted user-set internal concentration
+    array reset_Xo_;    // (mM) area-weighted user-set internal concentration
     array init_eX_;     // (mM) initial reversal potential
 
     array charge;       // charge of ionic species (global, length 1)
@@ -41,10 +45,7 @@ struct ion_state {
 
     ion_state(
         int charge,
-        const std::vector<fvm_index_type>& cv,
-        const std::vector<fvm_value_type>& init_Xi,
-        const std::vector<fvm_value_type>& init_Xo,
-        const std::vector<fvm_value_type>& init_eX,
+        const fvm_ion_config& ion_data,
         unsigned align
     );
 
@@ -97,10 +98,7 @@ struct shared_state {
     void add_ion(
         const std::string& ion_name,
         int charge,
-        const std::vector<fvm_index_type>& cv,
-        const std::vector<fvm_value_type>& init_iconc,
-        const std::vector<fvm_value_type>& init_econc,
-        const std::vector<fvm_value_type>& init_erev);
+        const fvm_ion_config& ion_data);
 
     void zero_currents();
 

--- a/arbor/backends/multicore/shared_state.hpp
+++ b/arbor/backends/multicore/shared_state.hpp
@@ -20,8 +20,8 @@
 #include "multi_event_stream.hpp"
 #include "threshold_watcher.hpp"
 
-#include "multicore_common.hpp"
 #include "fvm_layout.hpp"
+#include "multicore_common.hpp"
 
 namespace arb {
 namespace multicore {
@@ -49,8 +49,8 @@ struct ion_state {
 
     array init_Xi_;         // (mM) area-weighted initial internal concentration
     array init_Xo_;         // (mM) area-weighted initial external concentration
-    array reset_Xi_;        // (mM) area-weighted initial internal concentration
-    array reset_Xo_;        // (mM) area-weighted initial internal concentration
+    array reset_Xi_;        // (mM) area-weighted user-set internal concentration
+    array reset_Xo_;        // (mM) area-weighted user-set internal concentration
     array init_eX_;         // (mV) initial reversal potential
 
     array charge;           // charge of ionic species (global value, length 1)
@@ -59,7 +59,7 @@ struct ion_state {
 
     ion_state(
         int charge,
-        const fvm_ion_config& iod_data,
+        const fvm_ion_config& ion_data,
         unsigned align
     );
 

--- a/arbor/backends/multicore/shared_state.hpp
+++ b/arbor/backends/multicore/shared_state.hpp
@@ -21,6 +21,7 @@
 #include "threshold_watcher.hpp"
 
 #include "multicore_common.hpp"
+#include "fvm_layout.hpp"
 
 namespace arb {
 namespace multicore {
@@ -48,6 +49,8 @@ struct ion_state {
 
     array init_Xi_;         // (mM) area-weighted initial internal concentration
     array init_Xo_;         // (mM) area-weighted initial external concentration
+    array reset_Xi_;        // (mM) area-weighted initial internal concentration
+    array reset_Xo_;        // (mM) area-weighted initial internal concentration
     array init_eX_;         // (mV) initial reversal potential
 
     array charge;           // charge of ionic species (global value, length 1)
@@ -56,10 +59,7 @@ struct ion_state {
 
     ion_state(
         int charge,
-        const std::vector<fvm_index_type>& cv,
-        const std::vector<fvm_value_type>& init_Xi,
-        const std::vector<fvm_value_type>& init_Xo,
-        const std::vector<fvm_value_type>& init_eX,
+        const fvm_ion_config& iod_data,
         unsigned align
     );
 
@@ -115,10 +115,7 @@ struct shared_state {
     void add_ion(
         const std::string& ion_name,
         int charge,
-        const std::vector<fvm_index_type>& cv,
-        const std::vector<fvm_value_type>& init_iconc,
-        const std::vector<fvm_value_type>& init_econc,
-        const std::vector<fvm_value_type>& init_erev);
+        const fvm_ion_config& ion_data);
 
     void zero_currents();
 

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -756,6 +756,8 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
 
         ion_config.init_iconc.resize(ion_config.cv.size());
         ion_config.init_econc.resize(ion_config.cv.size());
+        ion_config.reset_iconc.resize(ion_config.cv.size());
+        ion_config.reset_econc.resize(ion_config.cv.size());
         ion_config.init_revpot.resize(ion_config.cv.size());
 
         for_each_cv_in_segments(D, keys(seg_ion_data),
@@ -767,6 +769,9 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
                 auto& seg_ion_entry = seg_ion_map[seg];
 
                 value_type weight = area/D.cv_area[cv];
+                ion_config.reset_iconc[i] += weight*seg_ion_entry.ion_data.init_int_concentration;
+                ion_config.reset_econc[i] += weight*seg_ion_entry.ion_data.init_ext_concentration;
+
                 if (!seg_ion_entry.mech_writes_iconc) {
                     ion_config.init_iconc[i] += weight*seg_ion_entry.ion_data.init_int_concentration;
                 }

--- a/arbor/fvm_layout.hpp
+++ b/arbor/fvm_layout.hpp
@@ -136,8 +136,7 @@ struct fvm_ion_config {
     std::vector<value_type> init_iconc;
     std::vector<value_type> init_econc;
 
-    // Normalized area contribution of default concentration contribution in corresponding CV
-    // before mechanisms can update the ion state
+    // Normalized area contribution of default concentration contribution in corresponding CV set by users
     std::vector<value_type> reset_iconc;
     std::vector<value_type> reset_econc;
 

--- a/arbor/fvm_layout.hpp
+++ b/arbor/fvm_layout.hpp
@@ -136,8 +136,14 @@ struct fvm_ion_config {
     std::vector<value_type> init_iconc;
     std::vector<value_type> init_econc;
 
+    // Normalized area contribution of default concentration contribution in corresponding CV
+    // before mechanisms can update the ion state
+    std::vector<value_type> reset_iconc;
+    std::vector<value_type> reset_econc;
+
     // Ion-specific (initial) reversal potential per CV.
     std::vector<value_type> init_revpot;
+
 };
 
 struct fvm_mechanism_data {

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -433,7 +433,7 @@ void fvm_lowered_cell_impl<B>::initialize(
         const std::string& ion_name = i.first;
 
         if (auto charge = value_by_key(global_props.ion_species, ion_name)) {
-            state_->add_ion(ion_name, *charge, i.second.cv, i.second.init_iconc, i.second.init_econc, i.second.init_revpot);
+            state_->add_ion(ion_name, *charge, i.second);
         }
         else {
             throw cable_cell_error("unrecognized ion '"+ion_name+"' in mechanism");

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -164,6 +164,8 @@ void fvm_lowered_cell_impl<Backend>::reset() {
 
     update_ion_state();
 
+    state_->zero_currents();
+
     // Call initialize again
     for (auto& m: revpot_mechanisms_) {
         m->initialize();

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -164,6 +164,15 @@ void fvm_lowered_cell_impl<Backend>::reset() {
 
     update_ion_state();
 
+    // Call initialize again
+    for (auto& m: revpot_mechanisms_) {
+        m->initialize();
+    }
+
+    for (auto& m: mechanisms_) {
+        m->initialize();
+    }
+
     // NOTE: Threshold watcher reset must come after the voltage values are set,
     // as voltage is implicitly read by watcher to set initial state.
     threshold_watcher_.reset();

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -166,7 +166,8 @@ void fvm_lowered_cell_impl<Backend>::reset() {
 
     state_->zero_currents();
 
-    // Call initialize again
+    // Note: mechanisms must be initialized again after the ion state is updated,
+    // as mechanisms can read/write the ion_state within the initialize block
     for (auto& m: revpot_mechanisms_) {
         m->initialize();
     }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -25,6 +25,8 @@ set(test_mechanisms
     read_eX
     write_multiple_eX
     write_eX
+    read_cai_init
+    write_cai_breakpoint
 )
 
 include(${PROJECT_SOURCE_DIR}/mechanisms/BuildModules.cmake)

--- a/test/unit/mod/read_cai_init.mod
+++ b/test/unit/mod/read_cai_init.mod
@@ -1,0 +1,27 @@
+: Test mechanism with linear response to ica.
+
+NEURON {
+    SUFFIX read_cai_init
+    USEION ca READ cai VALENCE 2
+}
+
+PARAMETER {}
+
+ASSIGNED {}
+
+STATE {
+    s
+}
+
+INITIAL {
+    s = cai
+}
+
+BREAKPOINT {
+    SOLVE states
+}
+
+DERIVATIVE states {
+    s = cai
+}
+

--- a/test/unit/mod/write_cai_breakpoint.mod
+++ b/test/unit/mod/write_cai_breakpoint.mod
@@ -1,0 +1,24 @@
+: Test mechanism with linear response to ica.
+
+NEURON {
+    SUFFIX write_cai_breakpoint
+    USEION ca WRITE cai READ ica VALENCE 2
+}
+
+PARAMETER {}
+
+ASSIGNED {}
+
+STATE {
+    cai
+}
+
+INITIAL {}
+
+BREAKPOINT {
+    SOLVE states
+}
+
+DERIVATIVE states {
+    cai = 5.2e-4
+}

--- a/test/unit/test_fvm_lowered.cpp
+++ b/test/unit/test_fvm_lowered.cpp
@@ -580,7 +580,7 @@ TEST(fvm_lowered, ionic_concentrations) {
     ion_config.init_revpot.assign(ncv, 0.);
     ion_config.init_econc.assign(ncv, 0.);
     ion_config.init_iconc.assign(ncv, 0.);
-    ion_config.reset_iconc.assign(ncv, 0.);
+    ion_config.reset_econc.assign(ncv, 0.);
     ion_config.reset_iconc.assign(ncv, 2.3e-4);
 
     auto read_cai  = cat.instance<backend>("read_cai_init");
@@ -606,7 +606,7 @@ TEST(fvm_lowered, ionic_concentrations) {
 
     EXPECT_EQ(expected_s_values, mechanism_field(read_cai_mech.get(), "s"));
 
-    // expect 5.2 value in state 's' in read_cai_init after state update:
+    // expect 5.2 + 2.3 value in state 's' in read_cai_init after state update:
     read_cai_mech->nrn_state();
     write_cai_mech->nrn_state();
 

--- a/test/unit/unit_test_catalogue.cpp
+++ b/test/unit/unit_test_catalogue.cpp
@@ -31,6 +31,8 @@
 #include "mechanisms/read_eX.hpp"
 #include "mechanisms/write_multiple_eX.hpp"
 #include "mechanisms/write_eX.hpp"
+#include "mechanisms/read_cai_init.hpp"
+#include "mechanisms/write_cai_breakpoint.hpp"
 
 #include "../gtest.h"
 
@@ -74,6 +76,8 @@ mechanism_catalogue make_unit_test_catalogue() {
     ADD_MECH(cat, read_eX)
     ADD_MECH(cat, write_multiple_eX)
     ADD_MECH(cat, write_eX)
+    ADD_MECH(cat, read_cai_init)
+    ADD_MECH(cat, write_cai_breakpoint)
 
     return cat;
 }


### PR DESCRIPTION
If ion concentrations are read and written in the `INITIAL` blocks of mechanisms, this ensures that the reading mechanisms will receive the correct values. 
Fixes #896 