### PR TITLE
Remove vector reserve when placing synapses

### DIFF
--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -159,7 +159,6 @@ struct cable_cell_impl {
     lid_range place(const mlocation_list& locs, const Desc& desc, std::vector<T>& list) {
         const auto first = list.size();
 
-        list.reserve(first+locs.size());
         for (auto loc: locs) {
             list.push_back({loc, desc});
         }


### PR DESCRIPTION
Calling `vector::reserve` to increase the size of the synapse vector by 1 causes significant performance degradation. 