### PR TITLE
Modcc: Add support for `COMMENT` and `ENDCOMMENT`

### DIFF
--- a/modcc/lexer.cpp
+++ b/modcc/lexer.cpp
@@ -20,7 +20,7 @@ inline bool is_alphanumeric(char c) {
     return (is_numeric(c) || is_alpha(c) );
 }
 inline bool is_whitespace(char c) {
-    return (c==' ' || c=='\t' || c=='\v' || c=='\f');
+    return (c==' ' || c=='\t' || c=='\v' || c=='\f' || c=='\n' || c=='\r');
 }
 inline bool is_eof(char c) {
     return (c==0);
@@ -97,14 +97,22 @@ Token Lexer::parse() {
             // identifier or keyword
             case 'a' ... 'z':
             case 'A' ... 'Z':
-            case '_':
+            case '_': {
                 // get std::string of the identifier
-                t.spelling = identifier();
-                t.type
-                    = status_==lexerStatus::error
-                    ? tok::reserved
-                    : get_identifier_type(t.spelling);
+                auto id = identifier();
+                if (id == "COMMENT") {
+                    while (!is_eof(*current_)) {
+                        while (is_whitespace(*current_) || !is_alpha(*current_)) current_++;
+                        if (identifier() == "ENDCOMMENT") break;
+                    }
+                    continue;
+                }
+                t.spelling = id;
+                t.type = status_ == lexerStatus::error
+                          ? tok::reserved
+                          : get_identifier_type(t.spelling);
                 return t;
+            }
             case '(':
                 t.type = tok::lparen;
                 t.spelling += character();

--- a/modcc/lexer.cpp
+++ b/modcc/lexer.cpp
@@ -100,6 +100,7 @@ Token Lexer::parse() {
             case '_': {
                 // get std::string of the identifier
                 auto id = identifier();
+                if (id == "UNITSON" || id == "UNITSOFF") continue;
                 if (id == "COMMENT") {
                     while (!is_eof(*current_)) {
                         while (is_whitespace(*current_) || !is_alpha(*current_)) current_++;

--- a/modcc/parser.cpp
+++ b/modcc/parser.cpp
@@ -35,15 +35,6 @@ bool Parser::expect(tok tok, std::string const& str) {
     return false;
 }
 
-void Parser::parse_unit() {
-    if(token_.type == tok::lparen) {
-        while (token_.type != tok::rparen) {
-            get_token();
-        }
-        get_token(); // consume ')'
-    }
-}
-
 void Parser::error(std::string msg) {
     std::string location_info = pprintf(
             "%:% ", module_ ? module_->source_name() : "", token_.location);
@@ -137,12 +128,6 @@ bool Parser::parse() {
                 if(!f) break;
                 module_->add_callable(std::move(f));
                 }
-                break;
-            case tok::unitson :
-                get_token();
-                break;
-            case tok::unitsoff :
-                get_token();
                 break;
             default :
                 error(pprintf("expected block type, found '%'", token_.spelling));
@@ -835,8 +820,6 @@ expression_ptr Parser::parse_prototype(std::string name=std::string()) {
 
         get_token(); // consume the identifier
 
-        parse_unit(); // consume the unit if provided
-
         // look for a comma
         if(!(token_.type == tok::comma || token_.type==tok::rparen)) {
             error(  "expected a comma or closing parenthesis, found '"
@@ -966,8 +949,6 @@ symbol_ptr Parser::parse_function() {
     // parse the prototype
     auto p = parse_prototype();
     if(p==nullptr) return nullptr;
-
-    parse_unit();
 
     // check for opening left brace {
     if(!expect(tok::lbrace)) return nullptr;

--- a/modcc/parser.hpp
+++ b/modcc/parser.hpp
@@ -81,7 +81,6 @@ private:
     Parser();
     Parser(Parser const &);
 
-    void parse_unit();
     bool expect(tok, const char *str="");
     bool expect(tok, std::string const& str);
 };


### PR DESCRIPTION
Also change the way we handle unitson/unitsoff.
`UNITSON`, `UNITSOFF`, `COMMENT`, `ENDCOMMENT` are now all handled in `Lexer::parse`

Fixes: #14 #885