### PR TITLE
Fix for improper vector element access.

### DIFF
--- a/arbor/backends/gpu/multi_event_stream.hpp
+++ b/arbor/backends/gpu/multi_event_stream.hpp
@@ -94,7 +94,7 @@ protected:
 
             // Within a subrange of events with the same index, events should
             // be sorted by time.
-            arb_assert(std::is_sorted(&tmp_ev_time_[ev_begin_i], &tmp_ev_time_[ev_i]));
+            arb_assert(util::is_sorted(util::subrange_view(tmp_ev_time_, ev_begin_i, ev_i)));
             n_nonempty += (tmp_divs_.back()!=ev_i);
             tmp_divs_.push_back(ev_i);
             ev_begin_i = ev_i;

--- a/arbor/backends/multicore/multi_event_stream.hpp
+++ b/arbor/backends/multicore/multi_event_stream.hpp
@@ -81,7 +81,7 @@ public:
 
             // Within a subrange of events with the same index, events should
             // be sorted by time.
-            arb_assert(std::is_sorted(&ev_time_[ev_begin_i], &ev_time_[ev_i]));
+            arb_assert(util::is_sorted(util::subrange_view(ev_time_, ev_begin_i, ev_i)));
             mark_[s] = ev_begin_i;
             span_begin_[s] = ev_begin_i;
             span_end_[s] = ev_i;

--- a/arbor/include/arbor/schedule.hpp
+++ b/arbor/include/arbor/schedule.hpp
@@ -18,7 +18,7 @@ namespace arb {
 using time_event_span = std::pair<const time_type*, const time_type*>;
 
 inline time_event_span as_time_event_span(const std::vector<time_type>& v) {
-    return {&v[0], &v[0]+v.size()};
+    return {v.data(), v.data()+v.size()};
 }
 
 // A schedule describes a sequence of time values used for sampling. Schedules


### PR DESCRIPTION
Fixes #917.

* Avoid use of empty ranges determined by expressions `&vector[i]` where i equals vector.size(). Replace with expressions using `vector.data()` or subrange views.