### PR TITLE
Fix support for i686 32-bit target.

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -91,7 +91,7 @@ function(set_arch_target optvar arch)
 
         # Use -mcpu for all supported targets _except_ for x86, where it should be -march.
 
-        if(target_model MATCHES "x86" OR target_model MATCHES "amd64" OR target_model MATCHES "aarch64")
+        if(target_model MATCHES "x86|i[3456]86" OR target_model MATCHES "amd64" OR target_model MATCHES "aarch64")
             set(arch_opt "-march=${arch}")
         else()
             set(arch_opt "-mcpu=${arch}")

--- a/test/unit/test_algorithms.cpp
+++ b/test/unit/test_algorithms.cpp
@@ -663,7 +663,7 @@ TEST(algorithms, binary_find)
         auto ita = binary_find(a, 1);
         auto found = ita!=std::end(a);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(a), ita), 0u);
+        EXPECT_EQ(std::distance(std::begin(a), ita), 0);
         if (found) {
             EXPECT_EQ(*ita, 1);
         }
@@ -672,7 +672,7 @@ TEST(algorithms, binary_find)
         auto itv = binary_find(v, 1);
         found = itv!=std::end(v);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(v), itv), 0u);
+        EXPECT_EQ(std::distance(std::begin(v), itv), 0);
         if (found) {
             EXPECT_EQ(*itv, 1);
         }
@@ -684,7 +684,7 @@ TEST(algorithms, binary_find)
         auto ita = binary_find(a, 15);
         auto found = ita!=std::end(a);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(a), ita), 2u);
+        EXPECT_EQ(std::distance(std::begin(a), ita), 2);
         if (found) {
             EXPECT_EQ(*ita, 15);
         }
@@ -693,7 +693,7 @@ TEST(algorithms, binary_find)
         auto itv = binary_find(v, 15);
         found = itv!=std::end(v);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(v), itv), 2u);
+        EXPECT_EQ(std::distance(std::begin(v), itv), 2);
         if (found) {
             EXPECT_EQ(*itv, 15);
         }
@@ -705,7 +705,7 @@ TEST(algorithms, binary_find)
         auto ita = binary_find(a, 10);
         auto found = ita!=std::end(a);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(a), ita), 1u);
+        EXPECT_EQ(std::distance(std::begin(a), ita), 1);
         if (found) {
             EXPECT_EQ(*ita, 10);
         }
@@ -714,7 +714,7 @@ TEST(algorithms, binary_find)
         auto itv = binary_find(v, 10);
         found = itv!=std::end(v);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(v), itv), 1u);
+        EXPECT_EQ(std::distance(std::begin(v), itv), 1);
         if (found) {
             EXPECT_EQ(*itv, 10);
         }
@@ -726,7 +726,7 @@ TEST(algorithms, binary_find)
         auto ita = binary_find(a, 10);
         auto found = ita!=std::end(a);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(a), ita), 1u);
+        EXPECT_EQ(std::distance(std::begin(a), ita), 1);
         if (found) {
             EXPECT_EQ(*ita, 10);
         }
@@ -735,7 +735,7 @@ TEST(algorithms, binary_find)
         auto itv = binary_find(v, 10);
         found = itv!=std::end(v);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::begin(v), itv), 1u);
+        EXPECT_EQ(std::distance(std::begin(v), itv), 1);
         if (found) {
             EXPECT_EQ(*itv, 10);
         }
@@ -750,7 +750,7 @@ TEST(algorithms, binary_find)
         auto itv = binary_find(vr, 10);
         auto found = itv!=std::end(vr);
         EXPECT_TRUE(found);
-        EXPECT_EQ(std::distance(std::cbegin(v), itv), 1u);
+        EXPECT_EQ(std::distance(std::cbegin(v), itv), 1);
         if (found) {
             EXPECT_EQ(*itv, 10);
         }

--- a/test/unit/test_simd.cpp
+++ b/test/unit/test_simd.cpp
@@ -664,7 +664,7 @@ TYPED_TEST_P(simd_fp_value, fp_maths) {
 
         fp exprelr_u[N];
         for (unsigned i = 0; i<N; ++i) {
-            exprelr_u[i] = u[i]+fp(1)==fp(1)? fp(1): u[i]/(std::exp(u[i])-fp(1));
+            exprelr_u[i] = u[i]+fp(1)==fp(1)? fp(1): u[i]/(std::expm1(u[i]));
         }
         exprelr(simd(u)).copy_to(r);
         EXPECT_TRUE(testing::seq_almost_eq<fp>(exprelr_u, r));


### PR DESCRIPTION
* Use alternative hashing of cell_member_type values for 32-bit target.
* Correctly match i686 as a "-march=" style target for gcc and clang.
* Correct a signed/unsigned comparison warning in test_algorithms.cpp with -Wall.
* Avoid spurious SIMD unit test failure for `exprelr` by using `std::expm1` instead of `std::exp` in denominator when computing expected results.

Fixes #920 