### PR TITLE
Make region/locset interface more consistent.

### DIFF
--- a/arbor/cable_cell_param.cpp
+++ b/arbor/cable_cell_param.cpp
@@ -50,10 +50,6 @@ void check_global_properties(const cable_cell_global_properties& G) {
         }
     }
 }
-    util::optional<double> init_membrane_potential; // [mV]
-    util::optional<double> temperature_K;           // [K]
-    util::optional<double> axial_resistivity;       // [Ω·cm]
-    util::optional<double> membrane_capacitance;    // [F/m²]
 
 cable_cell_parameter_set neuron_parameter_defaults = {
     // initial membrane potential [mV]
@@ -108,7 +104,7 @@ locset cv_policy_max_extent::cv_boundary_points(const cable_cell& cell) const {
         ++bidx;
     }
 
-    return std::accumulate(points.begin(), points.end(), ls::nil(), [](auto& l, auto& p) { return join(l, ls::location(p)); });
+    return points;
 }
 
 locset cv_policy_fixed_per_branch::cv_boundary_points(const cable_cell& cell) const {
@@ -140,7 +136,7 @@ locset cv_policy_fixed_per_branch::cv_boundary_points(const cable_cell& cell) co
         ++bidx;
     }
 
-    return std::accumulate(points.begin(), points.end(), ls::nil(), [](auto& l, auto& p) { return join(l, ls::location(p)); });
+    return points;
 }
 
 } // namespace arb

--- a/arbor/include/arbor/morph/locset.hpp
+++ b/arbor/include/arbor/morph/locset.hpp
@@ -16,11 +16,12 @@ namespace arb {
 struct mprovider;
 
 class locset;
+class locset_tag {};
 
 class locset {
 public:
     template <typename Impl,
-              typename X=std::enable_if_t<!std::is_same<std::decay_t<Impl>, locset>::value>>
+              typename = std::enable_if_t<std::is_base_of<locset_tag, std::decay_t<Impl>>::value>>
     explicit locset(Impl&& impl):
         impl_(new wrap<Impl>(std::forward<Impl>(impl))) {}
 
@@ -41,15 +42,16 @@ public:
     // The default constructor creates an empty "nil" set.
     locset();
 
-    // Construct an explicit location set with a single location.
+    // Implicity convert mlocation and mlocation_lists to locsets.
     locset(mlocation other);
+    locset(const mlocation_list& other);
 
     // Implicitly convert string to named locset expression.
     locset(std::string label);
     locset(const char* label);
 
     template <typename Impl,
-              typename X=std::enable_if_t<!std::is_same<std::decay_t<Impl>, locset>::value>>
+              typename = std::enable_if_t<std::is_base_of<locset_tag, std::decay_t<Impl>>::value>>
     locset& operator=(Impl&& other) {
         impl_ = new wrap<Impl>(std::forward<Impl>(other));
         return *this;
@@ -119,7 +121,7 @@ private:
 namespace ls {
 
 // Explicit location on morphology.
-locset location(mlocation);
+locset location(msize_t branch, double pos);
 
 // Location of a sample.
 locset sample(msize_t);

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -14,11 +14,12 @@
 namespace arb {
 
 struct mprovider;
+struct region_tag {};
 
 class region {
 public:
     template <typename Impl,
-              typename X=std::enable_if_t<!std::is_same<std::decay_t<Impl>, region>::value>>
+              typename = std::enable_if_t<std::is_base_of<region_tag, std::decay_t<Impl>>::value>>
     explicit region(Impl&& impl):
         impl_(new wrap<Impl>(std::forward<Impl>(impl))) {}
 
@@ -40,7 +41,7 @@ public:
     }
 
     template <typename Impl,
-              typename X=std::enable_if_t<!std::is_same<std::decay_t<Impl>, region>::value>>
+              typename = std::enable_if_t<std::is_base_of<region_tag, std::decay_t<Impl>>::value>>
     region& operator=(Impl&& other) {
         impl_ = new wrap<Impl>(std::forward<Impl>(other));
         return *this;
@@ -51,6 +52,10 @@ public:
         impl_ = new wrap<Impl>(other);
         return *this;
     }
+
+    // Implicit conversion from mcable or mcable_list.
+    region(mcable);
+    region(const mcable_list&);
 
     // Implicitly convert string to named region expression.
     region(std::string label);
@@ -133,9 +138,10 @@ region named(std::string);
 
 } // namespace reg
 
-// union of two regions
+// Union of two regions.
 region join(region, region);
-// intersection of two regions
+
+// Intersection of two regions.
 region intersect(region, region);
 
 } // namespace arb

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -216,7 +216,7 @@ locset::locset(mlocation loc) {
 
 locset::locset(const mlocation_list& ll) {
     *this = std::accumulate(ll.begin(), ll.end(), ls::nil(),
-        [](auto& ls, auto& p) { return join(ls, locset(p)); });
+        [](auto& ls, auto& p) { return sum(ls, locset(p)); });
 }
 
 locset::locset(std::string name) {

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -23,7 +23,7 @@ void assert_valid(mlocation x) {
 
 // Empty locset.
 
-struct nil_ {};
+struct nil_: locset_tag {};
 
 locset nil() {
     return locset{nil_{}};
@@ -39,11 +39,13 @@ std::ostream& operator<<(std::ostream& o, const nil_& x) {
 
 // An explicit location.
 
-struct location_ {
+struct location_: locset_tag {
+    explicit location_(mlocation loc): loc(loc) {}
     mlocation loc;
 };
 
-locset location(mlocation loc) {
+locset location(msize_t branch, double pos) {
+    mlocation loc{branch, pos};
     assert_valid(loc);
     return locset{location_{loc}};
 }
@@ -63,7 +65,8 @@ std::ostream& operator<<(std::ostream& o, const location_& x) {
 
 // Location corresponding to a sample id.
 
-struct sample_ {
+struct sample_: locset_tag {
+    explicit sample_(msize_t index): index(index) {}
     msize_t index;
 };
 
@@ -81,7 +84,7 @@ std::ostream& operator<<(std::ostream& o, const sample_& x) {
 
 // Set of terminal points (most distal points).
 
-struct terminal_ {};
+struct terminal_: locset_tag {};
 
 locset terminal() {
     return locset{terminal_{}};
@@ -101,7 +104,7 @@ std::ostream& operator<<(std::ostream& o, const terminal_& x) {
 
 // Root location (most proximal point).
 
-struct root_ {};
+struct root_: locset_tag {};
 
 locset root() {
     return locset{root_{}};
@@ -117,7 +120,8 @@ std::ostream& operator<<(std::ostream& o, const root_& x) {
 
 // Named locset.
 
-struct named_ {
+struct named_: locset_tag {
+    explicit named_(std::string name): name(std::move(name)) {}
     std::string name;
 };
 
@@ -136,7 +140,7 @@ std::ostream& operator<<(std::ostream& o, const named_& x) {
 
 // Intersection of two point sets.
 
-struct land {
+struct land: locset_tag {
     locset lhs;
     locset rhs;
     land(locset lhs, locset rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
@@ -152,7 +156,7 @@ std::ostream& operator<<(std::ostream& o, const land& x) {
 
 // Union of two point sets.
 
-struct lor {
+struct lor: locset_tag {
     locset lhs;
     locset rhs;
     lor(locset lhs, locset rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
@@ -168,7 +172,7 @@ std::ostream& operator<<(std::ostream& o, const lor& x) {
 
 // Sum of two point sets.
 
-struct lsum {
+struct lsum: locset_tag {
     locset lhs;
     locset rhs;
     lsum(locset lhs, locset rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
@@ -200,12 +204,19 @@ locset sum(locset lhs, locset rhs) {
     return locset(ls::lsum(std::move(lhs), std::move(rhs)));
 }
 
+// Implicit constructors.
+
 locset::locset() {
     *this = ls::nil();
 }
 
 locset::locset(mlocation loc) {
-    *this = ls::location(loc);
+    *this = ls::location(loc.branch, loc.pos);
+}
+
+locset::locset(const mlocation_list& ll) {
+    *this = std::accumulate(ll.begin(), ll.end(), ls::nil(),
+        [](auto& ls, auto& p) { return join(ls, locset(p)); });
 }
 
 locset::locset(std::string name) {
@@ -215,6 +226,5 @@ locset::locset(std::string name) {
 locset::locset(const char* name) {
     *this = ls::named(name);
 }
-
 
 } // namespace arb

--- a/test/unit/test_cv_policy.cpp
+++ b/test/unit/test_cv_policy.cpp
@@ -51,15 +51,7 @@ namespace {
 
     template <typename... A>
     locset as_locset(mlocation head, A... tail) {
-        return join(ls::location(head), ls::location(tail)...);
-    }
-
-    template <typename Seq>
-    locset as_locset(const Seq& seq) {
-        using std::begin;
-        using std::end;
-        return std::accumulate(begin(seq), end(seq), ls::nil(),
-            [](locset ls, const mlocation& p) { return join(std::move(ls), ls::location(p)); });
+        return join(locset(head), locset(tail)...);
     }
 }
 

--- a/test/unit/test_morph_expr.cpp
+++ b/test/unit/test_morph_expr.cpp
@@ -92,7 +92,7 @@ TEST(locset, expr_repn) {
     auto root = ls::root();
     auto term = ls::terminal();
     auto samp = ls::sample(42);
-    auto loc = ls::location({2, 0.5});
+    auto loc = ls::location(2, 0.5);
 
     EXPECT_EQ(to_string(root), "(root)");
     EXPECT_EQ(to_string(term), "(terminal)");
@@ -103,14 +103,14 @@ TEST(locset, expr_repn) {
     EXPECT_EQ(to_string(loc), "(location 2 0.5)");
 }
 
-TEST(region, invalid_mlocation) {
+TEST(locset, invalid_mlocation) {
     // Location positions have to be in the range [0,1].
-    EXPECT_NO_THROW(ls::location({123, 0.0}));
-    EXPECT_NO_THROW(ls::location({123, 0.02}));
-    EXPECT_NO_THROW(ls::location({123, 1.0}));
+    EXPECT_NO_THROW(ls::location(123, 0.0));
+    EXPECT_NO_THROW(ls::location(123, 0.02));
+    EXPECT_NO_THROW(ls::location(123, 1.0));
 
-    EXPECT_THROW(ls::location({0, 1.5}), invalid_mlocation);
-    EXPECT_THROW(ls::location({unsigned(-1), 0.}), invalid_mlocation);
+    EXPECT_THROW(ls::location(0, 1.5), invalid_mlocation);
+    EXPECT_THROW(ls::location(unsigned(-1), 0.), invalid_mlocation);
 }
 
 // Name evaluation (thingify) tests:
@@ -204,13 +204,13 @@ TEST(locset, thingify) {
     auto root = ls::root();
     auto term = ls::terminal();
     auto samp = ls::sample(4);
-    auto midb2 = ls::location({2, 0.5});
-    auto midb1 = ls::location({1, 0.5});
-    auto begb0 = ls::location({0, 0});
-    auto begb1 = ls::location({1, 0});
-    auto begb2 = ls::location({2, 0});
-    auto begb3 = ls::location({3, 0});
-    auto begb4 = ls::location({4, 0});
+    auto midb2 = ls::location(2, 0.5);
+    auto midb1 = ls::location(1, 0.5);
+    auto begb0 = ls::location(0, 0);
+    auto begb1 = ls::location(1, 0);
+    auto begb2 = ls::location(2, 0);
+    auto begb3 = ls::location(3, 0);
+    auto begb4 = ls::location(4, 0);
 
     // Eight samples
     //
@@ -245,6 +245,9 @@ TEST(locset, thingify) {
         EXPECT_EQ(thingify(begb2, mp), (ll{{2,0}}));
         EXPECT_EQ(thingify(begb3, mp), (ll{{3,0}}));
         EXPECT_EQ(thingify(begb4, mp), (ll{{4,0}}));
+
+        // Check round-trip of implicit locset conversions.
+        EXPECT_EQ(thingify(term, mp), thingify(locset(thingify(term, mp)), mp));
     }
     {
         mprovider mp(morphology(sm, false));
@@ -315,6 +318,10 @@ TEST(region, thingify) {
         EXPECT_TRUE(cablelist_eq(thingify(join(h1, t1), mp), (cl{{0, 0, 0.7}})));
         EXPECT_TRUE(cablelist_eq(thingify(join(h1, t2), mp), (cl{{0, 0, 0.5}, {0, 0.7, 1}})));
         EXPECT_TRUE(cablelist_eq(thingify(intersect(h2, t1), mp), (cl{{0, 0.5, 0.7}})));
+
+        // Check round-trip of implicit region conversions.
+        EXPECT_EQ((mcable_list{{0, 0.3, 0.6}}), thingify(region(mcable{0, 0.3, 0.6}), mp));
+        EXPECT_TRUE(cablelist_eq(t2_, thingify(region(t2_), mp)));
     }
 
 

--- a/test/unit/test_morph_expr.cpp
+++ b/test/unit/test_morph_expr.cpp
@@ -211,6 +211,7 @@ TEST(locset, thingify) {
     auto begb2 = ls::location(2, 0);
     auto begb3 = ls::location(3, 0);
     auto begb4 = ls::location(4, 0);
+    auto multi = sum(begb3, midb2, midb1, midb2);
 
     // Eight samples
     //
@@ -247,7 +248,9 @@ TEST(locset, thingify) {
         EXPECT_EQ(thingify(begb4, mp), (ll{{4,0}}));
 
         // Check round-trip of implicit locset conversions.
-        EXPECT_EQ(thingify(term, mp), thingify(locset(thingify(term, mp)), mp));
+        // (Use a locset which is non-trivially a multiset in order to
+        // test the fold in the constructor.)
+        EXPECT_EQ(thingify(multi, mp), thingify(locset(thingify(multi, mp)), mp));
     }
     {
         mprovider mp(morphology(sm, false));


### PR DESCRIPTION
* Add implicit conversions from `mlocation` and `mlocation_list` to `locset`.
* Add implicit conversions from `mcable` and `mcable_list` to `region`.
* Change arguments for `ls::location` to `(branch, position)`.
* Extend unit tests to suit.
* Make locset and region wrapping less promiscuous by demanding that expression implementation classes derive from `locset_tag` or `region_tag` respectively.
* Remove dubious chunk of variable declarations in `cable_cell_param.cpp`.