### PR TITLE
Some API fixes/cleanup from PR #899

### DIFF
--- a/arbor/connection.hpp
+++ b/arbor/connection.hpp
@@ -61,5 +61,6 @@ static inline bool operator<(cell_member_type lhs, const connection& rhs) {
 static inline std::ostream& operator<<(std::ostream& o, arb::connection const& con) {
     return o << "con [" << con.source() << " -> " << con.destination()
              << " : weight " << con.weight()
-             << ", delay " << con.delay() << "]";
+             << ", delay " << con.delay()
+             << ", index " << con.index_on_domain() << "]";
 }

--- a/arbor/execution_context.cpp
+++ b/arbor/execution_context.cpp
@@ -14,6 +14,10 @@
 
 namespace arb {
 
+void execution_context_deleter::operator()(execution_context* p) const {
+    delete p;
+}
+
 execution_context::execution_context(const proc_allocation& resources):
     distributed(make_local_context()),
     thread_pool(std::make_shared<threading::task_system>(resources.num_threads)),
@@ -22,7 +26,7 @@ execution_context::execution_context(const proc_allocation& resources):
 {}
 
 context make_context(const proc_allocation& p) {
-    return context(new execution_context(p), [](execution_context* p){delete p;});
+    return context(new execution_context(p));
 }
 
 #ifdef ARB_HAVE_MPI
@@ -36,7 +40,7 @@ execution_context::execution_context(const proc_allocation& resources, MPI_Comm 
 
 template <>
 context make_context<MPI_Comm>(const proc_allocation& p, MPI_Comm comm) {
-    return context(new execution_context(p, comm), [](execution_context* p){delete p;});
+    return context(new execution_context(p, comm));
 }
 #endif
 template <>
@@ -51,7 +55,7 @@ execution_context::execution_context(
 
 template <>
 context make_context(const proc_allocation& p, dry_run_info d) {
-    return context(new execution_context(p, d), [](execution_context* p){delete p;});
+    return context(new execution_context(p, d));
 }
 
 std::string distribution_type(const context& ctx) {

--- a/arbor/include/arbor/context.hpp
+++ b/arbor/include/arbor/context.hpp
@@ -49,7 +49,10 @@ struct execution_context;
 //
 // As execution_context is an incomplete type, an explicit deleter must be
 // provided.
-using context = std::unique_ptr<execution_context, void (*)(execution_context*)>;
+struct execution_context_deleter {
+    void operator()(execution_context*) const;
+};
+using context = std::unique_ptr<execution_context, execution_context_deleter>;
 
 // Helpers for creating contexts. These are implemented in the back end.
 

--- a/arbor/include/arbor/spike.hpp
+++ b/arbor/include/arbor/spike.hpp
@@ -32,6 +32,6 @@ using spike = basic_spike<cell_member_type>;
 
 // Custom stream operator for printing arb::spike<> values.
 template <typename I>
-std::ostream& operator<<(std::ostream& o, arb::basic_spike<I> s) {
+std::ostream& operator<<(std::ostream& o, arb::basic_spike<I> const& s) {
     return o << "S[src " << s.source << ", t " << s.time << "]";
 }


### PR DESCRIPTION
Split out from Alex's PR for quicker inclusion into master.

* Supply `execution_context` deleter for `std::unique_ptr` via class, so
that a function does not have to be supplied as an argument at
construction.
* Supply `arb::basic_spike` by const reference to `ostream` writer.
* Add domain index to `connection` `ostream` writer.