### PR TITLE
enable locset names for probe sites in single cell model.

### DIFF
--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -103,6 +103,10 @@ struct cable_cell_impl {
             }
         }
     }
+
+    mlocation_list locations(const locset& l) const {
+        return thingify(l, provider);
+    }
 };
 
 using impl_ptr = std::unique_ptr<cable_cell_impl, void (*)(cable_cell_impl*)>;
@@ -131,6 +135,10 @@ const arb::morphology& cable_cell::morphology() const {
 
 const mprovider& cable_cell::provider() const {
     return impl_->provider;
+}
+
+mlocation_list cable_cell::locations(const locset& l) const {
+    return impl_->locations(l);
 }
 
 const cable_cell_location_map& cable_cell::location_assignments() const {

--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -178,6 +178,9 @@ public:
         return location_assignments().get<i_clamp>();
     }
 
+    // Access to a concrete list of locations for a locset.
+    mlocation_list locations(const locset&) const;
+
     // Generic access to painted and placed items.
     const cable_cell_region_map& region_assignments() const;
     const cable_cell_location_map& location_assignments() const;

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -525,6 +525,10 @@ void register_cells(pybind11::module& m) {
             },
             "locations"_a, "detector"_a,
             "Add a voltage spike detector at each location in locations.")
+        // Get locations associated with a locset label.
+        .def("locations",
+            [](arb::cable_cell& c, const char* label) {return c.locations(label);},
+            "label"_a, "The locations of the cell morphology for a locset label.")
         // Discretization control.
         .def("compartments_on_samples",
             [](arb::cable_cell& c) {c.default_parameters.discretization = arb::cv_policy_every_sample{};},

--- a/python/example/ring.py
+++ b/python/example/ring.py
@@ -92,7 +92,7 @@ class ring_recipe (arbor.recipe):
         loc = arbor.location(0, 0) # at the soma
         return arbor.cable_probe('voltage', id, loc)
 
-context = arbor.context(threads=4, gpu_id=None)
+context = arbor.context(threads=12, gpu_id=None)
 print(context)
 
 meters = arbor.meter_manager()
@@ -128,7 +128,7 @@ spike_recorder = arbor.attach_spike_recorder(sim)
 # Sample rate of 10 sample every ms.
 samplers = [arbor.attach_sampler(sim, 0.1, arbor.cell_member(gid,0)) for gid in range(ncells)]
 
-tfinal=1
+tfinal=100
 sim.run(tfinal)
 print(f'{sim} finished')
 
@@ -147,7 +147,7 @@ fig, ax = plt.subplots()
 for gid in range(ncells):
     times = [s.time  for s in samplers[gid].samples(arbor.cell_member(gid,0))]
     volts = [s.value for s in samplers[gid].samples(arbor.cell_member(gid,0))]
-    ax.plot(times, volts, '.')
+    ax.plot(times, volts)
 
 legends = ['cell {}'.format(gid) for gid in range(ncells)]
 ax.legend(legends)

--- a/python/example/single_cell_builder.py
+++ b/python/example/single_cell_builder.py
@@ -43,6 +43,8 @@ b.add_label('dend', '(join (region "dendn") (region "dendx"))')
 b.add_label('stim_site', '(location 2 0.5)')
 # The root of the tree (equivalent to '(location 0 0)')
 b.add_label('root', '(root)')
+# The tips of the dendrites (3 locations at b4, b3, b5).
+b.add_label('dtips', '(terminal)')
 
 # Extract the cable cell from the builder.
 cell = b.build()
@@ -63,13 +65,12 @@ cell.place('stim_site', arbor.iclamp( 80, 2, 0.8))
 # Add a spike detector with threshold of -10 mV.
 cell.place('root', arbor.spike_detector(-10))
 
-# make single cell model
+# Make single cell model.
 m = arbor.single_cell_model(cell)
 
 # Attach voltage probes, sampling at 10 kHz.
-m.probe('voltage', loc(0,0), 10000) # at the soma
-m.probe('voltage', loc(3,1), 10000) # at the end of branch 3
-m.probe('voltage', loc(4,1), 10000) # at the end of branch 4
+m.probe('voltage', loc(0,0), 10000) # at the soma.
+m.probe('voltage', 'dtips',   10000) # at the tips of the dendrites.
 
 # Run simulation for 100 ms of simulated activity.
 tfinal=100

--- a/python/example/single_cell_swc.py
+++ b/python/example/single_cell_swc.py
@@ -42,7 +42,7 @@ cell.compartments_on_samples()
 m = arbor.single_cell_model(cell)
 
 # Attach voltage probes that sample at 50 kHz.
-m.probe('voltage', where=loc(0,0),  frequency=50000)
+m.probe('voltage', where='root',  frequency=50000)
 m.probe('voltage', where=loc(2,1),  frequency=50000)
 m.probe('voltage', where=loc(4,1),  frequency=50000)
 m.probe('voltage', where=loc(30,1), frequency=50000)

--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -41,13 +41,9 @@ void register_morphology(pybind11::module& m) {
         .def_readonly("position", &arb::mlocation::pos,
             "The relative position on the branch (∈ [0.,1.], where 0. means proximal and 1. distal).")
         .def("__str__",
-            [](arb::mlocation l) {
-                return util::pprintf("(location {} {})", l.branch, l.pos);
-            })
+            [](arb::mlocation l) { return util::pprintf("(location {} {})", l.branch, l.pos); })
         .def("__repr__",
-            [](arb::mlocation l) {
-                return util::pprintf("<arbor.location: branch {}, position {}>", l.branch, l.pos);
-            });
+            [](arb::mlocation l) { return util::pprintf("(location {} {})", l.branch, l.pos); });
 
     // arb::mpoint
     pybind11::class_<arb::mpoint> mpoint(m, "mpoint");


### PR DESCRIPTION
Use locset names to set probe sites in single cell model.

1. Extend C++ cable_cell interface to provide a concrete list of
   locations associated with a locset on the cell.
2. Extend Python single_cell_model to allow placement of probes
   on locsets.
3. Remove "debug" output in Python ring example.

The single cell model maintains a trace callback for each probe
location, and needs to know the explicit locations before
starting the simulation. The first step is required to enumerate
and record the locations associated with a locset when attaching probes.