### PR TITLE
Partition cells by complexity

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -102,7 +102,7 @@ range_check_failure::range_check_failure(const std::string& whatstr, double valu
 {}
 
 gid_range_check_failure::gid_range_check_failure(const std::string& whatstr):
-    arbor_exception(pprintf("gid range hint check failure: {}", whatstr))
+    arbor_exception(pprintf("gid_range check failure: {}", whatstr))
 {}
 
 } // namespace arb

--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -101,5 +101,9 @@ range_check_failure::range_check_failure(const std::string& whatstr, double valu
     value(value)
 {}
 
+gid_range_check_failure::gid_range_check_failure(const std::string& whatstr):
+    arbor_exception(pprintf("gid range hint check failure: {}", whatstr))
+{}
+
 } // namespace arb
 

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -116,4 +116,9 @@ struct range_check_failure: arbor_exception {
     double value;
 };
 
+// Partition hint sanity check
+struct gid_range_check_failure: arbor_exception {
+    explicit gid_range_check_failure(const std::string& whatstr);
+};
+
 } // namespace arb

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -18,14 +18,8 @@ struct cell_group_hint {
 
 using gid_range_hint =  std::pair<cell_gid_type, cell_gid_type>;
 
-struct custom_compare {
-    bool operator() (const gid_range_hint& lhs, const gid_range_hint& rhs) const {
-        return lhs.first < rhs.first;
-    }
-};
-
 using cell_group_hint_map = std::unordered_map<cell_kind, cell_group_hint>;
-using gid_range_hint_set  = std::set<gid_range_hint, custom_compare>;
+using gid_range_hint_set  = std::set<gid_range_hint>;
 
 struct partition_hint {
     cell_group_hint_map cell_group_map;
@@ -43,7 +37,7 @@ struct partition_hint {
                 throw gid_range_check_failure("overlapping ranges");
             }
             if (hint.second > prev_range_end) {
-                missing_ranges.push_back({prev_range_end, hint.first});
+                missing_ranges.emplace_back(prev_range_end, hint.first);
             }
             prev_range_end = hint.second;
         }
@@ -52,7 +46,7 @@ struct partition_hint {
             throw gid_range_check_failure("range outside total number of cells");
         }
         if (prev_range_end < num_cells) {
-            gid_range_set.insert({prev_range_end, num_cells});
+            missing_ranges.emplace_back(prev_range_end, num_cells);
         }
 
         gid_range_set.insert(missing_ranges.begin(), missing_ranges.end());

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <set>
+#include <iostream>
 
 #include <arbor/context.hpp>
 #include <arbor/domain_decomposition.hpp>
@@ -36,6 +37,9 @@ struct partition_hint {
         cell_gid_type prev_range_end = 0;
 
         for (auto hint: gid_range_set) {
+            if (hint.first > hint.second) {
+                throw gid_range_check_failure("incorrect range: start greater than end");
+            }
             if (hint.first < prev_range_end) {
                 throw gid_range_check_failure("overlapping ranges");
             }

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <set>
-#include <iostream>
 
 #include <arbor/context.hpp>
 #include <arbor/domain_decomposition.hpp>
@@ -38,7 +37,7 @@ struct partition_hint {
 
         for (auto hint: gid_range_set) {
             if (hint.first > hint.second) {
-                throw gid_range_check_failure("incorrect range: start greater than end");
+                throw gid_range_check_failure("incorrect range description: start greater than end");
             }
             if (hint.first < prev_range_end) {
                 throw gid_range_check_failure("overlapping ranges");
@@ -48,12 +47,14 @@ struct partition_hint {
             }
             prev_range_end = hint.second;
         }
+
         if (prev_range_end > num_cells) {
             throw gid_range_check_failure("range outside total number of cells");
         }
         if (prev_range_end < num_cells) {
             gid_range_set.insert({prev_range_end, num_cells});
         }
+
         gid_range_set.insert(missing_ranges.begin(), missing_ranges.end());
     }
 };

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
+#include <set>
+
 #include <arbor/context.hpp>
 #include <arbor/domain_decomposition.hpp>
 #include <arbor/recipe.hpp>
 
 namespace arb {
 
-struct partition_hint {
+struct cell_group_hint {
     constexpr static std::size_t max_size = -1;
 
     std::size_t cpu_group_size = 1;
@@ -14,11 +16,46 @@ struct partition_hint {
     bool prefer_gpu = true;
 };
 
-using partition_hint_map = std::unordered_map<cell_kind, partition_hint>;
+struct gid_range_hint {
+    std::pair<cell_gid_type, cell_gid_type> gid_range;
+    unsigned complexity;
+};
+
+struct partition_hint {
+    struct custom_compare {
+        bool operator() (const gid_range_hint& lhs, const gid_range_hint& rhs) const {
+            return lhs.gid_range.first < rhs.gid_range.first;
+        }
+    };
+
+    std::unordered_map<cell_kind, cell_group_hint> cell_group_hint_map;
+    std::set<gid_range_hint, custom_compare> gid_range_hint_set;
+
+    void verify_gid_ranges(cell_gid_type num_cells) {
+        std::vector<gid_range_hint> missing_ranges;
+        cell_gid_type prev_range_end = 0;
+        for (auto hint: gid_range_hint_set) {
+            if (hint.gid_range.first < prev_range_end) {
+                throw gid_range_check_failure("overlapping ranges");
+            }
+            if (hint.gid_range.second > prev_range_end) {
+                missing_ranges.push_back({{prev_range_end, hint.gid_range.first}, 0});
+            }
+            prev_range_end = hint.gid_range.second;
+        }
+        if (prev_range_end > num_cells) {
+            throw gid_range_check_failure("range outside total number of cells");
+        }
+        if (prev_range_end < num_cells) {
+            gid_range_hint_set.insert({{prev_range_end, num_cells}, 0});
+        }
+        gid_range_hint_set.insert(missing_ranges.begin(), missing_ranges.end());
+    }
+};
 
 domain_decomposition partition_load_balance(
     const recipe& rec,
     const context& ctx,
-    partition_hint_map hint_map = {});
+    partition_hint hint_map = {});
 
 } // namespace arb

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -18,7 +18,7 @@ struct cell_group_hint {
 
 struct gid_range_hint {
     std::pair<cell_gid_type, cell_gid_type> gid_range;
-    unsigned complexity;
+    unsigned complexity = 0;
 };
 
 struct partition_hint {
@@ -34,6 +34,7 @@ struct partition_hint {
     void verify_gid_ranges(cell_gid_type num_cells) {
         std::vector<gid_range_hint> missing_ranges;
         cell_gid_type prev_range_end = 0;
+
         for (auto hint: gid_range_hint_set) {
             if (hint.gid_range.first < prev_range_end) {
                 throw gid_range_check_failure("overlapping ranges");
@@ -56,6 +57,6 @@ struct partition_hint {
 domain_decomposition partition_load_balance(
     const recipe& rec,
     const context& ctx,
-    partition_hint hint_map = {});
+    partition_hint hint_map = partition_hint());
 
 } // namespace arb

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -36,7 +36,7 @@ struct partition_hint {
             if (hint.first < prev_range_end) {
                 throw gid_range_check_failure("overlapping ranges");
             }
-            if (hint.second > prev_range_end) {
+            if (hint.first > prev_range_end) {
                 missing_ranges.emplace_back(prev_range_end, hint.first);
             }
             prev_range_end = hint.second;

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -16,14 +16,11 @@ struct cell_group_hint {
     bool prefer_gpu = true;
 };
 
-struct gid_range_hint {
-    std::pair<cell_gid_type, cell_gid_type> gid_range;
-    unsigned complexity = 0;
-};
+using gid_range_hint =  std::pair<cell_gid_type, cell_gid_type>;
 
 struct custom_compare {
     bool operator() (const gid_range_hint& lhs, const gid_range_hint& rhs) const {
-        return lhs.gid_range.first < rhs.gid_range.first;
+        return lhs.first < rhs.first;
     }
 };
 
@@ -39,19 +36,19 @@ struct partition_hint {
         cell_gid_type prev_range_end = 0;
 
         for (auto hint: gid_range_set) {
-            if (hint.gid_range.first < prev_range_end) {
+            if (hint.first < prev_range_end) {
                 throw gid_range_check_failure("overlapping ranges");
             }
-            if (hint.gid_range.second > prev_range_end) {
-                missing_ranges.push_back({{prev_range_end, hint.gid_range.first}, 0});
+            if (hint.second > prev_range_end) {
+                missing_ranges.push_back({prev_range_end, hint.first});
             }
-            prev_range_end = hint.gid_range.second;
+            prev_range_end = hint.second;
         }
         if (prev_range_end > num_cells) {
             throw gid_range_check_failure("range outside total number of cells");
         }
         if (prev_range_end < num_cells) {
-            gid_range_set.insert({{prev_range_end, num_cells}, 0});
+            gid_range_set.insert({prev_range_end, num_cells});
         }
         gid_range_set.insert(missing_ranges.begin(), missing_ranges.end());
     }

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -21,21 +21,24 @@ struct gid_range_hint {
     unsigned complexity = 0;
 };
 
-struct partition_hint {
-    struct custom_compare {
-        bool operator() (const gid_range_hint& lhs, const gid_range_hint& rhs) const {
-            return lhs.gid_range.first < rhs.gid_range.first;
-        }
-    };
+struct custom_compare {
+    bool operator() (const gid_range_hint& lhs, const gid_range_hint& rhs) const {
+        return lhs.gid_range.first < rhs.gid_range.first;
+    }
+};
 
-    std::unordered_map<cell_kind, cell_group_hint> cell_group_hint_map;
-    std::set<gid_range_hint, custom_compare> gid_range_hint_set;
+using cell_group_hint_map = std::unordered_map<cell_kind, cell_group_hint>;
+using gid_range_hint_set  = std::set<gid_range_hint, custom_compare>;
+
+struct partition_hint {
+    cell_group_hint_map cell_group_map;
+    gid_range_hint_set gid_range_set;
 
     void verify_gid_ranges(cell_gid_type num_cells) {
         std::vector<gid_range_hint> missing_ranges;
         cell_gid_type prev_range_end = 0;
 
-        for (auto hint: gid_range_hint_set) {
+        for (auto hint: gid_range_set) {
             if (hint.gid_range.first < prev_range_end) {
                 throw gid_range_check_failure("overlapping ranges");
             }
@@ -48,9 +51,9 @@ struct partition_hint {
             throw gid_range_check_failure("range outside total number of cells");
         }
         if (prev_range_end < num_cells) {
-            gid_range_hint_set.insert({{prev_range_end, num_cells}, 0});
+            gid_range_set.insert({{prev_range_end, num_cells}, 0});
         }
-        gid_range_hint_set.insert(missing_ranges.begin(), missing_ranges.end());
+        gid_range_set.insert(missing_ranges.begin(), missing_ranges.end());
     }
 };
 

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -1,7 +1,6 @@
 #include <queue>
 #include <unordered_set>
 #include <vector>
-#include <iostream>
 
 #include <arbor/domain_decomposition.hpp>
 #include <arbor/load_balance.hpp>
@@ -69,8 +68,8 @@ domain_decomposition partition_load_balance(
         }
     }
 
-    std::vector<cell_gid_type> gid_divisions;
     auto partitions_per_domain = hints.gid_range_set.size();
+    std::vector<cell_gid_type> gid_divisions;
     auto gid_part = util::make_partition(gid_divisions, size_per_domain);
 
     // Local load balance

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -60,7 +60,7 @@ domain_decomposition partition_load_balance(
     hints.verify_gid_ranges(rec.num_cells());
 
     std::vector<cell_gid_type> size_per_domain;
-    for (auto gid_range: hints.gid_range_hint_set) {
+    for (auto gid_range: hints.gid_range_set) {
         for (auto dom: make_span(num_domains)) {
             auto range_size = gid_range.gid_range.second - gid_range.gid_range.first;
             const cell_gid_type B = range_size / num_domains;
@@ -70,7 +70,7 @@ domain_decomposition partition_load_balance(
     }
 
     std::vector<cell_gid_type> gid_divisions;
-    auto partitions_per_domain = hints.gid_range_hint_set.size();
+    auto partitions_per_domain = hints.gid_range_set.size();
     auto gid_part = util::make_partition(gid_divisions, size_per_domain);
 
     // Local load balance
@@ -175,7 +175,7 @@ domain_decomposition partition_load_balance(
     std::vector<group_description> groups;
     for (auto k: kinds) {
         cell_group_hint hint;
-        if (auto opt_hint = util::value_by_key(hints.cell_group_hint_map, k)) {
+        if (auto opt_hint = util::value_by_key(hints.cell_group_map, k)) {
             hint = opt_hint.value();
             if(!hint.cpu_group_size) {
                 throw arbor_exception(arb::util::pprintf("unable to perform load balancing because {} has invalid suggested cpu_cell_group size of {}", k, hint.cpu_group_size));

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -62,7 +62,7 @@ domain_decomposition partition_load_balance(
     std::vector<cell_gid_type> size_per_domain;
     for (auto gid_range: hints.gid_range_set) {
         for (auto dom: make_span(num_domains)) {
-            auto range_size = gid_range.gid_range.second - gid_range.gid_range.first;
+            auto range_size = gid_range.second - gid_range.first;
             const cell_gid_type B = range_size / num_domains;
             const cell_gid_type R = range_size - num_domains * B;
             size_per_domain.push_back(B + (dom < R));

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -60,8 +60,8 @@ domain_decomposition partition_load_balance(
     hints.verify_gid_ranges(rec.num_cells());
 
     std::vector<cell_gid_type> size_per_domain;
-    for (auto dom: make_span(num_domains)) {
-        for (auto gid_range: hints.gid_range_hint_set) {
+    for (auto gid_range: hints.gid_range_hint_set) {
+        for (auto dom: make_span(num_domains)) {
             auto range_size = gid_range.gid_range.second - gid_range.gid_range.first;
             const cell_gid_type B = range_size / num_domains;
             const cell_gid_type R = range_size - num_domains * B;

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -277,8 +277,8 @@ int main(int argc, char** argv) {
 
         brunel_recipe recipe(nexc, ninh, next, in_degree_prop, w, d, rel_inh_strength, poiss_lambda, seed);
 
-        partition_hint_map hints;
-        hints[cell_kind::lif].cpu_group_size = group_size;
+        partition_hint hints;
+        hints.cell_group_map[cell_kind::lif].cpu_group_size = group_size;
         auto decomp = partition_load_balance(recipe, context, hints);
 
         simulation sim(recipe, decomp, context);

--- a/python/domain_decomposition.cpp
+++ b/python/domain_decomposition.cpp
@@ -28,7 +28,7 @@ std::string dd_string(const arb::domain_decomposition& d) {
         d.domain_id, d.num_domains, d.num_local_cells, d.num_global_cells, d.groups.size());
 }
 
-std::string ph_string(const arb::partition_hint& h) {
+std::string ph_string(const arb::cell_group_hint& h) {
     return util::pprintf(
         "<arbor.partition_hint: cpu_group_size {}, gpu_group_size {}, prefer_gpu {}>",
         h.cpu_group_size, h.gpu_group_size, (h.prefer_gpu == 1) ? "True" : "False");
@@ -54,9 +54,9 @@ void register_domain_decomposition(pybind11::module& m) {
         .def("__repr__", &gd_string);
 
     // Partition hint
-    pybind11::class_<arb::partition_hint> partition_hint(m, "partition_hint",
+    pybind11::class_<arb::cell_group_hint> cell_group_hint(m, "cell_group_hint",
         "Provide a hint on how the cell groups should be partitioned.");
-    partition_hint
+    cell_group_hint
         .def(pybind11::init<std::size_t, std::size_t, bool>(),
             "cpu_group_size"_a = 1, "gpu_group_size"_a = std::numeric_limits<std::size_t>::max(), "prefer_gpu"_a = true,
             "Construct a partition hint with arguments:\n"
@@ -65,13 +65,13 @@ void register_domain_decomposition(pybind11::module& m) {
             "  gpu_group_size: The size of cell group assigned to GPU, all cells in one group by default.\n"
             "                  Must be positive, else set to default value.\n"
             "  prefer_gpu:     Whether GPU is preferred, True by default.")
-        .def_readwrite("cpu_group_size", &arb::partition_hint::cpu_group_size,
+        .def_readwrite("cpu_group_size", &arb::cell_group_hint::cpu_group_size,
                                         "The size of cell group assigned to CPU.")
-        .def_readwrite("gpu_group_size", &arb::partition_hint::gpu_group_size,
+        .def_readwrite("gpu_group_size", &arb::cell_group_hint::gpu_group_size,
                                         "The size of cell group assigned to GPU.")
-        .def_readwrite("prefer_gpu", &arb::partition_hint::prefer_gpu,
+        .def_readwrite("prefer_gpu", &arb::cell_group_hint::prefer_gpu,
                                         "Whether GPU usage is preferred.")
-        .def_property_readonly_static("max_size",  [](pybind11::object) { return arb::partition_hint::max_size; },
+        .def_property_readonly_static("max_size",  [](pybind11::object) { return arb::cell_group_hint::max_size; },
                                         "Get the maximum size of cell groups.")
         .def("__str__",  &ph_string)
         .def("__repr__", &ph_string);
@@ -104,7 +104,7 @@ void register_domain_decomposition(pybind11::module& m) {
     // Partition load balancer
     // The Python recipe has to be shimmed for passing to the function that takes a C++ recipe.
     m.def("partition_load_balance",
-        [](std::shared_ptr<py_recipe>& recipe, const context_shim& ctx, arb::partition_hint_map hint_map) {
+        [](std::shared_ptr<py_recipe>& recipe, const context_shim& ctx, arb::partition_hint hint_map) {
             try {
                 return arb::partition_load_balance(py_recipe_shim(recipe), ctx.context, std::move(hint_map));
             }
@@ -116,7 +116,7 @@ void register_domain_decomposition(pybind11::module& m) {
         "Construct a domain_decomposition that distributes the cells in the model described by recipe\n"
         "over the distributed and local hardware resources described by context.\n"
         "Optionally, provide a dictionary of partition hints for certain cell kinds, by default empty.",
-        "recipe"_a, "context"_a, "hints"_a=arb::partition_hint_map{});
+        "recipe"_a, "context"_a, "hints"_a=arb::partition_hint{});
 }
 
 } // namespace pyarb

--- a/python/domain_decomposition.cpp
+++ b/python/domain_decomposition.cpp
@@ -104,9 +104,11 @@ void register_domain_decomposition(pybind11::module& m) {
     // Partition load balancer
     // The Python recipe has to be shimmed for passing to the function that takes a C++ recipe.
     m.def("partition_load_balance",
-        [](std::shared_ptr<py_recipe>& recipe, const context_shim& ctx, arb::partition_hint hint_map) {
+        [](std::shared_ptr<py_recipe>& recipe, const context_shim& ctx, arb::cell_group_hint_map hint_map) {
             try {
-                return arb::partition_load_balance(py_recipe_shim(recipe), ctx.context, std::move(hint_map));
+                arb::partition_hint hint;
+                hint.cell_group_map = std::move(hint_map);
+                return arb::partition_load_balance(py_recipe_shim(recipe), ctx.context, std::move(hint));
             }
             catch (...) {
                 py_reset_and_throw();
@@ -116,7 +118,7 @@ void register_domain_decomposition(pybind11::module& m) {
         "Construct a domain_decomposition that distributes the cells in the model described by recipe\n"
         "over the distributed and local hardware resources described by context.\n"
         "Optionally, provide a dictionary of partition hints for certain cell kinds, by default empty.",
-        "recipe"_a, "context"_a, "hints"_a=arb::partition_hint{});
+        "recipe"_a, "context"_a, "hints"_a=arb::cell_group_hint_map{});
 }
 
 } // namespace pyarb

--- a/python/example/ring.py
+++ b/python/example/ring.py
@@ -107,7 +107,7 @@ meters.checkpoint('recipe-create', context)
 decomp = arbor.partition_load_balance(recipe, context)
 print(f'{decomp}')
 
-hint = arbor.partition_hint()
+hint = arbor.cell_group_hint()
 hint.prefer_gpu = True
 hint.gpu_group_size = 1000
 print(f'{hint}')

--- a/python/test/unit/test_domain_decompositions.py
+++ b/python/test/unit/test_domain_decompositions.py
@@ -186,10 +186,10 @@ class Domain_Decompositions(unittest.TestCase):
         # The hints perfer the multicore backend, so the decomposition is expected
         # to never have cell groups on the GPU, regardless of whether a GPU is
         # available or not.
-        cable_hint = arb.partition_hint()
+        cable_hint = arb.cell_group_hint()
         cable_hint.prefer_gpu = False
         cable_hint.cpu_group_size = 3
-        spike_hint = arb.partition_hint()
+        spike_hint = arb.cell_group_hint()
         spike_hint.prefer_gpu = False
         spike_hint.cpu_group_size = 4
         hints = dict([(arb.cell_kind.cable, cable_hint), (arb.cell_kind.spike_source, spike_hint)])
@@ -220,10 +220,10 @@ class Domain_Decompositions(unittest.TestCase):
         # The hints perfer the multicore backend, so the decomposition is expected
         # to never have cell groups on the GPU, regardless of whether a GPU is
         # available or not.
-        cable_hint = arb.partition_hint()
+        cable_hint = arb.cell_group_hint()
         cable_hint.prefer_gpu = False
         cable_hint.cpu_group_size = 0
-        spike_hint = arb.partition_hint()
+        spike_hint = arb.cell_group_hint()
         spike_hint.prefer_gpu = False
         spike_hint.gpu_group_size = 1
         hints = dict([(arb.cell_kind.cable, cable_hint), (arb.cell_kind.spike_source, spike_hint)])
@@ -232,10 +232,10 @@ class Domain_Decompositions(unittest.TestCase):
             "unable to perform load balancing because cell_kind::cable has invalid suggested cpu_cell_group size of 0"):
             decomp = arb.partition_load_balance(recipe, context, hints)
 
-        cable_hint = arb.partition_hint()
+        cable_hint = arb.cell_group_hint()
         cable_hint.prefer_gpu = False
         cable_hint.cpu_group_size = 1
-        spike_hint = arb.partition_hint()
+        spike_hint = arb.cell_group_hint()
         spike_hint.prefer_gpu = True
         spike_hint.gpu_group_size = 0
         hints = dict([(arb.cell_kind.cable, cable_hint), (arb.cell_kind.spike_source, spike_hint)])

--- a/python/test/unit_distributed/test_domain_decompositions.py
+++ b/python/test/unit_distributed/test_domain_decompositions.py
@@ -327,7 +327,7 @@ class Domain_Decompositions_Distributed(unittest.TestCase):
             self.assertEqual(int(i/cells_per_rank), decomp0.gid_domain(i))
 
         # Test different group_hints
-        hint1 = arb.partition_hint()
+        hint1 = arb.cell_group_hint()
         hint1.prefer_gpu = False
         hint1.cpu_group_size = recipe.num_cells()
         hints1 = dict([(arb.cell_kind.cable, hint1)])
@@ -343,7 +343,7 @@ class Domain_Decompositions_Distributed(unittest.TestCase):
         for i in range(recipe.num_cells()):
             self.assertEqual(int(i/cells_per_rank), decomp1.gid_domain(i))
 
-        hint2 = arb.partition_hint()
+        hint2 = arb.cell_group_hint()
         hint2.prefer_gpu = False
         hint2.cpu_group_size = int(cells_per_rank/2)
         hints2 = dict([(arb.cell_kind.cable, hint2)])
@@ -414,7 +414,7 @@ class Domain_Decompositions_Distributed(unittest.TestCase):
 
         recipe = gj_symmetric(nranks)
 
-        hint1 = arb.partition_hint()
+        hint1 = arb.cell_group_hint()
         hint1.prefer_gpu = False
         hint1.cpu_group_size = 0
         hints1 = dict([(arb.cell_kind.cable, hint1)])
@@ -423,7 +423,7 @@ class Domain_Decompositions_Distributed(unittest.TestCase):
             "unable to perform load balancing because cell_kind::cable has invalid suggested cpu_cell_group size of 0"):
             decomp1 = arb.partition_load_balance(recipe, context, hints1)
 
-        hint2 = arb.partition_hint()
+        hint2 = arb.cell_group_hint()
         hint2.prefer_gpu = True
         hint2.gpu_group_size = 0
         hints2 = dict([(arb.cell_kind.cable, hint2)])

--- a/test/unit-distributed/test_domain_decomposition.cpp
+++ b/test/unit-distributed/test_domain_decomposition.cpp
@@ -329,8 +329,8 @@ TEST(domain_decomposition, symmetric_groups)
 
     // Test different group_hints
     partition_hint hints;
-    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = R.num_cells();
-    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_map[cell_kind::cable].cpu_group_size = R.num_cells();
+    hints.cell_group_map[cell_kind::cable].prefer_gpu = false;
 
     const auto D1 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(1u, D1.groups.size());
@@ -345,8 +345,8 @@ TEST(domain_decomposition, symmetric_groups)
         EXPECT_EQ(i/cells_per_rank, (unsigned)D1.gid_domain(i));
     }
 
-    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = cells_per_rank/2;
-    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_map[cell_kind::cable].cpu_group_size = cells_per_rank/2;
+    hints.cell_group_map[cell_kind::cable].prefer_gpu = false;
 
     const auto D2 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(2u, D2.groups.size());

--- a/test/unit-distributed/test_domain_decomposition.cpp
+++ b/test/unit-distributed/test_domain_decomposition.cpp
@@ -328,9 +328,9 @@ TEST(domain_decomposition, symmetric_groups)
     }
 
     // Test different group_hints
-    partition_hint_map hints;
-    hints[cell_kind::cable].cpu_group_size = R.num_cells();
-    hints[cell_kind::cable].prefer_gpu = false;
+    partition_hint hints;
+    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = R.num_cells();
+    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
 
     const auto D1 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(1u, D1.groups.size());
@@ -345,8 +345,8 @@ TEST(domain_decomposition, symmetric_groups)
         EXPECT_EQ(i/cells_per_rank, (unsigned)D1.gid_domain(i));
     }
 
-    hints[cell_kind::cable].cpu_group_size = cells_per_rank/2;
-    hints[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = cells_per_rank/2;
+    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
 
     const auto D2 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(2u, D2.groups.size());

--- a/test/unit/test_domain_decomposition.cpp
+++ b/test/unit/test_domain_decomposition.cpp
@@ -276,10 +276,10 @@ TEST(domain_decomposition, hints) {
     auto ctx = make_context();
 
     std::vector<std::vector<cell_gid_type>> expected_c1d_groups =
-            {{0, 2, 4}, {6, 8, 10}, {12, 14, 16}, {18}};
+        {{0, 2, 4}, {6, 8, 10}, {12, 14, 16}, {18}};
 
     std::vector<std::vector<cell_gid_type>> expected_ss_groups =
-            {{1, 3, 5, 7}, {9, 11, 13, 15}, {17, 19}};
+        {{1, 3, 5, 7}, {9, 11, 13, 15}, {17, 19}};
 
     auto partition = [&](partition_hint hints) {
         domain_decomposition D = partition_load_balance(hetero_recipe(20), ctx, hints);

--- a/test/unit/test_domain_decomposition.cpp
+++ b/test/unit/test_domain_decomposition.cpp
@@ -276,9 +276,9 @@ TEST(domain_decomposition, hints) {
     auto ctx = make_context();
 
     partition_hint hints;
-    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = 3;
-    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
-    hints.cell_group_hint_map[cell_kind::spike_source].cpu_group_size = 4;
+    hints.cell_group_map[cell_kind::cable].cpu_group_size = 3;
+    hints.cell_group_map[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_map[cell_kind::spike_source].cpu_group_size = 4;
 
     domain_decomposition D = partition_load_balance(
         hetero_recipe(20),
@@ -328,8 +328,8 @@ TEST(domain_decomposition, compulsory_groups)
 
     // Test different group_hints
     partition_hint hints;
-    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = 3;
-    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_map[cell_kind::cable].cpu_group_size = 3;
+    hints.cell_group_map[cell_kind::cable].prefer_gpu = false;
 
 //    hints.gid_range_hint_set = { {{100, 180}, 0},
 //                                 {{200, 220}, 1},
@@ -337,7 +337,7 @@ TEST(domain_decomposition, compulsory_groups)
 //                               };
 //
 //    hints.verify_gid_ranges(220);
-    for (auto hint: hints.gid_range_hint_set) {
+    for (auto hint: hints.gid_range_set) {
         std::cout << hint.gid_range.first << " " << hint.gid_range.second << std::endl;
     }
     const auto D1 = partition_load_balance(R, ctx, hints);
@@ -350,8 +350,8 @@ TEST(domain_decomposition, compulsory_groups)
         EXPECT_EQ(expected_groups1[i], D1.groups[i].gids);
     }
 
-    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = 20;
-    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_map[cell_kind::cable].cpu_group_size = 20;
+    hints.cell_group_map[cell_kind::cable].prefer_gpu = false;
 
     const auto D2 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(1u, D2.groups.size());

--- a/test/unit/test_domain_decomposition.cpp
+++ b/test/unit/test_domain_decomposition.cpp
@@ -275,10 +275,10 @@ TEST(domain_decomposition, hints) {
 
     auto ctx = make_context();
 
-    partition_hint_map hints;
-    hints[cell_kind::cable].cpu_group_size = 3;
-    hints[cell_kind::cable].prefer_gpu = false;
-    hints[cell_kind::spike_source].cpu_group_size = 4;
+    partition_hint hints;
+    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = 3;
+    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_hint_map[cell_kind::spike_source].cpu_group_size = 4;
 
     domain_decomposition D = partition_load_balance(
         hetero_recipe(20),
@@ -327,10 +327,19 @@ TEST(domain_decomposition, compulsory_groups)
     }
 
     // Test different group_hints
-    partition_hint_map hints;
-    hints[cell_kind::cable].cpu_group_size = 3;
-    hints[cell_kind::cable].prefer_gpu = false;
+    partition_hint hints;
+    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = 3;
+    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
 
+//    hints.gid_range_hint_set = { {{100, 180}, 0},
+//                                 {{200, 220}, 1},
+//                                 {{50, 100},   2}
+//                               };
+//
+//    hints.verify_gid_ranges(220);
+    for (auto hint: hints.gid_range_hint_set) {
+        std::cout << hint.gid_range.first << " " << hint.gid_range.second << std::endl;
+    }
     const auto D1 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(5u, D1.groups.size());
 
@@ -341,8 +350,8 @@ TEST(domain_decomposition, compulsory_groups)
         EXPECT_EQ(expected_groups1[i], D1.groups[i].gids);
     }
 
-    hints[cell_kind::cable].cpu_group_size = 20;
-    hints[cell_kind::cable].prefer_gpu = false;
+    hints.cell_group_hint_map[cell_kind::cable].cpu_group_size = 20;
+    hints.cell_group_hint_map[cell_kind::cable].prefer_gpu = false;
 
     const auto D2 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(1u, D2.groups.size());

--- a/test/unit/test_domain_decomposition.cpp
+++ b/test/unit/test_domain_decomposition.cpp
@@ -275,37 +275,44 @@ TEST(domain_decomposition, hints) {
 
     auto ctx = make_context();
 
+    std::vector<std::vector<cell_gid_type>> expected_c1d_groups =
+            {{0, 2, 4}, {6, 8, 10}, {12, 14, 16}, {18}};
+
+    std::vector<std::vector<cell_gid_type>> expected_ss_groups =
+            {{1, 3, 5, 7}, {9, 11, 13, 15}, {17, 19}};
+
+    auto partition = [&](partition_hint hints) {
+        domain_decomposition D = partition_load_balance(hetero_recipe(20), ctx, hints);
+
+        std::vector<std::vector<cell_gid_type>> c1d_groups, ss_groups;
+        for (auto &g: D.groups) {
+            EXPECT_TRUE(g.kind == cell_kind::cable || g.kind == cell_kind::spike_source);
+
+            if (g.kind == cell_kind::cable) {
+                c1d_groups.push_back(g.gids);
+            } else if (g.kind == cell_kind::spike_source) {
+                ss_groups.push_back(g.gids);
+            }
+        }
+
+        EXPECT_EQ(expected_c1d_groups, c1d_groups);
+        EXPECT_EQ(expected_ss_groups, ss_groups);
+    };
+
     partition_hint hints;
     hints.cell_group_map[cell_kind::cable].cpu_group_size = 3;
     hints.cell_group_map[cell_kind::cable].prefer_gpu = false;
     hints.cell_group_map[cell_kind::spike_source].cpu_group_size = 4;
+    partition(hints);
 
-    domain_decomposition D = partition_load_balance(
-        hetero_recipe(20),
-        ctx,
-        hints);
+    hints.gid_range_set = {{0,20}};
+    partition(hints);
 
-    std::vector<std::vector<cell_gid_type>> expected_c1d_groups =
-        {{0, 2, 4}, {6, 8, 10}, {12, 14, 16}, {18}};
+    hints.gid_range_set = {{10,15}};
+    partition(hints);
 
-    std::vector<std::vector<cell_gid_type>> expected_ss_groups =
-        {{1, 3, 5, 7}, {9, 11, 13, 15}, {17, 19}};
-
-    std::vector<std::vector<cell_gid_type>> c1d_groups, ss_groups;
-
-    for (auto& g: D.groups) {
-        EXPECT_TRUE(g.kind==cell_kind::cable || g.kind==cell_kind::spike_source);
-
-        if (g.kind==cell_kind::cable) {
-            c1d_groups.push_back(g.gids);
-        }
-        else if (g.kind==cell_kind::spike_source) {
-            ss_groups.push_back(g.gids);
-        }
-    }
-
-    EXPECT_EQ(expected_c1d_groups, c1d_groups);
-    EXPECT_EQ(expected_ss_groups, ss_groups);
+    hints.gid_range_set = {{0,3},{6,11},{15,20},{11, 15}};
+    partition(hints);
 }
 
 TEST(domain_decomposition, compulsory_groups)

--- a/test/unit/test_domain_decomposition.cpp
+++ b/test/unit/test_domain_decomposition.cpp
@@ -331,15 +331,6 @@ TEST(domain_decomposition, compulsory_groups)
     hints.cell_group_map[cell_kind::cable].cpu_group_size = 3;
     hints.cell_group_map[cell_kind::cable].prefer_gpu = false;
 
-//    hints.gid_range_hint_set = { {{100, 180}, 0},
-//                                 {{200, 220}, 1},
-//                                 {{50, 100},   2}
-//                               };
-//
-//    hints.verify_gid_ranges(220);
-    for (auto hint: hints.gid_range_set) {
-        std::cout << hint.gid_range.first << " " << hint.gid_range.second << std::endl;
-    }
     const auto D1 = partition_load_balance(R, ctx, hints);
     EXPECT_EQ(5u, D1.groups.size());
 


### PR DESCRIPTION
Allow users to group cells into ranges of `gid`s which have the same complexity, and pass the set of ranges as a hint to `partition_load_balance`. 
`partition_load_balance` can then place an equal number of cells of the same complexity on each rank. 

Addresses #969