### PR TITLE
Change Neon macro

### DIFF
--- a/arbor/include/arbor/simd/native.hpp
+++ b/arbor/include/arbor/simd/native.hpp
@@ -65,7 +65,7 @@ ARB_DEF_NATIVE_SIMD_(double, 8, avx512)
 
 #endif
 
-#if defined(__ARM_NEON__) || defined(__aarch64__)
+#if defined(__ARM_NEON)
 
 #include <arbor/simd/neon.hpp>
 ARB_DEF_NATIVE_SIMD_(int, 2, neon)

--- a/arbor/include/arbor/simd/neon.hpp
+++ b/arbor/include/arbor/simd/neon.hpp
@@ -2,7 +2,7 @@
 
 // NEON SIMD intrinsics implementation.
 
-#if defined(__ARM_NEON__) || defined(__aarch64__)
+#if defined(__ARM_NEON)
 #include <arm_neon.h>
 #include <cmath>
 #include <cstdint>
@@ -646,4 +646,4 @@ struct neon<int, 2> {
 }  // namespace simd
 }  // namespace arb
 
-#endif  // def __ARM_NEON__
+#endif  // def __ARM_NEON

--- a/test/unit/test_simd.cpp
+++ b/test/unit/test_simd.cpp
@@ -589,7 +589,7 @@ typedef ::testing::Types<
     simd<int, 8, simd_abi::avx512>,
     simd<double, 8, simd_abi::avx512>,
 #endif
-#if defined(__ARM_NEON__) || defined(__aarch64__)
+#if defined(__ARM_NEON)
     simd<int, 2, simd_abi::neon>,
     simd<double, 2, simd_abi::neon>,
 #endif
@@ -875,7 +875,7 @@ typedef ::testing::Types<
 #ifdef __AVX512F__
     simd<double, 8, simd_abi::avx512>,
 #endif
-#if defined(__ARM_NEON__) || defined(__aarch64__)
+#if defined(__ARM_NEON)
     simd<double, 2, simd_abi::neon>,
 #endif
 
@@ -1202,7 +1202,7 @@ typedef ::testing::Types<
     simd_and_index<simd<int, 8, simd_abi::avx512>,
                    simd<int, 8, simd_abi::avx512>>,
 #endif
-#if defined(__ARM_NEON__) || defined(__aarch64__)
+#if defined(__ARM_NEON)
     simd_and_index<simd<double, 2, simd_abi::neon>,
                    simd<int, 2, simd_abi::neon>>,
 
@@ -1288,7 +1288,7 @@ typedef ::testing::Types<
     simd_pair<simd<double, 8, simd_abi::avx512>,
               simd<int, 8, simd_abi::avx512>>,
 #endif
-#if defined(__ARM_NEON__) || defined(__aarch64__)
+#if defined(__ARM_NEON)
     simd_pair<simd<double, 2, simd_abi::neon>,
               simd<int, 2, simd_abi::neon>>,
 #endif


### PR DESCRIPTION
`__ARM_NEON__` has been deprecated and replaced by `__ARM_NEON` which should be defined by the compiler provided `ARB_ARCH` is set correctly. For example `-DARB_ARCH=armv8-a+simd `