### PR TITLE
pip / setuptools support

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -29,10 +29,10 @@ with very few tools.
     =========== ============================================
     Git         To check out the code, minimum version 2.0.
     CMake       To set up the build, minimum version 3.9
-    compiler    A C++14 compiler. See `compilers <compilers_>`_.
+    compiler    A C++14 compiler. See `compilers <install-compilers_>`_.
     =========== ============================================
 
-.. _compilers:
+.. _install-compilers:
 
 Compilers
 ~~~~~~~~~
@@ -120,7 +120,7 @@ Python
 Arbor has a Python frontend, for which a minimum of Python 3.6 is required.
 In order to use MPI in combination with the python frontend the
 `mpi4py <https://mpi4py.readthedocs.io/en/stable/install.html#>`_
-Python package is recommended. See :ref:`pythonfrontend` for more information.
+Python package is recommended. See :ref:`install-python` for more information.
 
 
 Documentation
@@ -129,7 +129,7 @@ Documentation
 To build a local copy of the html documentation that you are reading now, you will need to
 install `Sphinx <http://www.sphinx-doc.org/en/master/>`_.
 
-.. _downloading:
+.. _install-downloading:
 
 Getting the Code
 ================
@@ -217,13 +217,13 @@ CMake parameters and flags, follow links to the more detailed descriptions below
         cmake -DARB_WITH_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=debug
 
 .. topic:: `Release <buildtarget_>`_ mode (compiler optimizations enabled) with the default
-           compiler, optimized for the local `system architecture <architecture_>`_.
+           compiler, optimized for the local `system architecture <install-architecture_>`_.
 
     .. code-block:: bash
 
         cmake -DARB_ARCH=native
 
-.. topic:: `Release <buildtarget_>`_ mode with `Clang <compilers_>`_.
+.. topic:: `Release <buildtarget_>`_ mode with `Clang <install-compilers_>`_.
 
     .. code-block:: bash
 
@@ -231,13 +231,13 @@ CMake parameters and flags, follow links to the more detailed descriptions below
         export CXX=`which clang++`
         cmake
 
-.. topic:: `Release <buildtarget_>`_ mode for the `Haswell architecture <architecture_>`_ and `explicit vectorization <vectorize_>`_ of kernels.
+.. topic:: `Release <buildtarget_>`_ mode for the `Haswell architecture <install-architecture_>`_ and `explicit vectorization <install-vectorize_>`_ of kernels.
 
     .. code-block:: bash
 
         cmake -DARB_VECTORIZE=ON -DARB_ARCH=haswell
 
-.. topic:: `Release <buildtarget_>`_ mode with `explicit vectorization <vectorize_>`_, targeting the `Broadwell architecture <vectorize_>`_, with support for `P100 GPUs <gpu_>`_, and building with `GCC 6 <compilers_>`_.
+.. topic:: `Release <buildtarget_>`_ mode with `explicit vectorization <install-vectorize_>`_, targeting the `Broadwell architecture <install-vectorize_>`_, with support for `P100 GPUs <install-gpu_>`_, and building with `GCC 6 <install-compilers_>`_.
 
     .. code-block:: bash
 
@@ -245,7 +245,7 @@ CMake parameters and flags, follow links to the more detailed descriptions below
         export CXX=g++-6
         cmake -DARB_VECTORIZE=ON -DARB_ARCH=broadwell -DARB_WITH_GPU=ON
 
-.. topic:: `Release <buildtarget_>`_ mode with `explicit vectorization <vectorize_>`_, optimized for the `local system architecture <architecture_>`_ and `install <install_>`_ in ``/opt/arbor``
+.. topic:: `Release <buildtarget_>`_ mode with `explicit vectorization <install-vectorize_>`_, optimized for the `local system architecture <install-architecture_>`_ and `install <install_>`_ in ``/opt/arbor``
 
     .. code-block:: bash
 
@@ -264,7 +264,7 @@ with ``-g -O0`` flags), use the ``CMAKE_BUILD_TYPE`` CMake parameter.
 
     cmake -DCMAKE_BUILD_TYPE={debug,release}
 
-..  _architecture:
+..  _install-architecture:
 
 Architecture
 ------------
@@ -306,7 +306,7 @@ and `ARM options <https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html>`_.
      # IBM Power8
      cmake -DARB_ARCH=power8
 
-..  _vectorize:
+..  _install-vectorize:
 
 Vectorization
 -------------
@@ -324,7 +324,7 @@ With this flag set, the library will use architecture-specific vectorization int
 to implement these kernels. Arbor currently has vectorization support for x86 architectures
 with AVX, AVX2 or AVX512 ISA extensions, and for ARM architectures with support for AArch64 NEON intrinsics (first available on ARMv8-A).
 
-.. _gpu:
+.. _install-gpu:
 
 GPU Backend
 -----------
@@ -355,7 +355,7 @@ example:
     Arbor supports and has been tested on the Kepler (K20 & K80), Pascal (P100) and Volta (V100) GPUs
 
 
-.. _pythonfrontend:
+.. _install-python:
 
 Python Frontend
 ----------------
@@ -460,6 +460,8 @@ software, so we cover some common issues in this section.  If you have problems
 on your target system that are not covered here, please make an issue on the
 Arbor `Github issues <https://github.com/arbor-sim/arbor/issues>`_ page.
 We will do our best to help you directly, and update this guide to help other users.
+
+.. _install-mpi:
 
 MPI
 ---
@@ -730,7 +732,7 @@ CMake Git Submodule Warnings
 ----------------------------
 
 When running CMake, warnings like the following indicate that the Git submodules
-need to be `updated <downloading_>`_.
+need to be `updated <install-downloading_>`_.
 
 .. code-block:: none
 

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -9,15 +9,13 @@ The getting started guides will introduce Arbor via the Python interface.
 
 To test that Arbor is available, try the following in a `Python 3 <python2_>`_ interpreter:
 
-.. container:: example-code
+.. code-block:: python
 
-    .. code-block:: python
-
-        >>> import arbor
-        >>> print(arbor.__config__)
-        {'mpi': True, 'mpi4py': True, 'gpu': False, 'version': '0.2.3-dev'}
-        >>> print(arbor.__version__)
-        0.2.3-dev
+    >>> import arbor
+    >>> print(arbor.__config__)
+    {'mpi': True, 'mpi4py': True, 'gpu': False, 'version': '0.2.3-dev'}
+    >>> print(arbor.__version__)
+    0.2.3-dev
 
 The dictionary ``arbor.__config__`` contains information about the Arbor installation.
 This can be used to check that Arbor supports features that you require to run your model,
@@ -25,20 +23,11 @@ or even to dynamically decide how to run a model.
 Single cell models like do not require parallelism like
 that provided by MPI or GPUs, so the ``'mpi'`` and ``'gpu'`` fields can be ``False``.
 
-Installing
--------------
-
-Before starting Arbor needs to be installed with the Python interface enabled,
-following the :ref:`Python configuration <pythonfrontend>` in
-the
-:ref:`installation guide <installarbor>`.
-
-
 Performance
 --------------
 
-The Python interface can incur significant performance overheads relative to C++
-during the *model building* phase, however simulation performance is be the same
+The Python interface can incur significant memory and runtime overheads relative to C++
+during the *model building* phase, however simulation performance is the same
 for both interfaces.
 
 .. _python2:
@@ -50,6 +39,104 @@ Python 2 reached `end of life <https://pythonclock.org/>`_ in January 2020.
 Arbor only officially supports Python 3.6 and later, and all examples in the
 documentation are in Python 3. While it is possible to install and run Arbor
 using Python 2.7 by setting the ``PYTHON_EXECUTABLE`` variable when
-configuring CMake, support is only provided for using Arbor with Python 3.6
-and later.
+:ref:`configuring CMake <pythonfrontend>`, support is only provided for using
+Arbor with Python 3.6 and later.
+
+Installing
+-------------
+
+Before starting Arbor needs to be installed with the Python interface enabled.
+The easiest way to get started with the Python interface is to install Arbor using
+`pip <https://packaging.python.org/tutorials/installing-packages>`_.
+
+Installing with pip requires two steps:
+**(1)** Obtain Arbor source code from GitHub;
+**(2)** then use pip to compile and install the Arbor package in one shot.
+
+.. code-block:: bash
+
+    git clone https://github.com/arbor-sim/arbor.git --recursive
+    # use pip (recommended)
+    pip3 install ./arbor
+    # use setuptools and python directly
+    python3 install ./arbor/setup.py
+
+This will install Arbor as a site-wide package with only multi-threading enabled.
+
+To enable more advanced forms of parallelism, the following flags can optionally
+be passed to the pip install command:
+
+* ``--mpi``: enable mpi support (requires MPI library).
+* ``--gpu``: enable nvidia cuda support (requires cudaruntime and nvcc).
+* ``--vec``: enable vectorization. This might require carefully choosing the ``--arch`` flag.
+* ``--arch``: cpu micro-architecture to target. By default this is set to ``native``.
+
+If calling ``setup.py`` the flags must to come after ``install`` on the command line,
+and if being passed to pip they must be passed via ``--install-option``. The examples
+below demonstrate this for both pip and ``setup.py``, with pip being our recommend method.
+
+Vanilla install with no additional options/features enabled:
+
+.. code-block:: bash
+
+    pip3 install ./arbor
+    python3 ./arbor/setup.py install
+
+Enable MPI support. This might require loading an MPI module or setting the ``CC`` and ``CXX``
+environment flags.
+
+.. code-block:: bash
+
+    pip3 install --install-option='--mpi' ./arbor
+    python3 ./arbor/setup.py install --mpi
+
+Compile with vectorization on a system with SkyLake micro-archtecture:
+
+.. code-block:: bash
+
+    pip3 install --install-option='--vec' --install-option='--arch=skylake' ./arbor
+    python3 ./arbor/setup.py install --vec --arch=skylake
+
+Compile with support for NVIDIA GPUs. This requires that the CUDA toolkit is installed
+and the CUDA compiler nvcc is available:
+
+.. code-block:: bash
+
+    pip3 install --install-option='--gpu' ./arbor
+    python3 ./arbor/setup.py install --gpu
+
+.. Note::
+    Installation takes a while because pip has to compile the Arbor C++ library and
+    wrapper, which takes a few minutes. Pass the ``--verbose`` flag to pip
+    to see the individual steps being preformed if concerned that progress
+    is halting.
+
+.. Note::
+    Detailed instructions on how to install using CMake are in the
+    :ref:`Python configuration <pythonfrontend>` section of the
+    :ref:`installation guide <installarbor>`.
+    CMake is recommended for developers, integration with package managers such as
+    Spack and EasyBuild, and users who require fine grained control over compilation
+    and installation.
+
+.. Note::
+    If there is an error installing with pip you want to report,
+    run pip with the ``--verbose`` flag, and attach the output (along with
+    the pip command itself) to a ticket on the
+    `Arbor GitHub <https://github.com/arbor-sim/arbor/issues>`_.
+    For example, ``pip3 install --install-option='--mpi' --verbose .``.
+
+Dependencies
+^^^^^^^^^^^^^
+
+If a downstream dependency of Arbor that requires Arbor be built with
+a specific feature enabled, use ``requirements.txt`` to
+`define the constraints <https://pip.pypa.io/en/stable/reference/pip_install/#per-requirement-overrides>`_.
+For example, a package that depends on `arbor` would version 0.3 or later
+with MPI support would add the following to its requirements.
+
+.. code-block:: python
+
+    arbor >= 0.3 --install-option='--gpu' \
+                 --install-option='--mpi'
 

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -39,7 +39,7 @@ Python 2 reached `end of life <https://pythonclock.org/>`_ in January 2020.
 Arbor only officially supports Python 3.6 and later, and all examples in the
 documentation are in Python 3. While it is possible to install and run Arbor
 using Python 2.7 by setting the ``PYTHON_EXECUTABLE`` variable when
-:ref:`configuring CMake <pythonfrontend>`, support is only provided for using
+:ref:`configuring CMake <install-python>`, support is only provided for using
 Arbor with Python 3.6 and later.
 
 Installing
@@ -83,22 +83,23 @@ Vanilla install with no additional options/features enabled:
     python3 ./arbor/setup.py install
 
 Enable MPI support. This might require loading an MPI module or setting the ``CC`` and ``CXX``
-environment flags.
+:ref:`environment variables <install-mpi>`.
 
 .. code-block:: bash
 
     pip3 install --install-option='--mpi' ./arbor
     python3 ./arbor/setup.py install --mpi
 
-Compile with vectorization on a system with SkyLake micro-archtecture:
+Compile with :ref:`vectorization <install-vectorize>` on a system with SkyLake
+:ref:`architecture <install-architecture>`:
 
 .. code-block:: bash
 
     pip3 install --install-option='--vec' --install-option='--arch=skylake' ./arbor
     python3 ./arbor/setup.py install --vec --arch=skylake
 
-Compile with support for NVIDIA GPUs. This requires that the CUDA toolkit is installed
-and the CUDA compiler nvcc is available:
+Compile with support for NVIDIA GPUs. This requires that the :ref:`CUDA toolkit <install-gpu>`
+is installed and the CUDA compiler nvcc is available:
 
 .. code-block:: bash
 
@@ -113,7 +114,7 @@ and the CUDA compiler nvcc is available:
 
 .. Note::
     Detailed instructions on how to install using CMake are in the
-    :ref:`Python configuration <pythonfrontend>` section of the
+    :ref:`Python configuration <install-python>` section of the
     :ref:`installation guide <installarbor>`.
     CMake is recommended for developers, integration with package managers such as
     Spack and EasyBuild, and users who require fine grained control over compilation

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -6,10 +6,15 @@
 
 from ._arbor import *
 
-import os
+# Parse VERSION file for the Arbor version string.
+def get_version():
+    import os
+    here = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(here, 'VERSION')) as version_file:
+        return version_file.read().strip()
 
-here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'VERSION')) as version_file:
-    __version__ = version_file.read().strip()
+__version__ = get_version()
+__config__  = config()
 
-__config__ = config()
+# Remove get_version from arbor module.
+del get_version

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import setuptools
+import pathlib
+from setuptools import Extension
+from setuptools.command.build_ext import build_ext
+import subprocess
+
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'VERSION')) as version_file:
+    version_ = version_file.read().strip()
+
+class cmake_extension(Extension):
+    def __init__(self, name):
+        Extension.__init__(self, name, sources=[])
+
+class cmake_build(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError(
+                "CMake must be installed to build the following extensions: " +
+                ", ".join(e.name for e in self.extensions))
+
+        build_directory = os.path.abspath(self.build_temp)
+
+        cmake_args = [
+            '-DARB_WITH_PYTHON=on',
+            '-DPYTHON_EXECUTABLE=' + sys.executable
+        ]
+
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
+        cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+
+        # Assuming Makefiles
+        build_args += ['--', '-j4']
+
+        self.build_args = build_args
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{}'.format(env.get('CXXFLAGS', ''))
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+
+        # CMakeLists.txt is in the same directory as this setup.py file
+        cmake_list_dir = os.path.abspath(os.path.dirname(__file__))
+        print('-'*10, 'Running CMake prepare', '-'*40)
+        subprocess.check_call(['cmake', cmake_list_dir] + cmake_args,
+                              cwd=self.build_temp, env=env)
+
+        print('-'*10, 'Building extensions', '-'*40)
+        cmake_cmd = ['cmake', '--build', '.'] + self.build_args
+        print('CMake command: ', cmake_cmd)
+        subprocess.check_call(cmake_cmd,
+                              cwd=self.build_temp)
+
+        # Move from build temp to final position
+        for ext in self.extensions:
+            self.move_output(ext)
+
+    def move_output(self, ext):
+        build_temp = pathlib.Path(self.build_temp).resolve()
+        dest_path = pathlib.Path(self.get_ext_fullpath(ext.name)).resolve()
+        source_path = build_temp / self.get_ext_filename(ext.name)
+        print('build_temp: ', build_temp)
+        print('dest_path: ', dest_path)
+        print('source_path: ', source_path)
+        dest_directory = dest_path.parents[0]
+        dest_directory.mkdir(parents=True, exist_ok=True)
+        self.copy_file(source_path, dest_path)
+
+setuptools.setup(
+    name='arbor',
+    #packages=['arbor'],
+    version=version_,
+    #package_data={
+        #'arbor': ['VERSION', '_arbor.*.so'],
+    #},
+    python_requires='>=3.6',
+    install_requires=[],
+    setup_requires=[],
+    zip_safe=False,
+    ext_modules=[cmake_extension('arbor')],
+    cmdclass=dict(build_ext=cmake_build),
+
+    author='CSCS and FSJ',
+    url='https://github.com/arbor-sim/arbor',
+    description='High performance simulation of networks of multicompartment neurons.',
+    long_description='',
+    classifiers=[
+        'Development Status :: 4 - Beta', # Upgrade to "5 - Production/Stable" on release.
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: Build Tools',
+        'License :: OSI Approved :: BSD License'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+    project_urls={
+        'Source': 'https://github.com/arbor-sim/arbor',
+        'Documentation': 'https://arbor.readthedocs.io',
+        'Bug Reports': 'https://github.com/arbor-sim/arbor/issues',
+    },
+)
+

--- a/setup.py
+++ b/setup.py
@@ -75,9 +75,6 @@ class cmake_build(build_ext):
         # can copy it into the target 'prefix' path.
         dest_path = lib_directory + '/arbor'
 
-        #print('-'*5, 'command line options:\n  mpi {}\n  gpu {}\n  vectorize {}\n  arch {}'.format(opt_mpi, opt_gpu, opt_vec, opt_arch))
-        print('-'*5, 'command line options: {}'.format(cl_opt))
-
         cmake_args = [
             '-DARB_WITH_PYTHON=on',
             '-DPYTHON_EXECUTABLE=' + sys.executable,
@@ -86,6 +83,8 @@ class cmake_build(build_ext):
             '-DARB_VECTORIZE={}'.format('on' if cl_opt['vec'] else 'off'),
             '-DARB_ARCH={}'.format(cl_opt['arch']),
         ]
+
+        print('-'*5, 'command line options: {}'.format(cl_opt))
         print('-'*5, 'cmake arguments: {}'.format(cmake_args))
 
         cfg = 'Debug' if self.debug else 'Release'
@@ -114,7 +113,7 @@ class cmake_build(build_ext):
         subprocess.check_call(cmake_cmd,
                               cwd=self.build_temp)
 
-        # Move from build path to some other place from whence it will later be installed.
+        # Copy from build path to some other place from whence it will later be installed.
         # ... or something like that
         # ... setuptools is an enigma monkey patched on a mystery
         if not os.path.exists(dest_path):

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,22 @@ class cmake_build(build_ext):
         if not check_cmake():
             raise RuntimeError('CMake is not available. CMake 3.12 is required.')
 
+        # cl_opt contains the command line arguments passed to install, via
+        # --install-option if using pip.
+        # pip skips building wheels when --install-option flags are set.
+        # However, when no --install-options are passed, it runs build_ext
+        # without running install_command, required to create and set cl_opt.
+        # This hack works around this. I think that the upshot of this is
+        # that only wheels built with default configuration will be possible.
+
+        if 'cl_opt' not in globals():
+            cl_opt = {
+                    'mpi': False,
+                    'gpu': False,
+                    'vec': False,
+                    'arch': 'native'
+            }
+
         # The path where CMake will be configured and Arbor will be built.
         build_directory = os.path.abspath(self.build_temp)
         # The path where the package will be copied after building.


### PR DESCRIPTION
Add a `setup.py` for installing Arbor directly with pip/setuptools.

Implement a setuptools extension for CMake in `setup.py`. To be honest, I don't understand entirely how it works, but setuptools is obtuse enough that I don't feel at all guilty about this.

Define additional flags for optionally enabling GPUs, MPI, Vectorization and micro-architecture targets, for more adventurous users.

The documentation is updated with a "howto pip" for more casual users who don't want anything to do with CMake.

Fixes #958 .