### PR TITLE
Implement mextent representation for concrete regions

### DIFF
--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -94,10 +94,13 @@ struct cable_cell_impl {
 
     template <typename Property>
     void paint(const region& reg, const Property& prop) {
-        mcable_list cables = thingify(reg, provider);
+        mextent cables = thingify(reg, provider);
         auto& mm = get_region_map(prop);
 
         for (auto c: cables) {
+            // Skip zero-length cables in extent:
+            if (c.prox_pos==c.dist_pos) continue;
+
             if (!mm.insert(c, prop)) {
                 throw cable_cell_error(util::pprintf("cable {} overpaints", c));
             }
@@ -108,7 +111,7 @@ struct cable_cell_impl {
         return thingify(l, provider);
     }
 
-    mcable_list concrete_region(const region& r) const {
+    mextent concrete_region(const region& r) const {
         return thingify(r, provider);
     }
 };
@@ -145,7 +148,7 @@ mlocation_list cable_cell::concrete_locset(const locset& l) const {
     return impl_->concrete_locset(l);
 }
 
-mcable_list cable_cell::concrete_region(const region& r) const {
+mextent cable_cell::concrete_region(const region& r) const {
     return impl_->concrete_region(r);
 }
 

--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -182,7 +182,7 @@ public:
     mlocation_list concrete_locset(const locset&) const;
 
     // Access to a concrete list of cable segments for a region.
-    mcable_list concrete_region(const region&) const;
+    mextent concrete_region(const region&) const;
 
     // Generic access to painted and placed items.
     const cable_cell_region_map& region_assignments() const;

--- a/arbor/include/arbor/morph/morphexcept.hpp
+++ b/arbor/include/arbor/morph/morphexcept.hpp
@@ -26,6 +26,10 @@ struct invalid_mcable: morphology_error {
     mcable cable;
 };
 
+struct invalid_mcable_list: morphology_error {
+    invalid_mcable_list();
+};
+
 struct invalid_sample_parent: morphology_error {
     invalid_sample_parent(msize_t parent, msize_t tree_size);
     msize_t parent;

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -36,9 +36,11 @@ public:
     msize_t num_samples() const;
 
     // The parent branch of branch b.
+    // Return mnpos if branch has no parent.
     msize_t branch_parent(msize_t b) const;
 
     // The child branches of branch b.
+    // If b is mnpos, return root branches.
     const std::vector<msize_t>& branch_children(msize_t b) const;
 
     // Branches with no children.
@@ -63,5 +65,68 @@ public:
 mlocation_list minset(const morphology&, const mlocation_list&);
 
 mlocation canonical(const morphology&, mlocation);
+
+// Represent a (possibly empty or disconnected) region on a morphology.
+// Wraps an mcable_list, and satisfies the additional constraints:
+//
+//    I.  Any two cables on the same branch are strictly disjoint, i.e.
+//        for cables p and q on the same branch, either p.prox_pos > q.dist_pos
+//        or p.dist_pos < q.prox_pos.
+//
+//    II. For any branch b on the morphology tree that intersects the subset
+//        described by the extent, there exists a cable in the extent defined
+//        on this branch b.
+//
+// While an mextent can only be built from an mcable_list in conjunction with
+// a morphology, union, intersection, and location membership operations can
+// be performed without one.
+struct mextent {
+    mextent() = default;
+    mextent(const mextent&) = default;
+    mextent(mextent&&) = default;
+
+    mextent& operator=(const mextent&) = default;
+    mextent& operator=(mextent&&) = default;
+
+    mextent(const morphology&, const mcable_list&);
+
+    bool test_invariants() const; // check invariant (I) above.
+    bool test_invariants(const morphology&) const; // check invariants (I) and (II) above.
+
+    const mcable_list& cables() const {
+        return cables_;
+    }
+
+    bool operator==(const mextent& a) const { return cables_==a.cables_; }
+    bool operator!=(const mextent& a) const { return cables_!=a.cables_; }
+
+    bool intersects(const mcable_list& a) const;
+    bool intersects(const mcable& a) const { return intersects(mcable_list{a}); }
+
+    bool intersects(const mextent& a) const {
+        return intersects(a.cables());
+    }
+    bool intersects(mlocation loc) const {
+        return intersects(mcable{loc.branch, loc.pos, loc.pos});
+    }
+
+    friend mextent intersect(const mextent& a, const mextent& b);
+    friend mextent join(const mextent& a, const mextent& b);
+
+    // Forward const container operations:
+    decltype(auto) cbegin() const { return cables_.begin(); }
+    decltype(auto) begin() const { return cables_.begin(); }
+    decltype(auto) cend() const { return cables_.end(); }
+    decltype(auto) end() const { return cables_.end(); }
+
+    bool empty() const { return cables_.empty(); }
+    std::size_t size() const { return cables_.size(); }
+    const mcable& front() const { return cables_.front(); }
+    const mcable& back() const { return cables_.back(); }
+
+private:
+    mcable_list cables_;
+};
+
 
 } // namespace arb

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -114,9 +114,9 @@ struct mextent {
     friend mextent join(const mextent& a, const mextent& b);
 
     // Forward const container operations:
-    decltype(auto) cbegin() const { return cables_.begin(); }
+    decltype(auto) cbegin() const { return cables_.cbegin(); }
     decltype(auto) begin() const { return cables_.begin(); }
-    decltype(auto) cend() const { return cables_.end(); }
+    decltype(auto) cend() const { return cables_.cend(); }
     decltype(auto) end() const { return cables_.end(); }
 
     bool empty() const { return cables_.empty(); }

--- a/arbor/include/arbor/morph/mprovider.hpp
+++ b/arbor/include/arbor/morph/mprovider.hpp
@@ -17,7 +17,7 @@ struct mprovider {
     explicit mprovider(arb::morphology m): mprovider(m, nullptr) {}
 
     // Throw exception on missing or recursive definition.
-    const mcable_list& region(const std::string& name) const;
+    const mextent& region(const std::string& name) const;
     const mlocation_list& locset(const std::string& name) const;
 
     // Read-only access to morphology and constructed embedding.
@@ -34,7 +34,7 @@ private:
     struct circular_def {};
 
     // Maps are mutated only during initialization phase of mprovider.
-    mutable std::unordered_map<std::string, util::either<mcable_list, circular_def>> regions_;
+    mutable std::unordered_map<std::string, util::either<mextent, circular_def>> regions_;
     mutable std::unordered_map<std::string, util::either<mlocation_list, circular_def>> locsets_;
 
     // Non-null only during initialization phase.

--- a/arbor/include/arbor/morph/primitives.hpp
+++ b/arbor/include/arbor/morph/primitives.hpp
@@ -83,6 +83,11 @@ mlocation_list join(const mlocation_list&, const mlocation_list&);
 mlocation_list intersection(const mlocation_list&, const mlocation_list&);
 
 // Describe an unbranched cable in the morphology.
+//
+// Cables are a representation of a closed interval of a branch in a morphology.
+// They may be zero-length, and fork points in the morphology may have multiple,
+// equivalent zero-length cable representations.
+
 struct mcable {
     // The id of the branch on which the cable lies.
     msize_t branch;

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -53,15 +53,16 @@ public:
         return *this;
     }
 
-    // Implicit conversion from mcable or mcable_list.
+    // Implicit conversion from mcable, mcable_list, or mextent.
     region(mcable);
-    region(const mcable_list&);
+    region(mextent);
+    region(mcable_list);
 
     // Implicitly convert string to named region expression.
     region(std::string label);
     region(const char* label);
 
-    friend mcable_list thingify(const region& r, const mprovider& m) {
+    friend mextent thingify(const region& r, const mprovider& m) {
         return r.impl_->thingify(m);
     }
 
@@ -90,7 +91,7 @@ private:
         virtual ~interface() {}
         virtual std::unique_ptr<interface> clone() = 0;
         virtual std::ostream& print(std::ostream&) = 0;
-        virtual mcable_list thingify(const mprovider&) = 0;
+        virtual mextent thingify(const mprovider&) = 0;
     };
 
     std::unique_ptr<interface> impl_;
@@ -104,7 +105,7 @@ private:
             return std::unique_ptr<interface>(new wrap<Impl>(wrapped));
         }
 
-        virtual mcable_list thingify(const mprovider& m) override {
+        virtual mextent thingify(const mprovider& m) override {
             return thingify_(wrapped, m);
         }
 

--- a/arbor/morph/morphexcept.cpp
+++ b/arbor/morph/morphexcept.cpp
@@ -25,6 +25,10 @@ invalid_mcable::invalid_mcable(mcable cable):
     cable(cable)
 {}
 
+invalid_mcable_list::invalid_mcable_list():
+    morphology_error("bad mcable_list")
+{}
+
 invalid_sample_parent::invalid_sample_parent(msize_t parent, msize_t tree_size):
     morphology_error(pprintf("invalid sample parent {} for a sample tree of size {}", parent, tree_size)),
     parent(parent),

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -287,14 +287,14 @@ mlocation canonical(const morphology& m, mlocation loc) {
 mcable_list build_mextent_cables(const morphology& m, const mcable_list& cables) {
     arb_assert(test_invariants(cables));
 
-    std::unordered_set<msize_t> branch_heads, branch_tails;
+    std::unordered_set<msize_t> branch_tails;
 
     mcable_list cs;
     for (auto& c: cables) {
         mcable* prev = cs.empty()? nullptr: &cs.back();
 
         if (c.prox_pos==0) {
-            branch_heads.insert(c.branch);
+            branch_tails.insert(m.branch_parent(c.branch));
         }
         if (c.dist_pos==1) {
             branch_tails.insert(c.branch);
@@ -308,12 +308,8 @@ mcable_list build_mextent_cables(const morphology& m, const mcable_list& cables)
         }
     }
 
-    if (!branch_heads.empty() || !branch_tails.empty()) {
+    if (!branch_tails.empty()) {
         std::vector<mcable> fork_covers;
-
-        for (auto b: branch_heads) {
-            branch_tails.insert(m.branch_parent(b));
-        }
 
         for (auto b: branch_tails) {
             if (b!=mnpos) fork_covers.push_back(mcable{b, 1., 1.});

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -8,13 +8,14 @@
 #include <arbor/morph/primitives.hpp>
 
 #include "morph/mbranch.hpp"
+#include "util/mergeview.hpp"
 #include "util/rangeutil.hpp"
 #include "util/span.hpp"
 
 using arb::util::make_span;
 
 namespace arb {
-namespace impl{
+namespace impl {
 
 std::vector<mbranch> branches_from_parent_index(const std::vector<msize_t>& parents,
                                                 const std::vector<point_prop>& props,
@@ -277,6 +278,209 @@ mlocation canonical(const morphology& m, mlocation loc) {
         return parent==mnpos? mlocation{0, 0.}: mlocation{parent, 1.};
     }
     return loc;
+}
+
+// Constructing an mextent from an mcable_list consists of taking the union
+// of any intersecting cables, and adding any required zero-length cables
+// around fork-points.
+
+mcable_list build_mextent_cables(const morphology& m, const mcable_list& cables) {
+    arb_assert(test_invariants(cables));
+
+    std::unordered_set<msize_t> branch_heads, branch_tails;
+
+    mcable_list cs;
+    for (auto& c: cables) {
+        mcable* prev = cs.empty()? nullptr: &cs.back();
+
+        if (c.prox_pos==0) {
+            branch_heads.insert(c.branch);
+        }
+        if (c.dist_pos==1) {
+            branch_tails.insert(c.branch);
+        }
+
+        if (prev && prev->branch==c.branch && prev->dist_pos>=c.prox_pos) {
+            prev->dist_pos = std::max(prev->dist_pos, c.dist_pos);
+        }
+        else {
+            cs.push_back(c);
+        }
+    }
+
+    if (!branch_heads.empty() || !branch_tails.empty()) {
+        std::vector<mcable> fork_covers;
+
+        for (auto b: branch_heads) {
+            branch_tails.insert(m.branch_parent(b));
+        }
+
+        for (auto b: branch_tails) {
+            if (b!=mnpos) fork_covers.push_back(mcable{b, 1., 1.});
+            for (auto b_child: m.branch_children(b)) {
+                fork_covers.push_back(mcable{b_child, 0., 0.});
+            }
+        }
+        util::sort(fork_covers);
+
+        // Merge cables in cs with 0-length cables corresponding to fork covers.
+        mcable_list a;
+        a.swap(cs);
+
+        for (auto c: util::merge_view(a, fork_covers)) {
+            mcable* prev = cs.empty()? nullptr: &cs.back();
+
+            if (prev && prev->branch==c.branch && prev->dist_pos>=c.prox_pos) {
+                prev->dist_pos = std::max(prev->dist_pos, c.dist_pos);
+            }
+            else {
+                cs.push_back(c);
+            }
+        }
+    }
+
+    return cs;
+
+}
+
+mextent::mextent(const morphology& m, const mcable_list& cables):
+    cables_(build_mextent_cables(m, cables)) {}
+
+bool mextent::test_invariants() const {
+    // Checks for sortedness:
+    if (!arb::test_invariants(cables_)) return false;
+
+    // Check for intersections:
+    for (auto i: util::count_along(cables_)) {
+        if (!i) continue;
+
+        const auto& c = cables_[i];
+        const auto& p = cables_[i-1];
+        if (p.branch==c.branch && p.dist_pos>=c.prox_pos) return false;
+    }
+
+    return true;
+}
+
+bool mextent::test_invariants(const morphology& m) const {
+    // Check for sortedness, intersections:
+    if (!test_invariants()) return false;
+
+    // Too many branches?
+    if (!empty() && cables_.back().branch>=m.num_branches()) return false;
+
+    // Gather branches which are covered at the proximal or distal end:
+    std::unordered_set<msize_t> branch_heads, branch_tails;
+    for (auto& c: cables_) {
+        if (c.prox_pos==0) branch_heads.insert(c.branch);
+        if (c.dist_pos==1) branch_tails.insert(c.branch);
+    }
+
+    // There should be an entry in branch_tails for parent(j) for all j
+    // in branch_heads, and an entry j in branch_heads for every j
+    // with parent(j) in branch_tails.
+
+    for (auto b: branch_heads) {
+        msize_t parent = m.branch_parent(b);
+        if (parent==mnpos) {
+            branch_tails.insert(mnpos);
+        }
+        else if (!branch_tails.count(parent)) {
+            return false;
+        }
+    }
+
+    for (auto b: branch_tails) {
+        for (auto child: m.branch_children(b)) {
+            if (!branch_heads.count(child)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool mextent::intersects(const mcable_list& a) const {
+    // Early exit?
+    if (empty() || a.empty() ||
+        cables_.front().branch>a.back().branch ||
+        cables_.back().branch<a.front().branch)
+    {
+        return false;
+    }
+
+    auto from = cables_.begin();
+    for (auto& c: a) {
+        auto i = std::lower_bound(from, cables_.end(), c);
+
+        if (i!=cables_.end() && i->branch==c.branch) {
+            arb_assert(i->prox_pos>=c.prox_pos);
+            if (i->prox_pos<=c.dist_pos) return true;
+        }
+
+        if (i!=cables_.begin()) {
+           auto j = std::prev(i);
+           if (j->branch==c.branch) {
+               arb_assert(j->prox_pos<c.prox_pos);
+               if (j->dist_pos>=c.prox_pos) return true;
+           }
+        }
+
+        from = i;
+    }
+
+    return false;
+}
+
+mextent intersect(const mextent& a, const mextent& b) {
+    auto precedes = [](mcable x, mcable y) {
+        return x.branch<y.branch || (x.branch==y.branch && x.dist_pos<y.prox_pos);
+    };
+
+    mextent m;
+    auto ai = a.cables().begin();
+    auto ae = a.cables().end();
+    auto bi = b.cables().begin();
+    auto be = b.cables().end();
+
+    while (ai!=ae && bi!=be) {
+        if (precedes(*ai, *bi)) {
+            ++ai;
+        }
+        else if (precedes(*bi, *ai)) {
+            ++bi;
+        }
+        else {
+            m.cables_.push_back(mcable{ai->branch,
+                std::max(ai->prox_pos, bi->prox_pos),
+                std::min(ai->dist_pos, bi->dist_pos)});
+            if (ai->dist_pos<bi->dist_pos) {
+                ++ai;
+            }
+            else {
+                ++bi;
+            }
+        }
+    }
+    return m;
+}
+
+mextent join(const mextent& a, const mextent& b) {
+    mextent m;
+    mcable_list& cs = m.cables_;
+
+    for (auto c: util::merge_view(a.cables(), b.cables())) {
+        mcable* prev = cs.empty()? nullptr: &cs.back();
+
+        if (prev && prev->branch==c.branch && prev->dist_pos>=c.prox_pos) {
+            prev->dist_pos = std::max(prev->dist_pos, c.dist_pos);
+        }
+        else {
+            cs.push_back(c);
+        }
+    }
+    return m;
 }
 
 } // namespace arb

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -285,7 +285,7 @@ mlocation canonical(const morphology& m, mlocation loc) {
 // around fork-points.
 
 mcable_list build_mextent_cables(const morphology& m, const mcable_list& cables) {
-    arb_assert(test_invariants(cables));
+    arb_assert(arb::test_invariants(cables));
 
     std::unordered_set<msize_t> branch_tails;
 
@@ -398,6 +398,8 @@ bool mextent::test_invariants(const morphology& m) const {
 }
 
 bool mextent::intersects(const mcable_list& a) const {
+    arb_assert(arb::test_invariants(a));
+
     // Early exit?
     if (empty() || a.empty() ||
         cables_.front().branch>a.back().branch ||

--- a/arbor/morph/mprovider.cpp
+++ b/arbor/morph/mprovider.cpp
@@ -61,7 +61,7 @@ static const auto& try_lookup(const mprovider& provider, const std::string& name
     }
 }
 
-const mcable_list& mprovider::region(const std::string& name) const {
+const mextent& mprovider::region(const std::string& name) const {
     const auto* regions_ptr = label_dict_ptr? &(label_dict_ptr->regions()): nullptr;
     return try_lookup(*this, name, regions_, regions_ptr, circular_def{});
 }

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -580,15 +580,6 @@ struct reg_or: region_tag {
 mextent thingify_(const reg_or& P, const mprovider& p) {
     return join(thingify(P.lhs, p), thingify(P.rhs, p));
 }
-#if 0
-    mcable_list L;
-    L.resize(lhs.size() + rhs.size());
-
-    std::merge(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), L.begin());
-
-    return merge(L);
-}
-#endif
 
 std::ostream& operator<<(std::ostream& o, const reg_or& x) {
     return o << "(join " << x.lhs << " " << x.rhs << ")";

--- a/arbor/util/iterutil.hpp
+++ b/arbor/util/iterutil.hpp
@@ -89,10 +89,11 @@ decltype(auto) back(Seq& seq) {
  * present rvalues on dereference.
  */
 template <typename V>
-struct pointer_proxy: public V {
-    pointer_proxy(const V& v): V(v) {}
-    pointer_proxy(V&& v): V(std::move(v)) {}
-    const V* operator->() const { return this; }
+struct pointer_proxy {
+    V v;
+    pointer_proxy(const V& v): v(v) {}
+    pointer_proxy(V&& v): v(std::move(v)) {}
+    const V* operator->() const { return &v; }
 };
 
 /*

--- a/arbor/util/mergeview.hpp
+++ b/arbor/util/mergeview.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <iterator>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+#include "util/iterutil.hpp"
+#include "util/meta.hpp"
+#include "util/range.hpp"
+
+namespace arb {
+namespace util {
+
+template <typename A, typename B, typename = void>
+struct has_common_type: std::false_type {};
+
+template <typename A, typename B>
+struct has_common_type<A, B, util::void_t<std::common_type_t<A, B>>>: std::true_type {};
+
+template <typename A, typename B, typename X, typename = void>
+struct common_type_or_else { using type = X; };
+
+template <typename A, typename B, typename X>
+struct common_type_or_else<A, B, X, util::void_t<std::common_type_t<A, B>>> {
+    using type = std::common_type_t<A, B>;
+};
+
+template <typename A, typename B, typename X>
+using common_type_or_else_t = typename common_type_or_else<A, B, X>::type;
+
+template <typename LeftI, typename LeftS, typename RightI, typename RightS>
+class merge_iterator {
+    mutable LeftI left_;
+    mutable RightI right_;
+
+    LeftS left_sentinel_;
+    RightS right_sentinel_;
+
+    mutable enum which {
+        undecided, left_next, right_next, done
+    } next_ = undecided;
+
+    void resolve_next() const {
+        if (next_!=undecided) return;
+
+        if (left_==left_sentinel_) {
+            next_ = right_==right_sentinel_? done: right_next;
+        }
+        else if (right_==right_sentinel_) {
+            next_ = left_next;
+        }
+        else {
+            next_ = *left_<*right_? left_next: right_next;
+        }
+    }
+
+public:
+    using value_type = std::common_type_t<
+        typename std::iterator_traits<LeftI>::value_type,
+        typename std::iterator_traits<RightI>::value_type>;
+
+    using pointer = common_type_or_else_t<LeftI, RightI, pointer_proxy<value_type>>;
+
+    using reference = std::conditional_t<
+        has_common_type<LeftI, RightI>::value,
+        typename std::iterator_traits<common_type_or_else_t<LeftI, RightI, char*>>::reference,
+        value_type>;
+
+    using difference_type = typename std::iterator_traits<LeftI>::difference_type;
+    using iterator_category = std::forward_iterator_tag;
+
+    merge_iterator(): next_(done) {}
+
+    template <typename LSeq, typename RSeq>
+    merge_iterator(LSeq&& lseq, RSeq&& rseq) {
+        using std::begin;
+        using std::end;
+
+        left_ = begin(lseq);
+        left_sentinel_ = end(lseq);
+        right_ = begin(rseq);
+        right_sentinel_ = end(rseq);
+    }
+
+    bool operator==(const merge_iterator& x) const {
+        resolve_next();
+        x.resolve_next();
+
+        if (next_==done && x.next_==done) return true;
+        return next_==x.next_ && left_==x.left_ && right_==x.right_;
+    }
+
+    bool operator!=(const merge_iterator& x) const { return !(*this==x); }
+
+    reference operator*() const {
+        resolve_next();
+
+        switch (next_) {
+        case left_next: return *left_;
+        case right_next: return *right_;
+        default:
+            throw std::range_error("derefence past end of sequence");
+        }
+    }
+
+    template <typename L = LeftI, typename R = RightI,
+              typename = std::enable_if_t<has_common_type<L, R>::value>>
+    std::common_type_t<L, R> operator->() const {
+        resolve_next();
+        return next_==left_next? left_: right_;
+    }
+
+    template <typename L = LeftI, typename R = RightI,
+              typename = std::enable_if_t<!has_common_type<L, R>::value>>
+    pointer_proxy<value_type> operator->() const {
+        return pointer_proxy<value_type>(*this);
+    }
+
+    merge_iterator& operator++() {
+        resolve_next();
+
+        switch (next_) {
+        case undecided:
+            throw std::logic_error("internal error: unexpected undecided");
+        case done: return *this;
+        case left_next:
+            ++left_;
+            break;
+        case right_next:
+            ++right_;
+            break;
+        }
+        next_ = undecided;
+        return *this;
+    }
+
+    merge_iterator& operator++(int) {
+        auto me = *this;
+        ++*this;
+        return me;
+    }
+
+    merge_iterator& operator=(const merge_iterator&) = default;
+};
+
+template <typename LSeq, typename RSeq>
+auto merge_view(LSeq&& left, RSeq&& right) {
+    using std::begin;
+    using std::end;
+    using LIter = decltype(begin(left));
+    using LSentinel = decltype(end(left));
+    using RIter = decltype(begin(right));
+    using RSentinel = decltype(end(right));
+    using MIter = merge_iterator<LIter, LSentinel, RIter, RSentinel>;
+
+    return make_range(MIter(left, right), MIter());
+}
+
+
+} // namespace util
+} // namespace arb
+

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -112,6 +112,7 @@ set(unit_sources
     test_mechcat.cpp
     test_mechinfo.cpp
     test_merge_events.cpp
+    test_merge_view.cpp
     test_morphology.cpp
     test_morph_embedding.cpp
     test_morph_expr.cpp

--- a/test/unit/morph_pred.hpp
+++ b/test/unit/morph_pred.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+// Predicates for morphology testing.
+
+#include "../gtest.h"
+
+#include <arbor/morph/morphology.hpp>
+#include <arbor/morph/primitives.hpp>
+#include <arbor/morph/region.hpp>
+
+#include "util/span.hpp"
+
+namespace testing {
+
+inline ::testing::AssertionResult mlocation_eq(arb::mlocation a, arb::mlocation b) {
+    if (a.branch!=b.branch) {
+        return ::testing::AssertionFailure()
+                << "cables " << a << " and " << b << " differ";
+    }
+
+    using FP = testing::internal::FloatingPoint<double>;
+    if (FP(a.pos).AlmostEquals(FP(b.pos))) {
+        return ::testing::AssertionSuccess();
+    }
+    else {
+        return ::testing::AssertionFailure()
+                << "mlocations " << a << " and " << b << " differ";
+    }
+}
+
+inline ::testing::AssertionResult cable_eq(arb::mcable a, arb::mcable b) {
+    if (a.branch!=b.branch) {
+        return ::testing::AssertionFailure()
+            << "cables " << a << " and " << b << " differ";
+    }
+
+    using FP = testing::internal::FloatingPoint<double>;
+    if (FP(a.prox_pos).AlmostEquals(FP(b.prox_pos)) && FP(a.dist_pos).AlmostEquals(FP(b.dist_pos))) {
+        return ::testing::AssertionSuccess();
+    }
+    else {
+        return ::testing::AssertionFailure()
+            << "cables " << a << " and " << b << " differ";
+    }
+}
+
+inline ::testing::AssertionResult cablelist_eq(const arb::mcable_list& as, const arb::mcable_list& bs) {
+    if (as.size()!=bs.size()) {
+        return ::testing::AssertionFailure()
+            << "cablelists " << as << " and " << bs << " differ";
+    }
+
+    for (auto i: arb::util::count_along(as)) {
+        auto result = cable_eq(as[i], bs[i]);
+        if (!result) return ::testing::AssertionFailure()
+            << "cablelists " << as << " and " << bs << " differ";
+    }
+    return ::testing::AssertionSuccess();
+}
+
+inline ::testing::AssertionResult extent_eq(const arb::mextent& xa, const arb::mextent& xb) {
+    return cablelist_eq(xa.cables(), xb.cables());
+}
+
+inline ::testing::AssertionResult region_eq(const arb::mprovider& p, arb::region a, arb::region b) {
+    return extent_eq(thingify(a, p), thingify(b, p));
+}
+
+inline ::testing::AssertionResult mlocationlist_eq(const arb::mlocation_list& as, const arb::mlocation_list& bs) {
+    if (as.size()!=bs.size()) {
+        return ::testing::AssertionFailure()
+                << "cablelists " << as << " and " << bs << " differ";
+    }
+
+    for (auto i: arb::util::count_along(as)) {
+        auto result = mlocation_eq(as[i], bs[i]);
+        if (!result) return ::testing::AssertionFailure()
+                    << "mlocation lists " << as << " and " << bs << " differ";
+    }
+    return ::testing::AssertionSuccess();
+}
+
+} // namespace testing
+

--- a/test/unit/test_cv_geom.cpp
+++ b/test/unit/test_cv_geom.cpp
@@ -30,6 +30,10 @@ TEST(cv_geom, empty) {
     EXPECT_EQ(1u, geom.n_cell()); // can have no CVs but >0 cells.
 }
 
+static bool region_eq(const mprovider& p, region a, region b) {
+    return thingify(a, p)==thingify(b, p);
+}
+
 TEST(cv_geom, trivial) {
     using namespace common_morphology;
 
@@ -57,8 +61,8 @@ TEST(cv_geom, trivial) {
             EXPECT_EQ(geom1.cv_cables, geom4.cv_cables);
         }
 
-        mcable_list all_cables = thingify(reg::all(), cell.provider());
-        EXPECT_TRUE(testing::seq_eq(all_cables, geom1.cables(0)));
+        mcable_list geom1_cables = util::assign_from(geom1.cables(0));
+        EXPECT_TRUE(region_eq(cell.provider(), reg::all(), geom1_cables));
     }
 }
 

--- a/test/unit/test_merge_view.cpp
+++ b/test/unit/test_merge_view.cpp
@@ -1,0 +1,111 @@
+#include "../gtest.h"
+
+#include <forward_list>
+#include <vector>
+
+#include <util/mergeview.hpp>
+
+#include "common.hpp"
+
+using namespace arb;
+
+static auto cstr_range(const char* b) { return util::make_range(b, testing::null_terminated); }
+
+TEST(mergeview, ctor_eq_iter) {
+    using std::begin;
+    using std::end;
+
+    // Make view from sequences with the same iterator types.
+    {
+        int a[3] = {1, 3, 5};
+        int b[3] = {2, 4, 7};
+
+        auto merged = util::merge_view(a, b);
+        EXPECT_TRUE((std::is_same<decltype(merged.begin())::pointer, int*>::value));
+    }
+
+    {
+        const char c[5] = "fish";
+        const char* x = "cakes";
+
+        auto merged = util::merge_view(c, cstr_range(x));
+        EXPECT_TRUE((std::is_same<decltype(merged.begin())::pointer, const char*>::value));
+    }
+}
+
+TEST(mergeview, ctor_eq_compat) {
+    // Make view from sequences with compatible iterator types.
+    {
+        int a[3] = {1, 3, 5};
+        const int b[3] = {2, 4, 7};
+
+        auto merged = util::merge_view(a, b);
+        EXPECT_TRUE((std::is_same<decltype(merged.begin())::pointer, const int*>::value));
+    }
+
+    {
+        const std::vector<int> a = {1, 3, 5};
+        std::vector<int> b = {2, 4, 6};
+
+        auto merged = util::merge_view(a, b);
+        EXPECT_TRUE((std::is_same<decltype(merged.begin())::pointer, std::vector<int>::const_iterator>::value));
+    }
+}
+
+TEST(mergeview, ctor_value_compat) {
+    // Make view from sequences with compatible value types.
+    int a[3] = {1, 3, 5};
+    double b[3] = {2, 4, 7};
+
+    auto merged = util::merge_view(a, b);
+    EXPECT_TRUE((std::is_same<std::decay_t<decltype(*merged.begin())>, double>::value));
+}
+
+TEST(mergeview, empty) {
+    std::vector<int> a, b;
+    auto merged = util::merge_view(a, b);
+    EXPECT_EQ(0, std::distance(merged.begin(), merged.end()));
+
+    b = {1, 3, 4};
+    merged = util::merge_view(a, b);
+    EXPECT_EQ(3, std::distance(merged.begin(), merged.end()));
+    EXPECT_TRUE(testing::seq_eq(merged, b));
+
+    std::swap(a, b);
+    merged = util::merge_view(a, b);
+    EXPECT_EQ(3, std::distance(merged.begin(), merged.end()));
+    EXPECT_TRUE(testing::seq_eq(merged, a));
+}
+
+TEST(mergeview, merge) {
+    int a[] = {1, 3, 5};
+    double b[] = {1., 2.5, 7.};
+    double expected[] = {1., 1., 2.5, 3., 5., 7.};
+
+    EXPECT_TRUE(testing::seq_eq(expected, util::merge_view(a, b)));
+    EXPECT_TRUE(testing::seq_eq(expected, util::merge_view(b, a)));
+}
+
+TEST(mergeview, iter_ptr) {
+    struct X {
+        X(double v): v(v) {}
+        double v;
+        bool written = false;
+        void write(std::vector<double>& buf) { written = true; buf.push_back(v); }
+
+        bool operator<(X b) const { return v<b.v; }
+    };
+
+    std::vector<double> out;
+    X a[] = {2., 4., 4., 6.};
+    X b[] = {5., 9.};
+
+    auto merged = util::merge_view(a, b);
+    for (auto i = merged.begin(); i!=merged.end(); ++i) {
+        i->write(out);
+    }
+
+    EXPECT_EQ((std::vector<double>{2., 4., 4., 5., 6., 9.}), out);
+    for (auto& x: a) EXPECT_TRUE(x.written);
+    for (auto& x: b) EXPECT_TRUE(x.written);
+}

--- a/test/unit/test_morphology.cpp
+++ b/test/unit/test_morphology.cpp
@@ -13,6 +13,8 @@
 #include "morph/mbranch.hpp"
 #include "util/span.hpp"
 
+#include "morph_pred.hpp"
+
 // Test basic functions on properties of mpoint
 TEST(morphology, mpoint) {
     using mp = arb::mpoint;
@@ -631,3 +633,104 @@ TEST(morphology, minset) {
     }
 }
 
+// Testing mextent; intersection and join operations are
+// exercised by region/locset thingifies in test_morph_expr.cpp.
+
+TEST(mextent, invariants) {
+    using namespace arb;
+    using testing::cablelist_eq;
+
+    using pvec = std::vector<msize_t>;
+    using svec = std::vector<msample>;
+    using cl = mcable_list;
+
+    // Eight samples
+    //                  no-sphere
+    //          sample   branch
+    //            0         0
+    //           1 3       0 1
+    //          2   4     0   1
+    //             5 6       2 3
+    //                7         3
+    pvec parents = {mnpos, 0, 1, 0, 3, 4, 4, 6};
+    svec samples = {
+        {{  0,  0,  0,  2}, 3},
+        {{ 10,  0,  0,  2}, 3},
+        {{100,  0,  0,  2}, 3},
+        {{  0, 10,  0,  2}, 3},
+        {{  0,100,  0,  2}, 3},
+        {{100,100,  0,  2}, 3},
+        {{  0,200,  0,  2}, 3},
+        {{  0,300,  0,  2}, 3},
+    };
+
+    morphology m(sample_tree(samples, parents));
+
+    mextent x1(m, cl{{1, 0.25, 0.75}});
+    ASSERT_TRUE(x1.test_invariants(m));
+    EXPECT_TRUE(cablelist_eq(cl{{1, 0.25, 0.75}}, x1.cables()));
+
+    mextent x2(m, cl{{1, 0., 0.75}});
+    ASSERT_TRUE(x2.test_invariants(m));
+    EXPECT_TRUE(cablelist_eq(cl{{0, 0, 0}, {1, 0., 0.75}}, x2.cables()));
+
+    mextent x3(m, cl{{2, 0., 1.}});
+    ASSERT_TRUE(x3.test_invariants(m));
+    EXPECT_TRUE(cablelist_eq(cl{{1, 1, 1}, {2, 0., 1.}, {3, 0., 0.}}, x3.cables()));
+}
+
+TEST(mextent, intersects) {
+    using namespace arb;
+    using testing::cablelist_eq;
+
+    using pvec = std::vector<msize_t>;
+    using svec = std::vector<msample>;
+    using cl = mcable_list;
+
+    // Eight samples
+    //                  no-sphere
+    //          sample   branch
+    //            0         0
+    //           1 3       0 1
+    //          2   4     0   1
+    //             5 6       2 3
+    //                7         3
+    pvec parents = {mnpos, 0, 1, 0, 3, 4, 4, 6};
+    svec samples = {
+        {{  0,  0,  0,  2}, 3},
+        {{ 10,  0,  0,  2}, 3},
+        {{100,  0,  0,  2}, 3},
+        {{  0, 10,  0,  2}, 3},
+        {{  0,100,  0,  2}, 3},
+        {{100,100,  0,  2}, 3},
+        {{  0,200,  0,  2}, 3},
+        {{  0,300,  0,  2}, 3},
+    };
+
+    morphology m(sample_tree(samples, parents));
+
+    mextent x1(m, cl{{1, 0.25, 0.75}});
+    EXPECT_TRUE(x1.intersects(mlocation{1, 0.25}));
+    EXPECT_TRUE(x1.intersects(mlocation{1, 0.5}));
+    EXPECT_TRUE(x1.intersects(mlocation{1, 0.75}));
+    EXPECT_FALSE(x1.intersects(mlocation{1, 0.}));
+    EXPECT_FALSE(x1.intersects(mlocation{1, 1.}));
+
+    EXPECT_FALSE(x1.intersects(mcable{1, 0., 0.2}));
+    EXPECT_TRUE(x1.intersects(mcable{1, 0., 0.25}));
+    EXPECT_TRUE(x1.intersects(mcable{1, 0.4, 0.6}));
+    EXPECT_TRUE(x1.intersects(mcable{1, 0.2, 0.8}));
+    EXPECT_TRUE(x1.intersects(mcable{1, 0.75, 1.0}));
+    EXPECT_FALSE(x1.intersects(mcable{1, 0.8, 1.0}));
+
+    mextent x2(m, cl{{1, 0., 0.75}});
+    EXPECT_TRUE(x2.intersects(mlocation{1, 0.}));
+    EXPECT_TRUE(x2.intersects(mlocation{0, 0.}));
+    EXPECT_FALSE(x2.intersects(mlocation{0, 1.}));
+
+    mextent x3(m, cl{{2, 0., 1.}});
+    EXPECT_FALSE(x3.intersects(mlocation{1, 0.}));
+    EXPECT_TRUE(x3.intersects(mlocation{1, 1.}));
+    EXPECT_TRUE(x3.intersects(mlocation{3, 0.}));
+    EXPECT_FALSE(x3.intersects(mlocation{3, 1.}));
+}


### PR DESCRIPTION
Use a wrapper `mextent` around an `mcable_list` with a stronger invariant for the representation of thingified regions, with public intersection and union and intersection-testing operations. Creation of an `mextent` requires a morphology, but any further operations on one do not.

* Implement `mextent`, wrapping an `mcable_list` and enforcing an invariant: all cables on the same branch are distinct; and there is a cable in the extent for every branch that intersects with the region on the morphology tree described by the cable list.
* Recast region union and intersection operations on regions in terms of `mextent` objects.
* Use `mextent` objects as the concrete representation for regions in `mprovider`.
* Modify region/locset expression implementations to accommodate new representation.
* Add `region` ctors that wrap an explicit cable list or `mextent`.
* Add a lazy range-based merge view in `util/mergeview.hpp`.