### PR TITLE
Use `time_type` = double

### DIFF
--- a/arbor/connection.hpp
+++ b/arbor/connection.hpp
@@ -36,8 +36,8 @@ public:
 private:
     cell_member_type source_;
     cell_member_type destination_;
+    float delay_;
     float weight_;
-    time_type delay_;
     cell_size_type index_on_domain_;
 };
 

--- a/arbor/include/arbor/common_types.hpp
+++ b/arbor/include/arbor/common_types.hpp
@@ -54,7 +54,7 @@ ARB_DEFINE_LEXICOGRAPHIC_ORDERING(cell_member_type,(a.gid,a.index),(b.gid,b.inde
 
 // For storing time values [ms]
 
-using time_type = float;
+using time_type = double;
 constexpr time_type terminal_time = std::numeric_limits<time_type>::max();
 
 // Extra contextual information associated with a probe.


### PR DESCRIPTION
Benchmarks were run to evaluate the cost of switching to `time_type = double` before implementing  #543. 
In most cases, most of the memory consumed in the simulation is in the `connections` table built during model-init. Explicitly using `float` for the `delay`, reduces the memory overhead without reducing accuracy. 

Memory breakdown of a simulation of 1024 cells with a 13Hz spiking rate each with 10000 synapses
```
time_type=float
--------------------------------------
model-init    |53.72% (287 MB) std::vector<connection>
model-init    |23.02% (123 MB) std::vector<target_handle>
model-run     |8.9%   (47 MB)  std::array<std::vector<pse_vector>, 2> (simulation_state::event_lanes_)
model-run     |6.2%   (33 MB)  std::vector<pse_vector>                (simulation_state::pending_events_)
model-run     |3.3%   (17 MB)  UNKNOWN
model-run     |1.98%  (10 MB)  std::vector<deliverable_event>         (mc_cell_group::staged_events_) 
```
```
time_type=double; connection { float delay; ...}
--------------------------------------
model-init    |49.58% (287 MB) std::vector<connection>                                                       
model-init    |21.25% (123 MB) std::vector<target_handle>
model-run     |12.3%  (71 MB)  std::array<std::vector<pse_vector>, 2> (simulation_state::event_lanes_)
model-run     |8.6%   (50 MB)  std::vector<pse_vector>                (simulation_state::pending_events_)
model-run     |3.44%  (20 MB)  UNKNOWN
model-run     |2.19%  (13 MB)  std::vector<deliverable_event>         (mc_cell_group::staged_events_) 
```
The difference is a 9% increase in memory consumption.

Similar experiments were run for systems with 26Hz and 62Hz spiking rates, memory consumption increases by 14% and 22% respectively due to these changes.

Addresses #543 