### PR TITLE
Re-write pow in terms of exp and log.

### DIFF
--- a/arbor/include/arbor/simd/implbase.hpp
+++ b/arbor/include/arbor/simd/implbase.hpp
@@ -523,14 +523,7 @@ struct implbase {
     }
 
     static vector_type pow(const vector_type& s, const vector_type &t) {
-        store a, b, r;
-        I::copy_to(s, a);
-        I::copy_to(t, b);
-
-        for (unsigned i = 0; i<width; ++i) {
-            r[i] = std::pow(a[i], b[i]);
-        }
-        return I::copy_from(r);
+        return I::exp(I::mul(I::log(s), t));
     }
 };
 


### PR DESCRIPTION
Re-write `pow(b, e) = exp(log(b) e)`, a common optimisation.

In my tests (nsuite busyring with 'hh' and 'pas' mechanism swapped) it
yields a significant speed-up 11.5s vs 7.7s on the largee/run_128_2.json
input.