### PR TITLE
Fix warnings 

### DIFF
--- a/arbor/connection.hpp
+++ b/arbor/connection.hpp
@@ -13,7 +13,7 @@ public:
     connection( cell_member_type src,
                 cell_member_type dest,
                 float w,
-                time_type d,
+                float d,
                 cell_gid_type didx=cell_gid_type(-1)):
         source_(src),
         destination_(dest),
@@ -36,8 +36,8 @@ public:
 private:
     cell_member_type source_;
     cell_member_type destination_;
-    float delay_;
     float weight_;
+    float delay_;
     cell_size_type index_on_domain_;
 };
 

--- a/arbor/include/arbor/recipe.hpp
+++ b/arbor/include/arbor/recipe.hpp
@@ -40,9 +40,9 @@ struct cell_connection {
     cell_connection_endpoint dest;
 
     float weight;
-    time_type delay;
+    float delay;
 
-    cell_connection(cell_connection_endpoint src, cell_connection_endpoint dst, float w, time_type d):
+    cell_connection(cell_connection_endpoint src, cell_connection_endpoint dst, float w, float d):
         source(src), dest(dst), weight(w), delay(d)
     {}
 };

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -97,7 +97,7 @@ void register_recipe(pybind11::module& m) {
         "Describes a connection between two cells:\n"
         "  Defined by source and destination end points (that is pre-synaptic and post-synaptic respectively), a connection weight and a delay time.");
     cell_connection
-        .def(pybind11::init<arb::cell_member_type, arb::cell_member_type, float, arb::time_type>(),
+        .def(pybind11::init<arb::cell_member_type, arb::cell_member_type, float, float>(),
             "source"_a, "dest"_a, "weight"_a, "delay"_a,
             "Construct a connection with arguments:\n"
             "  source:      The source end point of the connection.\n"


### PR DESCRIPTION
Fix warning generated when `delay` and `weight` were accidentally swapped in #984 
Match `cell_connection` delay type to `connection` delay type