### PR TITLE
Move q10 calculation to initialisation.

### DIFF
--- a/mechanisms/mod/hh.mod
+++ b/mechanisms/mod/hh.mod
@@ -64,7 +64,7 @@ DERIVATIVE states {
 
 PROCEDURE rates(v)
 {
-    LOCAL  alpha, beta, sum, q10
+    LOCAL  alpha, beta, sum
 
     :"m" sodium activation system
     alpha = .1 * vtrap(-(v+40),10)

--- a/mechanisms/mod/hh.mod
+++ b/mechanisms/mod/hh.mod
@@ -35,6 +35,7 @@ ASSIGNED {
     mtau (ms)
     htau (ms)
     ntau (ms)
+    q10
 }
 
 BREAKPOINT {
@@ -47,7 +48,8 @@ BREAKPOINT {
 }
 
 INITIAL {
-    rates(v, celsius)
+    q10 = 3^((celsius - 6.3)/10)
+    rates(v)
     m = minf
     h = hinf
     n = ninf
@@ -60,11 +62,9 @@ DERIVATIVE states {
     n' = (ninf-n)/ntau
 }
 
-PROCEDURE rates(v, celsius)
+PROCEDURE rates(v)
 {
     LOCAL  alpha, beta, sum, q10
-
-    q10 = 3^((celsius - 6.3)/10)
 
     :"m" sodium activation system
     alpha = .1 * vtrap(-(v+40),10)

--- a/mechanisms/mod/hh.mod
+++ b/mechanisms/mod/hh.mod
@@ -56,7 +56,7 @@ INITIAL {
 }
 
 DERIVATIVE states {
-    rates(v, celsius)
+    rates(v)
     m' = (minf-m)/mtau
     h' = (hinf-h)/htau
     n' = (ninf-n)/ntau


### PR DESCRIPTION
Pull out a constant computation from the update function to the initialisation step in the HH mechanism. In the busyring benchmark with hh/pas swapped this results in an overall speed-up
of roughly 20%.