### PR TITLE
CI on Daint via Sarus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "python/pybind11"]
 	path = python/pybind11
 	url = https://github.com/pybind/pybind11.git
+[submodule "ci"]
+	path = ci
+	url = https://gitlab.com/cscs-ci/arbor-sim/arbor-ci.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/arbor-sim/arbor) 
+[![CI status](https://gitlab.com/cscs-ci/arbor-sim/arbor/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/arbor-sim/arbor/-/commits/master) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/arbor-sim/arbor) 
 
 # Arbor Library
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = [
+  "ci/gitlab/%",
+]
+delete_merged_branches = true

--- a/docker/build-env/Dockerfile
+++ b/docker/build-env/Dockerfile
@@ -1,0 +1,32 @@
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
+
+WORKDIR /root
+
+ARG MPICH_VERSION=3.1.4
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV FORCE_UNSAFE_CONFIGURE 1
+ENV MPICH_VERSION ${MPICH_VERSION}
+
+# Install basic tools
+RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
+    build-essential \
+    python \
+    git tar wget curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install cmake
+RUN wget -qO- "https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+
+# Install MPICH ABI compatible with Cray's lib on Piz Daint
+RUN wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz && \
+    tar -xzf mpich-${MPICH_VERSION}.tar.gz && \
+    cd mpich-${MPICH_VERSION} && \
+    ./configure --disable-fortran && \
+    make install -j$(nproc) && \
+    rm -rf mpich-${MPICH_VERSION}.tar.gz mpich-${MPICH_VERSION}
+
+# Install bundle tooling for creating small Docker images
+RUN wget -q https://github.com/haampie/bundler/releases/download/v0.1.3/bundler_x86_64.tar.gz && \
+    tar -xzf bundler_x86_64.tar.gz && \
+    rm bundler_x86_64.tar.gz

--- a/docker/build-env/Dockerfile
+++ b/docker/build-env/Dockerfile
@@ -27,6 +27,6 @@ RUN wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPIC
     rm -rf mpich-${MPICH_VERSION}.tar.gz mpich-${MPICH_VERSION}
 
 # Install bundle tooling for creating small Docker images
-RUN wget -q https://github.com/haampie/bundler/releases/download/v0.1.3/bundler_x86_64.tar.gz && \
-    tar -xzf bundler_x86_64.tar.gz && \
-    rm bundler_x86_64.tar.gz
+RUN wget -q https://github.com/haampie/libtree/releases/download/v1.0.3/libtree_x86_64.tar.gz && \
+    tar -xzf libtree_x86_64.tar.gz && \
+    rm libtree_x86_64.tar.gz

--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /arbor/build && cd /arbor/build && \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr && \
     make -j$(nproc) tests && \
-    /root/libtree/libtree \
+    /root/libtree/libtree --chrpath --strip \
       -d /root/arbor.bundle \
       /arbor/build/bin/modcc \
       /arbor/build/bin/unit \

--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -21,13 +21,13 @@ RUN mkdir /arbor/build && cd /arbor/build && \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr && \
     make -j$(nproc) tests && \
-    /root/bundler/bundler \
+    /root/libtree/libtree \
       -d /root/arbor.bundle \
-      -e /arbor/build/bin/modcc \
-      -e /arbor/build/bin/unit \
-      -e /arbor/build/bin/unit-local \
-      -e /arbor/build/bin/unit-modcc \
-      -e /arbor/build/bin/unit-mpi && \
+      /arbor/build/bin/modcc \
+      /arbor/build/bin/unit \
+      /arbor/build/bin/unit-local \
+      /arbor/build/bin/unit-modcc \
+      /arbor/build/bin/unit-mpi && \
     rm -rf /arbor
 
 FROM ubuntu:18.04

--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -1,0 +1,48 @@
+# Multistage build: here we import the current source code
+# into build environment image, build the project, bundle it
+# and then extract it into a small image that just contains
+# the binaries we need to run
+
+ARG BUILD_ENV
+
+FROM $BUILD_ENV as builder
+
+# Build arbor
+COPY . /arbor
+
+# Build and bundle binaries
+RUN mkdir /arbor/build && cd /arbor/build && \
+    CC=mpicc CXX=mpicxx cmake .. \
+      -DARB_VECTORIZE=ON \
+      -DARB_ARCH=broadwell \
+      -DARB_WITH_PYTHON=OFF \
+      -DARB_WITH_MPI=ON \
+      -DARB_WITH_GPU=ON \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr && \
+    make -j$(nproc) tests && \
+    /root/bundler/bundler \
+      -d /root/arbor.bundle \
+      -e /arbor/build/bin/modcc \
+      -e /arbor/build/bin/unit \
+      -e /arbor/build/bin/unit-local \
+      -e /arbor/build/bin/unit-modcc \
+      -e /arbor/build/bin/unit-mpi && \
+    rm -rf /arbor
+
+FROM ubuntu:18.04
+
+# This is the only thing necessary really from nvidia/cuda's ubuntu18.04 runtime image
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.1 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=396,driver<397 brand=tesla,driver>=410,driver<411"
+
+COPY --from=builder /root/arbor.bundle /root/arbor.bundle
+
+# Make it easy to call our binaries.
+ENV PATH="/root/arbor.bundle/usr/bin:$PATH"
+
+RUN echo "/root/arbor.bundle/usr/lib/" > /etc/ld.so.conf.d/arbor.conf && ldconfig
+
+WORKDIR /root/arbor.bundle/usr/bin
+


### PR DESCRIPTION
Adds Dockerfiles to build arbor's tests s.t. they can be run on Daint via Sarus

The CI pipeline has to be stored outside of this repository (https://gitlab.com/cscs-ci/arbor-sim/arbor-ci/-/blob/master/.gitlab-ci.yml) for security reasons, it could be moved to the `arbor` organization on Github if that's more convenient.

Todo:

- [x] A maintainer of the arbor Github project should be added to the `cscs-ci` group on Gitlab, and should mirror this repo at https://gitlab.com/cscs-ci/arbor-sim/arbor via **New Project** > **CI/CD for external repositories** and then pick the `cscs-ci/arbor-sim` namespace.
- [x] Add sensible `srun` commands to the pipeline (https://gitlab.com/cscs-ci/arbor-sim/arbor-ci/-/blob/master/.gitlab-ci.yml#L45-48)
- [x] Install [Bors](https://github.com/bors-ng/bors-ng) for this repo ([installation link](https://github.com/apps/bors/installations/new)), which ensures Gitlab's CI is triggered, and adds other useful features (e.g. authorization for CI)
- [x] Add CI status badge to `README.md`
- [x] Make the arbor-ci repo a submodule of this for convenience
- [x] Make a slurm allocation once to improve CI run times
