### PR TITLE
Fix setuptools to work with older Pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,16 @@ from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
 import subprocess
 
+# Sometimes version 19 and earlier of pip skip the install step
+# when building the extension without command line arguments.
+# Assert that users are using a recent version of pip to work around
+# this potential issue.
+import pip; assert int(pip.__version__.split('.')[0])>=20, '\n'.join(['\n',
+    '------------------------------------------------------------------------------',
+    'Arbor requires a recent version of pip; run the following before installing:',
+    'pip install --upgrade pip',
+    '------------------------------------------------------------------------------\n'])
+
 # VERSION is in the same path as setup.py
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'VERSION')) as version_file:
@@ -127,7 +137,7 @@ setuptools.setup(
     python_requires='>=3.6',
 
     install_requires=[],
-    setup_requires=['pip>20'],
+    setup_requires=[],
     zip_safe=False,
     ext_modules=[cmake_extension('arbor')],
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ class cmake_build(build_ext):
             '-DARB_WITH_MPI={}'.format( 'on' if opt['mpi'] else 'off'),
             '-DARB_WITH_GPU={}'.format( 'on' if opt['gpu'] else 'off'),
             '-DARB_VECTORIZE={}'.format('on' if opt['vec'] else 'off'),
-            '-DARB_ARCH={}'.format(cl_opt_arch),
+            '-DARB_ARCH={}'.format(opt['arch']),
             '-DCMAKE_BUILD_TYPE=Release' # we compile with debug symbols in release mode.
         ]
 

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setuptools.setup(
     python_requires='>=3.6',
 
     install_requires=[],
-    setup_requires=[],
+    setup_requires=['pip>20'],
     zip_safe=False,
     ext_modules=[cmake_extension('arbor')],
     cmdclass={


### PR DESCRIPTION
Work around issue caused by some versions of pip skipping the `install` stage when no additional command line args are passed via `--install-option`.

Keep settings that can be modified via install option in a singleton that initializes them to their default.