### PR TITLE
clean up of region/locset implementation

### DIFF
--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -62,7 +62,14 @@ public:
 };
 
 // Morphology utility functions.
+
+// Find the set of locations in an mlocation_list for which there
+// are no other locations that are more proximal in that list.
 mlocation_list minset(const morphology&, const mlocation_list&);
+
+// Find the set of locations in an mlocation_list for which there
+// are no other locations that are more distal in the list.
+mlocation_list maxset(const morphology&, const mlocation_list&);
 
 mlocation canonical(const morphology&, mlocation);
 

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <stack>
+#include <unordered_map>
 #include <utility>
 
 #include <arbor/morph/morphexcept.hpp>
@@ -269,6 +270,37 @@ mlocation_list minset(const morphology& m, const mlocation_list& in) {
     }
 
     util::sort(L);
+    return L;
+}
+
+mlocation_list maxset(const morphology& m, const mlocation_list& in_) {
+    mlocation_list L;
+
+    // Sort the input in reverse order, so that more distal locations
+    // come first.
+    mlocation_list in = in_;
+    util::sort(in, [](const auto& l, const auto& r) {return r<l;});
+
+    // List of branches that have had a more distal location found.
+    std::unordered_set<msize_t> br;
+    for (auto loc: in) {
+        auto b = loc.branch;
+
+        // A child of this branch has already been visited: a more distal
+        // location has already been found, so we can skip.
+        if (br.count(b)) continue;
+
+        // Add the location to the maxset.
+        L.push_back(loc);
+
+        // Mark the branch and its parents.
+        while (b!=mnpos) {
+            br.insert(b);
+            b = m.branch_parent(b);
+        }
+    }
+
+    std::reverse(L.begin(), L.end());
     return L;
 }
 

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -335,7 +335,7 @@ mextent thingify_(const proximal_interval_& reg, const mprovider& p) {
 }
 
 std::ostream& operator<<(std::ostream& o, const proximal_interval_& d) {
-    return o << "(distal_interval " << d.end << " " << d.distance << ")";
+    return o << "(proximal_interval " << d.end << " " << d.distance << ")";
 }
 
 mextent radius_cmp(const mprovider& p, region r, double val, comp_op op) {

--- a/python/morph_parse.cpp
+++ b/python/morph_parse.cpp
@@ -1,6 +1,7 @@
 #include <arbor/util/any.hpp>
 #include <arbor/morph/region.hpp>
 #include <arbor/morph/locset.hpp>
+#include <limits>
 
 #include "error.hpp"
 #include "s_expr.hpp"
@@ -187,8 +188,16 @@ std::unordered_multimap<std::string, evaluator> eval_map {
                             "'region' with 1 argument: (name:string)")},
     {"distal_interval",  make_call<arb::locset, double>(arb::reg::distal_interval,
                             "'distal_interval' with 2 arguments: (start:locset extent:real)")},
+    {"distal_interval", make_call<arb::locset>(
+                            [](arb::locset ls){return arb::reg::distal_interval(std::move(ls), std::numeric_limits<double>::max());},
+                            "'distal_interval' with 1 argument: (start:locset)")},
     {"proximal_interval",make_call<arb::locset, double>(arb::reg::proximal_interval,
                             "'proximal_interval' with 2 arguments: (start:locset extent:real)")},
+    {"proximal_interval", make_call<arb::locset>(
+                            [](arb::locset ls){return arb::reg::proximal_interval(std::move(ls), std::numeric_limits<double>::max());},
+                            "'proximal_interval' with 1 argument: (start:locset)")},
+    {"super",     make_call<arb::region>(arb::reg::super,
+                            "'super' with 1 argment: (reg:region)")},
     {"radius_lt",make_call<arb::region, double>(arb::reg::radius_lt,
                             "'radius_lt' with 2 arguments: (reg:region radius:real)")},
     {"radius_le",make_call<arb::region, double>(arb::reg::radius_le,

--- a/test/unit/test_morphology.cpp
+++ b/test/unit/test_morphology.cpp
@@ -636,6 +636,57 @@ TEST(morphology, minset) {
     }
 }
 
+TEST(morphology, maxset) {
+    using pvec = std::vector<arb::msize_t>;
+    using svec = std::vector<arb::msample>;
+    using ll = arb::mlocation_list;
+    constexpr auto npos = arb::mnpos;
+
+    // Eight samples
+    //                  no-sphere  sphere
+    //          sample   branch    branch
+    //            0         0         0
+    //           1 3       0 1       1 2
+    //          2   4     0   1     1   2
+    //             5 6       2 3       3 4
+    //                7         3         4
+    pvec parents = {npos, 0, 1, 0, 3, 4, 4, 6};
+    svec samples = {
+        {{  0,  0,  0,  2}, 3},
+        {{ 10,  0,  0,  2}, 3},
+        {{100,  0,  0,  2}, 3},
+        {{  0, 10,  0,  2}, 3},
+        {{  0,100,  0,  2}, 3},
+        {{100,100,  0,  2}, 3},
+        {{  0,200,  0,  2}, 3},
+        {{  0,300,  0,  2}, 3},
+    };
+    arb::sample_tree sm(samples, parents);
+    {
+        arb::morphology m(sm, false);
+
+        EXPECT_EQ((ll{}), maxset(m, ll{}));
+        EXPECT_EQ((ll{{2,0.1}}), maxset(m, ll{{2,0.1}}));
+        EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), maxset(m, ll{{0,0.5}, {1,0.5}}));
+        EXPECT_EQ((ll{{0,0.5}}), maxset(m, ll{{0,0.5}}));
+        EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
+        EXPECT_EQ((ll{{0,0.5}, {2,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0.5}, {2,0.5}}));
+        EXPECT_EQ((ll{{0,0.5}, {2,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {2,0.5}}));
+        EXPECT_EQ((ll{{0,0.5}, {2,0.5}, {3,1}}), maxset(m, ll{{0,0}, {0,0.5}, {2,0.5}, {3,0}, {3,1}}));
+        EXPECT_EQ((ll{{2,0.5}, {3,0.5}}), maxset(m, ll{{1,0.5}, {2,0.5}, {3,0}, {3,0.2}, {3,0.5}}));
+    }
+    {
+        arb::morphology m(sm, true);
+
+        EXPECT_EQ((ll{}), maxset(m, ll{}));
+        EXPECT_EQ((ll{{2,0.1}}), maxset(m, ll{{2,0.1}}));
+        EXPECT_EQ((ll{{1,0.5}}), maxset(m, ll{{0,0.5}, {1,0.5}}));
+        EXPECT_EQ((ll{{1,0}, {2,0}}), maxset(m, ll{{2,0}, {1,0}, {0,0}}));
+        EXPECT_EQ((ll{{1,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
+        EXPECT_EQ((ll{{1,1}, {3,0.1}, {4,0.7}}), maxset(m, ll{{1,0.5}, {1,1}, {3,0.1}, {4,0.5}, {4,0.7}}));
+    }
+}
+
 // Testing mextent; intersection and join operations are
 // exercised by region/locset thingifies in test_morph_expr.cpp.
 


### PR DESCRIPTION
Add `maxset` function that returns the most distal set of locations in a location list, similar to existing `minset` function.

Use `minset` and `maxset` consistently in `most_proximal` and `most_distal` locset expressions respectively.