### PR TITLE
set the default ARB_ARCH target to native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
     compiler: clang
 
 ######################### LINUX #########################
-## test gcc6 - single node/rank with threading backend ##
+## test gcc7 - single node/rank with threading backend ##
   - name: "linux, gcc, serial, py"
     os: linux
     dist: bionic
@@ -63,16 +63,16 @@ matrix:
       apt:
         sources:
         packages:
-          - g++-6
+          - g++-7
           - openmpi-bin
           - libopenmpi-dev
     env:
-      - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+      - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
       - BUILD_NAME=cthread-linux-gcc-py
       - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3
-    compiler: gcc-6
+    compiler: gcc-7
 
-## test gcc6 - mpi with threading backend ##
+## test gcc7 - mpi with threading backend ##
   - name: "linux, gcc, mpi, py"
     os: linux
     dist: bionic
@@ -84,10 +84,10 @@ matrix:
           - openmpi-bin
           - libopenmpi-dev
     env:
-      - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+      - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
       - BUILD_NAME=mpi-linux-gcc-py
       - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3
-    compiler: gcc-6
+    compiler: gcc-7
 
 ## test clang4 - single node/rank with threading backend ##
   - name: "linux, clang, serial, py"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ enable_language(CXX)
 
 # Specify target archiecture.
 
-set(ARB_ARCH "" CACHE STRING "Target architecture for arbor libraries")
+set(ARB_ARCH "native" CACHE STRING "Target architecture for arbor libraries")
 
 # Perform explicit vectorization?
 


### PR DESCRIPTION
Fixes an oversight in #1038 that produced incorrect configuration information in `version.hpp` and `python.__config__` when a target architecture was not explicitly mentioned.

Also fixed an obscure compilation bug that surfaced on some systems when compiling with `ARB_VECTORIZE` and no explicit target architecture.