### PR TITLE
Travis CI arch bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ install:
 before_script:
   - eval "${MATRIX_EVAL}"
 
-script: source ./scripts/travis/build.sh $ARCH
+script: source ./scripts/travis/build.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     env:
       - MATRIX_EVAL="brew install gcc@6 && brew link --force --overwrite gcc@6 && brew install cmake && CC=gcc-6 && CXX=g++-6"
       - BUILD_NAME=cthread-osx-gcc-py
-      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3 ARCH=native
     compiler: gcc-6
 
 ## test gcc6 - mpi with threading backend ##
@@ -29,7 +29,7 @@ matrix:
     env:
       - MATRIX_EVAL="brew install gcc@6 && brew link --force --overwrite gcc@6 && brew install cmake && CC=gcc-6 && CXX=g++-6"
       - BUILD_NAME=mpi-osx-gcc-py
-      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3 ARCH=native
     compiler: gcc-6
 
 ## test clang9 - single node/rank with threading backend ##
@@ -40,7 +40,7 @@ matrix:
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++"
       - BUILD_NAME=cthread-osx-clang-py
-      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3 ARCH=native
     compiler: clang
 
 ## test clang9 - mpi with threading backend ##
@@ -51,7 +51,7 @@ matrix:
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++"
       - BUILD_NAME=mpi-osx-clang
-      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3 ARCH=native
     compiler: clang
 
 ######################### LINUX #########################
@@ -69,7 +69,7 @@ matrix:
     env:
       - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
       - BUILD_NAME=cthread-linux-gcc-py
-      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3 ARCH=haswell
     compiler: gcc-7
 
 ## test gcc7 - mpi with threading backend ##
@@ -86,7 +86,7 @@ matrix:
     env:
       - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
       - BUILD_NAME=mpi-linux-gcc-py
-      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3 ARCH=haswell
     compiler: gcc-7
 
 ## test clang4 - single node/rank with threading backend ##
@@ -102,7 +102,7 @@ matrix:
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++"
       - BUILD_NAME=cthread-linux-clang-py
-      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=serial WITH_PYTHON=true PY=3 ARCH=native
     compiler: clang-4.0
 
 ## test clang4 - mpi with threading backend ##
@@ -118,7 +118,7 @@ matrix:
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++"
       - BUILD_NAME=mpi-linux-clang-py
-      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3
+      - WITH_DISTRIBUTED=mpi WITH_PYTHON=true PY=3 ARCH=native
     compiler: clang-4.0
 
 before_install:
@@ -147,7 +147,7 @@ install:
 before_script:
   - eval "${MATRIX_EVAL}"
 
-script: source ./scripts/travis/build.sh
+script: source ./scripts/travis/build.sh $ARCH
 
 notifications:
   email:

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -76,7 +76,7 @@ cd $build_path
 #
 progress "Configuring with cmake"
 
-cmake_flags="-DARB_WITH_ASSERTIONS=ON -DARB_WITH_MPI=${WITH_MPI} -DARB_WITH_PYTHON=${ARB_WITH_PYTHON} -DARB_ARCH=$1 ${CXX_FLAGS} ${PY_FLAGS}"
+cmake_flags="-DARB_WITH_ASSERTIONS=ON -DARB_WITH_MPI=${WITH_MPI} -DARB_WITH_PYTHON=${ARB_WITH_PYTHON} -DARB_ARCH=${ARCH} ${CXX_FLAGS} ${PY_FLAGS}"
 echo "cmake flags: ${cmake_flags}"
 cmake .. ${cmake_flags} || error "unable to configure cmake"
 

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -76,7 +76,7 @@ cd $build_path
 #
 progress "Configuring with cmake"
 
-cmake_flags="-DARB_WITH_ASSERTIONS=ON -DARB_WITH_MPI=${WITH_MPI} -DARB_WITH_PYTHON=${ARB_WITH_PYTHON} ${CXX_FLAGS} ${PY_FLAGS}"
+cmake_flags="-DARB_WITH_ASSERTIONS=ON -DARB_WITH_MPI=${WITH_MPI} -DARB_WITH_PYTHON=${ARB_WITH_PYTHON} -DARB_ARCH=$1 ${CXX_FLAGS} ${PY_FLAGS}"
 echo "cmake flags: ${cmake_flags}"
 cmake .. ${cmake_flags} || error "unable to configure cmake"
 


### PR DESCRIPTION
Travis CI is failing on some simd tests for `ARB_ARCH=native`
GCC appears to be setting incorrect flags in the Travis environment for `-march=native`. Using `-march=skylake-avx512/haswell/etc` fixes the errors. 