### PR TITLE
Implement exact sampling for cable cells.

### DIFF
--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -228,16 +228,18 @@ public:
 
     cable_cell_parameter_set default_parameters;
 
-    /// Default constructor
+    // Default constructor.
     cable_cell();
 
-    /// Copy constructor
+    // Copy and move constructors.
     cable_cell(const cable_cell& other);
-
-    /// Move constructor
     cable_cell(cable_cell&& other) = default;
 
+    // Copy and move assignment operators..
     cable_cell& operator=(cable_cell&&) = default;
+    cable_cell& operator=(const cable_cell& other) {
+        return *this = cable_cell(other);
+    }
 
     /// construct from morphology
     cable_cell(const class morphology& m, const label_dict& dictionary={});

--- a/arbor/include/arbor/sampling.hpp
+++ b/arbor/include/arbor/sampling.hpp
@@ -33,8 +33,7 @@ using sampler_association_handle = std::size_t;
 
 enum class sampling_policy {
     lax,
-    // interpolated, // placeholder: unsupported
-    // exact         // placeholder: unsupported
+    exact
 };
 
 } // namespace arb

--- a/arbor/include/arbor/util/pp_util.hpp
+++ b/arbor/include/arbor/util/pp_util.hpp
@@ -44,9 +44,19 @@
 #define ARB_PP_FOREACH_8_(M, A, ...)  M(A) ARB_PP_FOREACH_7_(M, __VA_ARGS__)
 #define ARB_PP_FOREACH_9_(M, A, ...)  M(A) ARB_PP_FOREACH_8_(M, __VA_ARGS__)
 #define ARB_PP_FOREACH_10_(M, A, ...) M(A) ARB_PP_FOREACH_9_(M, __VA_ARGS__)
-#define ARB_PP_GET_11TH_ARGUMENT_(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, ...) a11
+#define ARB_PP_FOREACH_11_(M, A, ...) M(A) ARB_PP_FOREACH_10_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_12_(M, A, ...) M(A) ARB_PP_FOREACH_11_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_13_(M, A, ...) M(A) ARB_PP_FOREACH_12_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_14_(M, A, ...) M(A) ARB_PP_FOREACH_13_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_15_(M, A, ...) M(A) ARB_PP_FOREACH_14_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_16_(M, A, ...) M(A) ARB_PP_FOREACH_15_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_17_(M, A, ...) M(A) ARB_PP_FOREACH_16_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_18_(M, A, ...) M(A) ARB_PP_FOREACH_17_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_19_(M, A, ...) M(A) ARB_PP_FOREACH_18_(M, __VA_ARGS__)
+#define ARB_PP_FOREACH_20_(M, A, ...) M(A) ARB_PP_FOREACH_19_(M, __VA_ARGS__)
+#define ARB_PP_GET_21ST_ARGUMENT_(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, ...) a21
 
-// Apply macro in first argument to each of the remaining arguments (up to 10).
-// Note: if __VA_ARGS__ has size N, when it is expanded the 11th argument is the ARB_PP_FOREACH_N_ macro.
+// Apply macro in first argument to each of the remaining arguments (up to 20).
+// Note: if __VA_ARGS__ has size N, when it is expanded the 21st argument is the ARB_PP_FOREACH_N_ macro.
 #define ARB_PP_FOREACH(M, ...)\
-ARB_PP_GET_11TH_ARGUMENT_(__VA_ARGS__, ARB_PP_FOREACH_10_, ARB_PP_FOREACH_9_, ARB_PP_FOREACH_8_, ARB_PP_FOREACH_7_, ARB_PP_FOREACH_6_, ARB_PP_FOREACH_5_, ARB_PP_FOREACH_4_, ARB_PP_FOREACH_3_, ARB_PP_FOREACH_2_, ARB_PP_FOREACH_1_)(M, __VA_ARGS__)
+ARB_PP_GET_21ST_ARGUMENT_(__VA_ARGS__, ARB_PP_FOREACH_20_, ARB_PP_FOREACH_19_, ARB_PP_FOREACH_18_, ARB_PP_FOREACH_17_, ARB_PP_FOREACH_16_, ARB_PP_FOREACH_15_, ARB_PP_FOREACH_14_, ARB_PP_FOREACH_13_, ARB_PP_FOREACH_12_, ARB_PP_FOREACH_11_, ARB_PP_FOREACH_10_, ARB_PP_FOREACH_9_, ARB_PP_FOREACH_8_, ARB_PP_FOREACH_7_, ARB_PP_FOREACH_6_, ARB_PP_FOREACH_5_, ARB_PP_FOREACH_4_, ARB_PP_FOREACH_3_, ARB_PP_FOREACH_2_, ARB_PP_FOREACH_1_)(M, __VA_ARGS__)

--- a/arbor/sampler_map.hpp
+++ b/arbor/sampler_map.hpp
@@ -24,6 +24,7 @@ struct sampler_association {
     schedule sched;
     sampler_function sampler;
     std::vector<cell_member_type> probe_ids;
+    sampling_policy policy;
 };
 
 // Maintain a set of associations paired with handles used for deletion.

--- a/doc/sampling_api.rst
+++ b/doc/sampling_api.rst
@@ -183,8 +183,11 @@ Two helper functions are provided for making ``cell_member_predicate`` objects:
 The ``sampling_policy`` policy is used to modify sampling behaviour: by
 default, the ``lax`` policy is to perform a best-effort sampling that
 minimizes sampling overhead and which will not change the numerical
-behaviour of the simulation. Other policies may be implemented in the
-future, e.g. ``interpolated`` or ``exact``.
+behaviour of the simulation. The ``exact`` policy requests that samples
+are provided for the exact time specified in the schedule, even if this
+means disrupting the course of the simulation. Other policies may be
+implemented in the future, but cell groups are in general not required
+to support any policy other than ``lax``.
 
 The simulation object will pass on the sampler setting request to the cell
 group that owns the given probe id. The ``cell_group`` interface will be
@@ -277,11 +280,12 @@ The ``schedule`` class and its implementations are found in ``schedule.hpp``.
 Helper classes for probe/sampler management
 -------------------------------------------
 
-The ``simulation`` and ``mc_cell_group`` classes use classes defined in ``scheduler_map.hpp`` to simplify
-the management of sampler--probe associations and probe metdata.
+The ``simulation`` and ``mc_cell_group`` classes use classes defined in
+``scheduler_map.hpp`` to simplify the management of sampler--probe associations
+and probe metdata.
 
 ``sampler_association_map`` wraps an ``unordered_map`` between sampler association
-handles and tuples (*schedule*, *sampler*, *probe set*), with thread-safe
+handles and tuples (*schedule*, *sampler*, *probe set*, *policy*), with thread-safe
 accessors.
 
 ``probe_association_map<Handle>`` is a type alias for an unordered map between
@@ -305,6 +309,14 @@ after any postsynaptic spike events have been delivered.
 It is the responsibility of the ``mc_cell_group::advance()`` method to create the sample
 events from the entries of its ``sampler_association_map``, and to dispatch the
 sampled values to the sampler callbacks after the integration is complete.
-Given an association tuple (*schedule*, *sampler*, *probe set*) where the *schedule*
+Given an association tuple (*schedule*, *sampler*, *probe set*, *policy*) where the *schedule*
 has (non-zero) *n* sample times in the current integration interval, the ``mc_cell_group`` will
 call the *sampler* callback once for probe in *probe set*, with *n* sample values.
+
+In addition to the ``lax`` sampling polocy, ``mc_cell_group`` supports the ``exact``
+policy. Integration steps will be shortened such that any sample times associated
+with an ``exact`` policy can be satisfied precisely.
+
+
+
+

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -128,6 +128,7 @@ set(unit_sources
     test_path.cpp
     test_piecewise.cpp
     test_point.cpp
+    test_pp_util.cpp
     test_probe.cpp
     test_range.cpp
     test_ratelem.cpp

--- a/test/unit/test_pp_util.cpp
+++ b/test/unit/test_pp_util.cpp
@@ -1,0 +1,23 @@
+#include "../gtest.h"
+
+#include <string>
+#include <arbor/util/pp_util.hpp>
+
+TEST(pp_util, foreach) {
+#undef X
+#define X(n) #n "."
+
+    std::string str1 = "foo:" ARB_PP_FOREACH(X, a);
+    EXPECT_EQ("foo:a.", str1);
+
+#undef LETTERS10
+#define LETTERS10 a, b, c, d, e, f, g, h, i, j
+    std::string str10 = "bar:" ARB_PP_FOREACH(X, LETTERS10);
+    EXPECT_EQ("bar:a.b.c.d.e.f.g.h.i.j.", str10);
+
+    std::string str20 = "baz:" ARB_PP_FOREACH(X, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t);
+    EXPECT_EQ("baz:a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.", str20);
+
+#undef LETTERS10
+#undef X
+}


### PR DESCRIPTION
Fixes #1037. 

* Add fake unmatchable spike events to event queue for each exact sample request, so that integration boundaries align with exact sample times.
* Update probe-demo for exact sampling.
* Add copy assignment for `cable_cell`.
* Extend max args for ARB_PP_FOREACH to 20.
* Add unit test for ARB_PP_FOREACH.
* Use ARB_PP_FOREACH to instantiate backend-specific probe unit tests. This also fixes the GPU probe tests that were using multicore backend.
* Add unit test that exercises exact sampling requests combined with regular events in a gap junction context.