### PR TITLE
Tidy synapse collation code.

### DIFF
--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -739,8 +739,8 @@ fvm_mechanism_data& append(fvm_mechanism_data& left, const fvm_mechanism_data& r
             append(L.norm_area, R.norm_area);
             append_offset(L.target, target_offset, R.target);
 
-            arb_assert(util::is_sorted_by(L.param_values, util::first));
-            arb_assert(util::is_sorted_by(R.param_values, util::first));
+            arb_assert(util::equal(L.param_values, R.param_values,
+                [](auto& a, auto& b) { return a.first==b.first; }));
             arb_assert(L.param_values.size()==R.param_values.size());
 
             for (auto j: count_along(R.param_values)) {

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -28,6 +28,7 @@ using util::append;
 using util::assign;
 using util::assign_by;
 using util::count_along;
+using util::make_span;
 using util::pw_elements;
 using util::pw_element;
 using util::sort;
@@ -219,7 +220,7 @@ cv_geometry cv_geometry_from_ends(const cable_cell& cell, const locset& lset) {
             [](auto v) { return v!=no_parent; }));
 
     // Construct CV children mapping by sorting CV indices by parent.
-    assign(geom.cv_children, util::make_span(1, n_cv));
+    assign(geom.cv_children, make_span(1, n_cv));
     stable_sort_by(geom.cv_children, [&geom](auto cv) { return geom.cv_parent[cv]; });
 
     geom.cv_children_divs.reserve(n_cv+1);
@@ -243,7 +244,7 @@ cv_geometry cv_geometry_from_ends(const cable_cell& cell, const locset& lset) {
     geom.branch_cv_map.resize(1);
     std::vector<pw_elements<fvm_size_type>>& bmap = geom.branch_cv_map.back();
 
-    for (auto cv: util::make_span(n_cv)) {
+    for (auto cv: make_span(n_cv)) {
         for (auto cable: geom.cables(cv)) {
             if (cable.branch>=bmap.size()) {
                 bmap.resize(cable.branch+1);
@@ -934,12 +935,13 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
 
     struct synapse_instance {
         size_type cv;
-        std::vector<double> param_value;
+        std::size_t param_values_offset;
         size_type target_index;
     };
 
-    // Working vectors.
+    // Working vectors for synapse collation:
     std::vector<double> default_param_value;
+    std::vector<double> all_param_values;
     std::vector<synapse_instance> inst_list;
     std::vector<size_type> cv_order;
 
@@ -947,34 +949,44 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
         const std::string& name = entry.first;
         mechanism_info info = catalogue[name];
 
-        // Vectors of parameter values are stored in the order of
-        // parameters given by info.parameters.
+        std::size_t n_param = info.parameters.size();
+        std::size_t n_inst = entry.second.size();
 
-        // Map from a parameter name to index in ordering.
+        default_param_value.resize(n_param);
+        inst_list.clear();
+        inst_list.reserve(n_inst);
+
+        all_param_values.resize(n_param*n_inst);
+
+        // Vectors of parameter values are stored in the order of
+        // parameters given by info.parameters. param_index holds
+        // the mapping from parameter names to their index in this
+        // order.
+
         std::unordered_map<std::string, unsigned> param_index;
 
-        // Default values indexed by param_map index.
-        default_param_value.clear();
-        default_param_value.resize(info.parameters.size());
-
-        // Reset working synapse instance list.
-        inst_list.clear();
-        inst_list.reserve(entry.second.size());
-
-        unsigned id=0;
+        unsigned ix=0;
         for (const auto& kv: info.parameters) {
-            param_index[kv.first] = id;
-            default_param_value[id++] = kv.second.default_value;
+            param_index[kv.first] = ix;
+            default_param_value.at(ix++) = kv.second.default_value;
         }
+        arb_assert(ix==n_param);
 
+        std::size_t offset = 0;
         for (const placed<mechanism_desc>& pm: entry.second) {
             verify_mechanism(info, pm.item);
 
             synapse_instance in;
 
-            in.param_value = default_param_value;
+            in.param_values_offset = offset;
+            offset += n_param;
+            arb_assert(offset<=all_param_values.size());
+
+            double* in_param = all_param_values.data()+in.param_values_offset;
+            std::copy(default_param_value.begin(), default_param_value.end(), in_param);
+
             for (const auto& kv: pm.item.values()) {
-                in.param_value.at(param_index.at(kv.first)) = kv.second;
+                in_param[param_index.at(kv.first)] = kv.second;
             }
 
             in.target_index = pm.lid;
@@ -987,9 +999,31 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
         // instances in the same CV with the same parameter values are adjacent.
         // cv_order[i] is the index of the ith instance by this ordering.
 
+        auto cmp_inst_param = [n_param, &all_param_values](const synapse_instance& a, const synapse_instance& b) {
+            const double* aparam = all_param_values.data()+a.param_values_offset;
+            const double* bparam = all_param_values.data()+b.param_values_offset;
+
+            for (auto j: make_span(n_param)) {
+                if (aparam[j]<bparam[j]) return -1;
+                if (bparam[j]<aparam[j]) return 1;
+            }
+            return 0;
+        };
+
         assign(cv_order, count_along(inst_list));
-        sort_by(cv_order, [&](size_type i) {
-            return std::tie(inst_list[i].cv, inst_list[i].param_value, inst_list[i].target_index);
+        sort(cv_order, [&](size_type i, size_type j) {
+            const synapse_instance& a = inst_list[i];
+            const synapse_instance& b = inst_list[j];
+
+            if (a.cv<b.cv) return true;
+            if (b.cv<a.cv) return false;
+
+            auto cmp_param = cmp_inst_param(a, b);
+            if (cmp_param<0) return true;
+            if (cmp_param>0) return false;
+
+            // CV and all parameters are equal, so finally sort on target index.
+            return a.target_index<b.target_index;
         });
 
         bool coalesce = catalogue[name].linear && gprop.coalesce_synapses;
@@ -998,13 +1032,16 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
         config.kind = mechanismKind::point;
         for (auto& kv: info.parameters) {
             config.param_values.emplace_back(kv.first, std::vector<value_type>{});
+            if (!coalesce) {
+                config.param_values.back().second.reserve(n_inst);
+            }
         }
 
         const synapse_instance* prev = nullptr;
         for (auto i: cv_order) {
             const auto& in = inst_list[i];
 
-            if (coalesce && prev && prev->cv==in.cv && prev->param_value==in.param_value) {
+            if (coalesce && prev && prev->cv==in.cv && cmp_inst_param(*prev, in)==0) {
                 ++config.multiplicity.back();
             }
             else {
@@ -1013,8 +1050,8 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
                     config.multiplicity.push_back(1);
                 }
 
-                for (auto j: count_along(in.param_value)) {
-                    config.param_values[j].second.push_back(in.param_value[j]);
+                for (auto j: make_span(n_param)) {
+                    config.param_values[j].second.push_back(all_param_values[in.param_values_offset+j]);
                 }
             }
             config.target.push_back(in.target_index);


### PR DESCRIPTION
Avoid some double work and reallocations in the fvm_layout synapse collation code.

The use of the working vectors added in this PR wouldn't make much of a difference unless there was a great variety of different synapse types, and there is opportunity yet to avoid a large number of small vector allocations, but it is a step in the right direction.