### PR TITLE
New recipe probe API

### DIFF
--- a/arbor/backends/event.hpp
+++ b/arbor/backends/event.hpp
@@ -49,7 +49,7 @@ inline deliverable_event_data event_data(const deliverable_event& ev) {
 }
 
 
-// Sample events (scalar values)
+// Sample events (raw values from back-end state).
 
 using probe_handle = const fvm_value_type*;
 

--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -15,6 +15,7 @@
 #include <arbor/morph/mprovider.hpp>
 #include <arbor/morph/morphology.hpp>
 #include <arbor/morph/primitives.hpp>
+#include <arbor/util/hash_def.hpp>
 #include <arbor/util/typed_map.hpp>
 
 namespace arb {
@@ -52,7 +53,10 @@ using cable_sample_range = std::pair<const double*, const double*>;
 //     * `cable_probe_point_info` for point mechanism state queries;
 //     * `mcable_list` for most vector queries;
 //     * `std::vector<cable_probe_point_info>` for cell-wide point mechanism state queries.
-
+//
+// Scalar probes which are described by a locset expression will generate multiple
+// calls to an attached sampler, one per valid location matched by the expression.
+//
 // Metadata for point process probes.
 struct cable_probe_point_info {
     cell_lid_type target;   // Target number of point process instance on cell.
@@ -64,7 +68,7 @@ struct cable_probe_point_info {
 // Sample value type: `double`
 // Sample metadata type: `mlocation`
 struct cable_probe_membrane_voltage {
-    mlocation location;
+    locset locations;
 };
 
 // Voltage estimate [mV], reported against each cable in each control volume. Not interpolated.
@@ -76,14 +80,14 @@ struct cable_probe_membrane_voltage_cell {};
 // Sample value type: `double`
 // Sample metadata type: `mlocation`
 struct cable_probe_axial_current {
-    mlocation location;
+    locset locations;
 };
 
 // Total current density [A/m²] across membrane _excluding_ capacitive current at `location`.
 // Sample value type: `cable_sample_range`
 // Sample metadata type: `mlocation`
 struct cable_probe_total_ion_current_density {
-    mlocation location;
+    locset locations;
 };
 
 // Total ionic current [nA] across membrance _excluding_ capacitive current across components of the cell.
@@ -100,7 +104,7 @@ struct cable_probe_total_current_cell {};
 // Sample value type: `double`
 // Sample metadata type: `mlocation`
 struct cable_probe_density_state {
-    mlocation location;
+    locset locations;
     std::string mechanism;
     std::string state;
 };
@@ -135,7 +139,7 @@ struct cable_probe_point_state_cell {
 // Sample value type: `double`
 // Sample metadata type: `mlocation`
 struct cable_probe_ion_current_density {
-    mlocation location;
+    locset locations;
     std::string ion;
 };
 
@@ -150,7 +154,7 @@ struct cable_probe_ion_current_cell {
 // Sample value type: `double`
 // Sample metadata type: `mlocation`
 struct cable_probe_ion_int_concentration {
-    mlocation location;
+    locset locations;
     std::string ion;
 };
 
@@ -165,7 +169,7 @@ struct cable_probe_ion_int_concentration_cell {
 // Sample value type: `double`
 // Sample metadata type: `mlocation`
 struct cable_probe_ion_ext_concentration {
-    mlocation location;
+    locset locations;
     std::string ion;
 };
 
@@ -335,3 +339,5 @@ private:
 };
 
 } // namespace arb
+
+ARB_DEFINE_HASH(arb::cable_probe_point_info, a.target, a.multiplicity, a.loc);

--- a/arbor/include/arbor/common_types.hpp
+++ b/arbor/include/arbor/common_types.hpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 
 #include <arbor/util/lexcmp_def.hpp>
+#include <arbor/util/hash_def.hpp>
 
 namespace arb {
 
@@ -96,29 +97,4 @@ std::ostream& operator<<(std::ostream& o, backend_kind k);
 
 } // namespace arb
 
-namespace std {
-    template <> struct hash<arb::cell_member_type> {
-        std::size_t operator()(const arb::cell_member_type& m) const {
-            using namespace arb;
-            if (sizeof(std::size_t)>sizeof(cell_gid_type)) {
-                constexpr unsigned shift = 8*sizeof(cell_gid_type);
-
-                std::size_t k = m.gid;
-                k <<= (shift/2); // dodge gcc shift warning when other branch taken
-                k <<= (shift/2);
-                k += m.index;
-                return std::hash<std::size_t>{}(k);
-            }
-            else {
-                constexpr std::size_t prime1 = 93481;
-                constexpr std::size_t prime2 = 54517;
-
-                std::size_t k = prime1;
-                k = k*prime2 + m.gid;
-                k = k*prime2 + m.index;
-                return k;
-            }
-        }
-    };
-}
-
+ARB_DEFINE_HASH(arb::cell_member_type, a.gid, a.index)

--- a/arbor/include/arbor/load_balance.hpp
+++ b/arbor/include/arbor/load_balance.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstddef>
+#include <unordered_map>
+
 #include <arbor/context.hpp>
 #include <arbor/domain_decomposition.hpp>
 #include <arbor/recipe.hpp>

--- a/arbor/include/arbor/morph/primitives.hpp
+++ b/arbor/include/arbor/morph/primitives.hpp
@@ -5,6 +5,7 @@
 #include <ostream>
 #include <vector>
 
+#include <arbor/util/hash_def.hpp>
 #include <arbor/util/lexcmp_def.hpp>
 
 //
@@ -139,3 +140,6 @@ ARB_PROP(terminal)
 ARB_PROP(collocated)
 
 } // namespace arb
+
+ARB_DEFINE_HASH(arb::mcable, a.branch, a.prox_pos, a.dist_pos);
+ARB_DEFINE_HASH(arb::mlocation, a.branch, a.pos);

--- a/arbor/include/arbor/recipe.hpp
+++ b/arbor/include/arbor/recipe.hpp
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <cstddef>
-#include <memory>
-#include <unordered_map>
-#include <stdexcept>
+#include <utility>
+#include <vector>
 
-#include <arbor/arbexcept.hpp>
 #include <arbor/common_types.hpp>
 #include <arbor/event_generator.hpp>
 #include <arbor/util/unique_any.hpp>
@@ -13,11 +10,19 @@
 namespace arb {
 
 struct probe_info {
-    cell_member_type id;
     probe_tag tag;
 
     // Address type will be specific to cell kind of cell `id.gid`.
     util::any address;
+
+    probe_info(probe_info&) = default;
+    probe_info(const probe_info&) = default;
+    probe_info(probe_info&&) = default;
+
+    // Implicit ctor uses tag of zero.
+    template <typename X>
+    probe_info(X&& x, probe_tag tag = 0):
+        tag(tag), address(std::forward<X>(x)) {}
 };
 
 /* Recipe descriptions are cell-oriented: in order that the building
@@ -66,7 +71,6 @@ public:
 
     virtual cell_size_type num_sources(cell_gid_type) const { return 0; }
     virtual cell_size_type num_targets(cell_gid_type) const { return 0; }
-    virtual cell_size_type num_probes(cell_gid_type)  const { return 0; }
     virtual cell_size_type num_gap_junction_sites(cell_gid_type gid)  const {
         return gap_junctions_on(gid).size();
     }
@@ -80,8 +84,8 @@ public:
         return {};
     }
 
-    virtual probe_info get_probe(cell_member_type probe_id) const {
-        throw bad_probe_id(probe_id);
+    virtual std::vector<probe_info> get_probes(cell_gid_type gid) const {
+        return {};
     }
 
     // Global property type will be specific to given cell kind.

--- a/arbor/include/arbor/sampling.hpp
+++ b/arbor/include/arbor/sampling.hpp
@@ -16,15 +16,20 @@ inline cell_member_predicate one_probe(cell_member_type pid) {
     return [pid](cell_member_type x) { return pid==x; };
 }
 
+struct probe_metadata {
+    cell_member_type id; // probe id
+    probe_tag tag;       // probe tag associated with id
+    unsigned index;      // index of probe source within those supplied by probe id
+    util::any_ptr meta;  // probe-specific metadata
+};
+
 struct sample_record {
     time_type time;
     util::any_ptr data;
 };
 
 using sampler_function = std::function<
-    void (cell_member_type,     // probe id
-          probe_tag,            // probe tag associated with probe id
-          util::any_ptr,        // pointer to constant metadata
+    void (probe_metadata,
           std::size_t,          // number of sample records
           const sample_record*  // pointer to first sample record
          )>;

--- a/arbor/include/arbor/simple_sampler.hpp
+++ b/arbor/include/arbor/simple_sampler.hpp
@@ -68,12 +68,12 @@ struct trace_data<V, void>: private std::vector<trace_entry<V>> {
 // the ith element will correspond to the sample data obtained
 // from the probe with index i.
 //
-// The overriden method `at(i)` returns a const reference to the ith
+// The method `get(i)` returns a const reference to the ith
 // element if it exists, or else to an empty trace_data value.
 
 template <typename V, typename Meta = void>
 struct trace_vector: private std::vector<trace_data<V, Meta>> {
-    const trace_data<V, Meta>& at(std::size_t i) const {
+    const trace_data<V, Meta>& get(std::size_t i) const {
         return i<this->size()? (*this)[i]: empty_trace;
     }
 

--- a/arbor/include/arbor/simple_sampler.hpp
+++ b/arbor/include/arbor/simple_sampler.hpp
@@ -46,7 +46,7 @@ struct trace_data: private std::vector<trace_entry<V>> {
 };
 
 template <typename V>
-struct trace_data<V, void>: public std::vector<trace_entry<V>> {
+struct trace_data<V, void>: private std::vector<trace_entry<V>> {
     explicit operator bool() const { return !this->empty(); }
 
     using base = std::vector<trace_entry<V>>;
@@ -72,7 +72,7 @@ struct trace_data<V, void>: public std::vector<trace_entry<V>> {
 // element if it exists, or else to an empty trace_data value.
 
 template <typename V, typename Meta = void>
-struct trace_vector: public std::vector<trace_data<V, Meta>> {
+struct trace_vector: private std::vector<trace_data<V, Meta>> {
     const trace_data<V, Meta>& at(std::size_t i) const {
         return i<this->size()? (*this)[i]: empty_trace;
     }

--- a/arbor/include/arbor/simple_sampler.hpp
+++ b/arbor/include/arbor/simple_sampler.hpp
@@ -22,16 +22,76 @@ struct trace_entry {
     V v;
 };
 
-// Trace data wraps a std::vector of trace_entry, optionally with
-// a copy of the metadata associated with a probe.
+// `trace_data` wraps a std::vector of trace_entry with
+// a copy of the probe-specific metadata associated with a probe.
+//
+// If `Meta` is void, ignore any metadta.
 
 template <typename V, typename Meta = void>
-struct trace_data: public std::vector<trace_entry<V>> {
-    util::optional<Meta> metadata;
+struct trace_data: private std::vector<trace_entry<V>> {
+    Meta meta;
+    explicit operator bool() const { return !this->empty(); }
+
+    using base = std::vector<trace_entry<V>>;
+    using base::size;
+    using base::empty;
+    using base::at;
+    using base::begin;
+    using base::end;
+    using base::clear;
+    using base::resize;
+    using base::push_back;
+    using base::emplace_back;
+    using base::operator[];
 };
 
 template <typename V>
-struct trace_data<V, void>: public std::vector<trace_entry<V>> {};
+struct trace_data<V, void>: public std::vector<trace_entry<V>> {
+    explicit operator bool() const { return !this->empty(); }
+
+    using base = std::vector<trace_entry<V>>;
+    using base::size;
+    using base::empty;
+    using base::at;
+    using base::begin;
+    using base::end;
+    using base::clear;
+    using base::resize;
+    using base::push_back;
+    using base::emplace_back;
+    using base::operator[];
+};
+
+// `trace_vector` wraps a vector of `trace_data`.
+//
+// When there are multiple probes associated with a probe id,
+// the ith element will correspond to the sample data obtained
+// from the probe with index i.
+//
+// The overriden method `at(i)` returns a const reference to the ith
+// element if it exists, or else to an empty trace_data value.
+
+template <typename V, typename Meta = void>
+struct trace_vector: public std::vector<trace_data<V, Meta>> {
+    const trace_data<V, Meta>& at(std::size_t i) const {
+        return i<this->size()? (*this)[i]: empty_trace;
+    }
+
+    using base = std::vector<trace_data<V, Meta>>;
+    using base::size;
+    using base::empty;
+    using base::at;
+    using base::begin;
+    using base::end;
+    using base::clear;
+    using base::resize;
+    using base::push_back;
+    using base::emplace_back;
+    using base::operator[];
+
+private:
+    trace_data<V, Meta> empty_trace;
+};
 
 // Add a bit of smarts for collecting variable-length samples which are
 // passed back as a pair of pointers describing a range; these can
@@ -68,49 +128,57 @@ struct trace_push_back<std::vector<V>> {
 template <typename V, typename Meta = void>
 class simple_sampler {
 public:
-    explicit simple_sampler(trace_data<V, Meta>& trace): trace_(trace) {}
+    explicit simple_sampler(trace_vector<V, Meta>& trace): trace_(trace) {}
 
-    void operator()(cell_member_type probe_id, probe_tag tag, util::any_ptr meta, std::size_t n, const sample_record* recs) {
-        // TODO: C++17 use if constexpr to test for Meta = void case.
-        if (meta && !trace_.metadata) {
-            if (auto m = util::any_cast<const Meta*>(meta)) {
-                trace_.metadata = *m;
-            }
-            else {
-                throw std::runtime_error("unexpected metadata type in simple_sampler");
-            }
+    // TODO: C++17 use if constexpr to test for Meta = void case.
+    void operator()(probe_metadata pm, std::size_t n, const sample_record* recs) {
+        const Meta* m = util::any_cast<const Meta*>(pm.meta);
+        if (!m) {
+            throw std::runtime_error("unexpected metadata type in simple_sampler");
+        }
+
+        if (trace_.size()<=pm.index) {
+            trace_.resize(pm.index+1);
+        }
+
+        if (trace_[pm.index].empty()) {
+            trace_[pm.index].meta = *m;
         }
 
         for (std::size_t i = 0; i<n; ++i) {
-            if (!trace_push_back<V>::push_back(trace_, recs[i])) {
+            if (!trace_push_back<V>::push_back(trace_[pm.index], recs[i])) {
                 throw std::runtime_error("unexpected sample type in simple_sampler");
             }
         }
     }
 
 private:
-    trace_data<V, Meta>& trace_;
+    trace_vector<V, Meta>& trace_;
 };
 
 template <typename V>
 class simple_sampler<V, void> {
 public:
-    explicit simple_sampler(trace_data<V, void>& trace): trace_(trace) {}
+    explicit simple_sampler(trace_vector<V, void>& trace): trace_(trace) {}
 
-    void operator()(cell_member_type probe_id, probe_tag tag, util::any_ptr meta, std::size_t n, const sample_record* recs) {
+    void operator()(probe_metadata pm, std::size_t n, const sample_record* recs) {
+        if (trace_.size()<=pm.index) {
+            trace_.resize(pm.index+1);
+        }
+
         for (std::size_t i = 0; i<n; ++i) {
-            if (!trace_push_back<V>::push_back(trace_, recs[i])) {
+            if (!trace_push_back<V>::push_back(trace_[pm.index], recs[i])) {
                 throw std::runtime_error("unexpected sample type in simple_sampler");
             }
         }
     }
 
 private:
-    trace_data<V, void>& trace_;
+    trace_vector<V, void>& trace_;
 };
 
 template <typename V, typename Meta>
-inline simple_sampler<V, Meta> make_simple_sampler(trace_data<V, Meta>& trace) {
+inline simple_sampler<V, Meta> make_simple_sampler(trace_vector<V, Meta>& trace) {
     return simple_sampler<V, Meta>(trace);
 }
 

--- a/arbor/include/arbor/symmetric_recipe.hpp
+++ b/arbor/include/arbor/symmetric_recipe.hpp
@@ -47,10 +47,6 @@ public:
         return tiled_recipe_->num_targets(i % tiled_recipe_->num_cells());
     }
 
-    cell_size_type num_probes(cell_gid_type i) const override {
-        return tiled_recipe_->num_probes(i % tiled_recipe_->num_cells());
-    }
-
     // Only function that calls the underlying tile's function on the same gid.
     // This is because applying transformations to event generators is not straightforward.
     std::vector<event_generator> event_generators(cell_gid_type i) const override {
@@ -73,9 +69,9 @@ public:
         return conns;
     }
 
-    probe_info get_probe(cell_member_type probe_id) const override {
-        probe_id.gid %= tiled_recipe_->num_cells();
-        return tiled_recipe_->get_probe(probe_id);
+    std::vector<probe_info> get_probes(cell_gid_type i) const override {
+        i %= tiled_recipe_->num_cells();
+        return tiled_recipe_->get_probes(i);
     }
 
     util::any get_global_properties(cell_kind ck) const override {

--- a/arbor/include/arbor/util/hash_def.hpp
+++ b/arbor/include/arbor/util/hash_def.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/*
+ * Macro definitions for defining hash functions for compound objects.
+ *
+ * Use:
+ *
+ * To define a std::hash overload for a record type xyzzy
+ * with fields foo, bar and baz:
+ *
+ * ARB_DEFINE_HASH(xyzzy, a.foo, a.bar, a.baz)
+ *
+ * The explicit use of 'a' in the macro invocation is just to simplify
+ * the implementation.
+ *
+ * The macro must be used outside of any namespace.
+ */
+
+#include <cstddef>
+#include <typeindex>
+
+// Helpers for forming hash values of compounds objects.
+
+namespace arb {
+
+inline std::size_t hash_value_combine(std::size_t n) {
+    return n;
+}
+
+template <typename... T>
+std::size_t hash_value_combine(std::size_t n, std::size_t m, T... tail) {
+    constexpr std::size_t prime2 = 54517;
+    return hash_value_combine(prime2*n + m, tail...);
+}
+
+template <typename... T>
+std::size_t hash_value(const T&... t) {
+    constexpr std::size_t prime1 = 93481;
+    return hash_value_combine(prime1, std::hash<T>{}(t)...);
+}
+}
+
+#define ARB_DEFINE_HASH(type,...)\
+namespace std {\
+template <> struct hash<type> { std::size_t operator()(const type& a) const { return ::arb::hash_value(__VA_ARGS__); }};\
+}

--- a/arbor/include/arbor/util/lexcmp_def.hpp
+++ b/arbor/include/arbor/util/lexcmp_def.hpp
@@ -9,7 +9,7 @@
  * To define comparison operations for a record type xyzzy
  * with fields foo, bar and baz:
  *
- * DEFINE_LEXICOGRAPHIC_ORDERING(xyzzy,(a.foo,a.bar,a.baz),(b.foo,b.bar,b.baz))
+ * ARB_DEFINE_LEXICOGRAPHIC_ORDERING(xyzzy,(a.foo,a.bar,a.baz),(b.foo,b.bar,b.baz))
  *
  * The explicit use of 'a' and 'b' in the second and third parameters
  * is needed only to save a heroic amount of preprocessor macro

--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -43,9 +43,7 @@ mc_cell_group::mc_cell_group(const std::vector<cell_gid_type>& gids, const recip
             util::transform_view(gids_, [&rec](cell_gid_type i) { return rec.num_targets(i); }));
     std::size_t n_targets = target_handle_divisions_.back();
 
-    // Pre-allocate space to store handles, probe map.
-    auto n_probes = util::sum_by(gids_, [&rec](cell_gid_type i) { return rec.num_probes(i); });
-    probe_map_.reserve(n_probes);
+    // Pre-allocate space to store handles.
     target_handles_.reserve(n_targets);
 
     // Construct cell implementation, retrieving handles and maps. 
@@ -86,6 +84,8 @@ struct sampler_call_info {
     sampler_function sampler;
     cell_member_type probe_id;
     probe_tag tag;
+    unsigned index;
+    const fvm_probe_data* pdata_ptr;
 
     // Offsets are into lowered cell sample time and event arrays.
     sample_size_type begin_offset;
@@ -112,7 +112,7 @@ void run_samples(
     std::vector<sample_record>&,
     fvm_probe_scratch&)
 {
-    throw arbor_internal_error("invalid fvm_probe_info in sampler map");
+    throw arbor_internal_error("invalid fvm_probe_data in sampler map");
 }
 
 void run_samples(
@@ -135,7 +135,7 @@ void run_samples(
 
     // Metadata may be an mlocation or cell_lid_type (for point mechanism state probes).
     util::visit(
-        [&](auto& metadata) { sc.sampler(sc.probe_id, sc.tag, &metadata, n_sample, sample_records.data()); },
+        [&](auto& metadata) { sc.sampler({sc.probe_id, sc.tag, sc.index, &metadata}, n_sample, sample_records.data()); },
         p.metadata);
 }
 
@@ -166,7 +166,7 @@ void run_samples(
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &ctmp[j]});
     }
 
-    sc.sampler(sc.probe_id, sc.tag, &p.metadata, n_sample, sample_records.data());
+    sc.sampler({sc.probe_id, sc.tag, sc.index, &p.metadata}, n_sample, sample_records.data());
 }
 
 void run_samples(
@@ -198,7 +198,7 @@ void run_samples(
 
     // Metadata may be an mlocation_list or mcable_list.
     util::visit(
-        [&](auto& metadata) { sc.sampler(sc.probe_id, sc.tag, &metadata, n_sample, sample_records.data()); },
+        [&](auto& metadata) { sc.sampler({sc.probe_id, sc.tag, sc.index, &metadata}, n_sample, sample_records.data()); },
         p.metadata);
 }
 
@@ -243,8 +243,9 @@ void run_samples(
     }
 
     // (Unlike fvm_probe_multi, we only have mcable_list metadata.)
-    sc.sampler(sc.probe_id, sc.tag, &p.metadata, n_sample, sample_records.data());
+    sc.sampler({sc.probe_id, sc.tag, sc.index, &p.metadata}, n_sample, sample_records.data());
 }
+
 void run_samples(
     const fvm_probe_membrane_currents& p,
     const sampler_call_info& sc,
@@ -304,19 +305,18 @@ void run_samples(
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }
 
-    sc.sampler(sc.probe_id, sc.tag, &p.metadata, n_sample, sample_records.data());
+    sc.sampler({sc.probe_id, sc.tag, sc.index, &p.metadata}, n_sample, sample_records.data());
 }
 
 // Generic run_samples dispatches on probe info variant type.
 void run_samples(
-    const fvm_probe_info& p,
     const sampler_call_info& sc,
     const fvm_value_type* raw_times,
     const fvm_value_type* raw_samples,
     std::vector<sample_record>& sample_records,
     fvm_probe_scratch& scratch)
 {
-    util::visit([&](auto& x) {run_samples(x, sc, raw_times, raw_samples, sample_records, scratch); }, p.info);
+    util::visit([&](auto& x) {run_samples(x, sc, raw_times, raw_samples, sample_records, scratch); }, sc.pdata_ptr->info);
 }
 
 void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& event_lanes) {
@@ -402,20 +402,22 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
 
         for (cell_member_type pid: sa.probe_ids) {
             auto cell_index = gid_index_map_.at(pid.gid);
-            auto p = probe_map_[pid];
-            sample_size_type n_raw = p.handle.n_raw();
 
-            call_info.push_back({sa.sampler, pid, p.tag, n_samples, n_samples+n_times*n_raw});
-
-            for (auto t: sample_times) {
+            probe_tag tag = probe_map_.tag.at(pid);
+            unsigned index = 0;
+            for (const fvm_probe_data& pdata: probe_map_.data_on(pid)) {
+                call_info.push_back({sa.sampler, pid, tag, index++, &pdata, n_samples, n_samples + n_times*pdata.n_raw()});
                 auto intdom = cell_to_intdom_[cell_index];
-                for (probe_handle h: p.handle.raw_handle_range()) {
-                    sample_event ev{t, (cell_gid_type)intdom, {h, n_samples++}};
-                    sample_events.push_back(ev);
-                }
-                if (sa.policy==sampling_policy::exact) {
-                    target_handle h(-1, 0, intdom);
-                    exact_sampling_events.push_back({t, h, 0.f});
+
+                for (auto t: sample_times) {
+                    for (probe_handle h: pdata.raw_handle_range()) {
+                        sample_event ev{t, (cell_gid_type)intdom, {h, n_samples++}};
+                        sample_events.push_back(ev);
+                    }
+                    if (sa.policy==sampling_policy::exact) {
+                        target_handle h(-1, 0, intdom);
+                        exact_sampling_events.push_back({t, h, 0.f});
+                    }
                 }
             }
         }
@@ -462,8 +464,7 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
     reserve_scratch(scratch, max_samples_per_call);
 
     for (auto& sc: call_info) {
-        run_samples(probe_map_[sc.probe_id].handle, sc, result.sample_time.data(), result.sample_value.data(),
-            sample_records, scratch);
+        run_samples(sc, result.sample_time.data(), result.sample_value.data(), sample_records, scratch);
     }
     PL();
 
@@ -481,7 +482,7 @@ void mc_cell_group::add_sampler(sampler_association_handle h, cell_member_predic
                                 schedule sched, sampler_function fn, sampling_policy policy)
 {
     std::vector<cell_member_type> probeset =
-        util::assign_from(util::filter(util::keys(probe_map_), probe_ids));
+        util::assign_from(util::filter(util::keys(probe_map_.tag), probe_ids));
 
     if (!probeset.empty()) {
         sampler_map_.add(h, sampler_association{std::move(sched), std::move(fn), std::move(probeset), policy});

--- a/arbor/mc_cell_group.hpp
+++ b/arbor/mc_cell_group.hpp
@@ -89,7 +89,7 @@ private:
     std::vector<target_handle> target_handles_;
 
     // Maps probe ids to probe handles (from lowered cell) and tags (from probe descriptions).
-    probe_association_map<fvm_probe_info> probe_map_;
+    probe_association_map probe_map_;
 
     // Collection of samplers to be run against probes in this group.
     sampler_association_map sampler_map_;

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -1,7 +1,9 @@
 #include <queue>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include <arbor/arbexcept.hpp>
 #include <arbor/domain_decomposition.hpp>
 #include <arbor/load_balance.hpp>
 #include <arbor/recipe.hpp>

--- a/arbor/sampler_map.hpp
+++ b/arbor/sampler_map.hpp
@@ -61,16 +61,4 @@ public:
     auto end()   { return assoc_view().end(); }
 };
 
-// Manage associations between probe ids, probe tags, and (lowered cell) probe handles.
-
-template <typename Handle>
-struct probe_association {
-    using probe_handle_type = Handle;
-    probe_handle_type handle;
-    probe_tag tag;
-};
-
-template <typename Handle>
-using probe_association_map = std::unordered_map<cell_member_type, probe_association<Handle>>;
-
 } // namespace arb

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -2,6 +2,7 @@
 #include <set>
 #include <vector>
 
+#include <arbor/arbexcept.hpp>
 #include <arbor/context.hpp>
 #include <arbor/domain_decomposition.hpp>
 #include <arbor/generic_event.hpp>

--- a/arbor/spike_source_cell_group.cpp
+++ b/arbor/spike_source_cell_group.cpp
@@ -1,5 +1,6 @@
 #include <exception>
 
+#include <arbor/arbexcept.hpp>
 #include <arbor/recipe.hpp>
 #include <arbor/spike_source_cell.hpp>
 #include <arbor/schedule.hpp>

--- a/doc/cpp_cable_cell.rst
+++ b/doc/cpp_cable_cell.rst
@@ -308,20 +308,26 @@ Mechanism state queries however will throw a ``cable_cell_error`` exception
 at simulation initialization if the requested state variable does not exist
 on the mechanism.
 
+Cable cell probe addresses that are described by a ``locset`` may generate more
+than one concrete probe: there will be one per location in the locset that is
+satisfiable. Sampler callback functions can distinguish between different
+probes with the same address and id by examining their index and/or
+probe-sepcific metadata found in the ``probe_metadata`` parameter.
+
 Membrane voltage
 ^^^^^^^^^^^^^^^^
 
 .. code::
 
     struct cable_probe_membrane_voltage {
-        mlocation location;
+        locset locations;
     };
 
-Queries cell membrane potential at the specified location.
+Queries cell membrane potential at each site in ``locations``.
 
 *  Sample value: ``double``. Membrane potential in millivolts.
 
-*  Metadata: ``mlocation``. Location as given in the probe address.
+*  Metadata: ``mlocation``. Location of probe.
 
 
 .. code::
@@ -343,14 +349,15 @@ Axial current
 .. code::
 
     struct cable_probe_axial_current {
-        mlocation location;
+        locset locations;
     };
 
-Estimate intracellular current at given location in the distal direction.
+Estimate intracellular current at each site in ``locations``,
+in the distal direction.
 
 *  Sample value: ``double``. Current in nanoamperes.
 
-*  Metadata: ``mlocation``. Location as given in the probe address.
+*  Metadata: ``mlocation``. Location as of probe.
 
 
 Transmembrane current
@@ -359,15 +366,16 @@ Transmembrane current
 .. code::
 
     struct cable_probe_ion_current_density {
-        mlocation location;
+        locset locations;
         std::string ion;
     };
 
-Membrance current density attributed to a particular ion at a given location.
+Membrance current density attributed to a particular ion at
+each site in ``locations``.
 
 *  Sample value: ``double``. Current density in amperes per square metre.
 
-*  Metadata: ``mlocation``. Location as given in the probe address.
+*  Metadata: ``mlocation``. Location of probe.
 
 
 .. code::
@@ -389,14 +397,14 @@ Membrane current attributed to a particular ion across components of the cell.
 .. code::
 
     struct cable_probe_total_ion_current_density {
-        mlocation location;
+        locset locations;
     };
 
-Membrane current density at gvien location _excluding_ capacitive currents.
+Membrane current density at given locations _excluding_ capacitive currents.
 
 *  Sample value: ``double``. Current density in amperes per square metre.
 
-*  Metadata: ``mlocation``. Location as given in the probe address.
+*  Metadata: ``mlocation``. Location of probe.
 
 
 .. code::
@@ -433,15 +441,15 @@ Ion concentration
 .. code::
 
     struct cable_probe_ion_int_concentration {
-        mlocation location;
+        locset locations;
         std::string ion;
     };
 
-Ionic internal concentration of ion at given location.
+Ionic internal concentration of ion at each site in ``locations``.
 
 *  Sample value: ``double``. Ion concentration in millimoles per litre.
 
-*  Metadata: ``mlocation``. Location as given in the probe address.
+*  Metadata: ``mlocation``. Location of probe.
 
 
 .. code::
@@ -467,11 +475,11 @@ Ionic external concentration of ion across components of the cell.
         std::string ion;
     };
 
-Ionic internal concentration of ion at given location.
+Ionic external concentration of ion at each site in ``locations``.
 
 *  Sample value: ``double``. Ion concentration in millimoles per litre.
 
-*  Metadata: ``mlocation``. Location as given in the probe address.
+*  Metadata: ``mlocation``. Location of probe.
 
 
 .. code::
@@ -497,14 +505,14 @@ Mechanism state
 .. code::
 
     struct cable_probe_density_state {
-        mlocation location;
+        locset locations;
         std::string mechanism;
         std::string state;
     };
 
 
-Value of state variable in a density mechanism in at given location.
-If the mechanism is not defined at the location, the probe is ignored.
+Value of state variable in a density mechanism in each site in ``locations``.
+If the mechanism is not defined at a particular site, that site is ignored.
 
 *  Sample value: ``double``. State variable value.
 

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -168,14 +168,6 @@ public:
         return 1;
     }
 
-    cell_size_type num_probes(cell_gid_type) const override {
-        return 0;
-    }
-
-    probe_info get_probe(cell_member_type probe_id) const override {
-        return {};
-    }
-
 private:
     // Number of excitatory cells.
     cell_size_type ncells_exc_;

--- a/example/dryrun/dryrun.cpp
+++ b/example/dryrun/dryrun.cpp
@@ -17,7 +17,6 @@
 #include <arbor/morph/primitives.hpp>
 #include <arbor/profile/meter_manager.hpp>
 #include <arbor/profile/profiler.hpp>
-#include <arbor/simple_sampler.hpp>
 #include <arbor/simulation.hpp>
 #include <arbor/symmetric_recipe.hpp>
 #include <arbor/recipe.hpp>
@@ -120,16 +119,9 @@ public:
         return gens;
     }
 
-    // There is one probe (for measuring voltage at the soma) on the cell.
-    cell_size_type num_probes(cell_gid_type gid)  const override {
-        return 1;
-    }
-
-    arb::probe_info get_probe(cell_member_type id) const override {
-        // Measure at the soma.
-        arb::mlocation loc{0, 0.0};
-
-        return arb::probe_info{id, 0, arb::cable_probe_membrane_voltage{loc}};
+    std::vector<arb::probe_info> get_probes(cell_gid_type gid) const override {
+        // One probe per cell, sampling membrane voltage at end of soma.
+        return {arb::cable_probe_membrane_voltage{arb::mlocation{0, 0.0}}};
     }
 
 private:

--- a/example/generators/generators.cpp
+++ b/example/generators/generators.cpp
@@ -115,19 +115,12 @@ public:
         return gens;
     }
 
-    // There is one probe (for measuring voltage at the soma) on the cell
-    cell_size_type num_probes(cell_gid_type gid)  const override {
-        assert(gid==0); // There is only one cell in the model
-        return 1;
-    }
+    std::vector<arb::probe_info> get_probes(cell_gid_type gid) const override {
+        assert(gid==0);     // There is only one cell,
 
-    arb::probe_info get_probe(cell_member_type id) const override {
-        assert(id.gid==0);     // There is one cell,
-        assert(id.index==0);   // with one probe.
-
-        // Measure at the soma
+        // Measure membrane voltage at end of soma.
         arb::mlocation loc{0, 0.0};
-        return arb::probe_info{id, 0, arb::cable_probe_membrane_voltage{loc}};
+        return {arb::cable_probe_membrane_voltage{loc}};
     }
 };
 
@@ -153,7 +146,7 @@ int main() {
     // The schedule for sampling is 10 samples every 1 ms.
     auto sched = arb::regular_schedule(0.1);
     // This is where the voltage samples will be stored as (time, value) pairs
-    arb::trace_data<double> voltage;
+    arb::trace_vector<double> voltage;
     // Now attach the sampler at probe_id, with sampling schedule sched, writing to voltage
     sim.add_sampler(arb::one_probe(probe_id), sched, arb::make_simple_sampler(voltage));
 
@@ -161,7 +154,7 @@ int main() {
     sim.run(100, 0.01);
 
     // Write the samples to a json file.
-    write_trace_json(voltage);
+    write_trace_json(voltage.at(0));
 }
 
 void write_trace_json(const arb::trace_data<double>& trace) {

--- a/example/probe-demo/probe-demo.cpp
+++ b/example/probe-demo/probe-demo.cpp
@@ -83,8 +83,8 @@ struct options {
 
 const char* argv0 = "";
 bool parse_options(options&, int& argc, char** argv);
-void vector_sampler(arb::cell_member_type, arb::probe_tag, any_ptr, std::size_t, const arb::sample_record*);
-void scalar_sampler(arb::cell_member_type, arb::probe_tag, any_ptr, std::size_t, const arb::sample_record*);
+void vector_sampler(arb::probe_metadata, std::size_t, const arb::sample_record*);
+void scalar_sampler(arb::probe_metadata, std::size_t, const arb::sample_record*);
 
 struct cable_recipe: public arb::recipe {
     arb::cable_cell_global_properties gprop;
@@ -98,11 +98,10 @@ struct cable_recipe: public arb::recipe {
     }
 
     arb::cell_size_type num_cells() const override { return 1; }
-    arb::cell_size_type num_probes(arb::cell_gid_type) const override { return 1; }
     arb::cell_size_type num_targets(arb::cell_gid_type) const override { return 0; }
 
-    arb::probe_info get_probe(arb::cell_member_type probe_id) const override {
-        return {probe_id, 0, probe_addr}; // (tag value 0 is not used)
+    std::vector<arb::probe_info> get_probes(arb::cell_gid_type) const override {
+        return {probe_addr}; // (use default tag value 0)
     }
 
     arb::cell_kind get_cell_kind(arb::cell_gid_type) const override {
@@ -160,8 +159,8 @@ int main(int argc, char** argv) {
     }
 }
 
-void scalar_sampler(arb::cell_member_type, arb::probe_tag, any_ptr meta, std::size_t n, const arb::sample_record* samples) {
-    auto* loc = any_cast<const arb::mlocation*>(meta);
+void scalar_sampler(arb::probe_metadata pm, std::size_t n, const arb::sample_record* samples) {
+    auto* loc = any_cast<const arb::mlocation*>(pm.meta);
     assert(loc);
 
     std::cout << std::fixed << std::setprecision(4);
@@ -173,8 +172,8 @@ void scalar_sampler(arb::cell_member_type, arb::probe_tag, any_ptr meta, std::si
     }
 }
 
-void vector_sampler(arb::cell_member_type, arb::probe_tag, any_ptr meta, std::size_t n, const arb::sample_record* samples) {
-    auto* cables_ptr = any_cast<const arb::mcable_list*>(meta);
+void vector_sampler(arb::probe_metadata pm, std::size_t n, const arb::sample_record* samples) {
+    auto* cables_ptr = any_cast<const arb::mcable_list*>(pm.meta);
     assert(cables_ptr);
     unsigned n_cable = cables_ptr->size();
 
@@ -200,19 +199,21 @@ bool parse_options(options& opt, int& argc, char** argv) {
 
     auto do_help = [&]() { usage(argv0, help_msg); };
 
+    using L = arb::mlocation;
+
     // Map probe argument to output variable name, scalarity, and a lambda that makes specific probe address from a location.
     std::pair<const char*, std::tuple<const char*, bool, std::function<any (double)>>> probe_tbl[] {
         // located probes
-        {"v",         {"v",       true,  [](double x) { return arb::cable_probe_membrane_voltage{{0, x}}; }}},
-        {"i_axial",   {"i_axial", true,  [](double x) { return arb::cable_probe_axial_current{{0, x}}; }}},
-        {"j_ion",     {"j_ion",   true,  [](double x) { return arb::cable_probe_total_ion_current_density{{0, x}}; }}},
-        {"j_na",      {"j_na",    true,  [](double x) { return arb::cable_probe_ion_current_density{{0, x}, "na"}; }}},
-        {"j_k",       {"j_k",     true,  [](double x) { return arb::cable_probe_ion_current_density{{0, x}, "k"}; }}},
-        {"c_na",      {"c_na",    true,  [](double x) { return arb::cable_probe_ion_int_concentration{{0, x}, "na"}; }}},
-        {"c_k",       {"c_k",     true,  [](double x) { return arb::cable_probe_ion_int_concentration{{0, x}, "k"}; }}},
-        {"hh_m",      {"hh_m",    true,  [](double x) { return arb::cable_probe_density_state{{0, x}, "hh", "m"}; }}},
-        {"hh_h",      {"hh_h",    true,  [](double x) { return arb::cable_probe_density_state{{0, x}, "hh", "h"}; }}},
-        {"hh_n",      {"hh_n",    true,  [](double x) { return arb::cable_probe_density_state{{0, x}, "hh", "n"}; }}},
+        {"v",         {"v",       true,  [](double x) { return arb::cable_probe_membrane_voltage{L{0, x}}; }}},
+        {"i_axial",   {"i_axial", true,  [](double x) { return arb::cable_probe_axial_current{L{0, x}}; }}},
+        {"j_ion",     {"j_ion",   true,  [](double x) { return arb::cable_probe_total_ion_current_density{L{0, x}}; }}},
+        {"j_na",      {"j_na",    true,  [](double x) { return arb::cable_probe_ion_current_density{L{0, x}, "na"}; }}},
+        {"j_k",       {"j_k",     true,  [](double x) { return arb::cable_probe_ion_current_density{L{0, x}, "k"}; }}},
+        {"c_na",      {"c_na",    true,  [](double x) { return arb::cable_probe_ion_int_concentration{L{0, x}, "na"}; }}},
+        {"c_k",       {"c_k",     true,  [](double x) { return arb::cable_probe_ion_int_concentration{L{0, x}, "k"}; }}},
+        {"hh_m",      {"hh_m",    true,  [](double x) { return arb::cable_probe_density_state{L{0, x}, "hh", "m"}; }}},
+        {"hh_h",      {"hh_h",    true,  [](double x) { return arb::cable_probe_density_state{L{0, x}, "hh", "h"}; }}},
+        {"hh_n",      {"hh_n",    true,  [](double x) { return arb::cable_probe_density_state{L{0, x}, "hh", "n"}; }}},
         // all-of-cell probes
         {"all_v",     {"v",       false, [](double)   { return arb::cable_probe_membrane_voltage_cell{}; }}},
         {"all_i_ion", {"i_ion",   false, [](double)   { return arb::cable_probe_total_ion_current_cell{}; }}},

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -3,6 +3,7 @@
  *
  */
 
+#include <cassert>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -108,15 +109,10 @@ public:
         return gens;
     }
 
-    // There is one probe (for measuring voltage at the soma) on the cell.
-    cell_size_type num_probes(cell_gid_type gid)  const override {
-        return 1;
-    }
-
-    arb::probe_info get_probe(cell_member_type id) const override {
-        // Measure at the soma.
+    std::vector<arb::probe_info> get_probes(cell_gid_type gid) const override {
+        // Measure membrane voltage at end of soma.
         arb::mlocation loc{0, 0.0};
-        return arb::probe_info{id, 0, arb::cable_probe_membrane_voltage{loc}};
+        return {arb::cable_probe_membrane_voltage{loc}};
     }
 
     arb::util::any get_global_properties(arb::cell_kind) const override {
@@ -186,7 +182,7 @@ int main(int argc, char** argv) {
         // The schedule for sampling is 10 samples every 1 ms.
         auto sched = arb::regular_schedule(1);
         // This is where the voltage samples will be stored as (time, value) pairs
-        arb::trace_data<double> voltage;
+        arb::trace_vector<double> voltage;
         // Now attach the sampler at probe_id, with sampling schedule sched, writing to voltage
         sim.add_sampler(arb::one_probe(probe_id), sched, arb::make_simple_sampler(voltage));
 
@@ -229,7 +225,9 @@ int main(int argc, char** argv) {
         }
 
         // Write the samples to a json file.
-        if (root) write_trace_json(voltage);
+        if (root) {
+            write_trace_json(voltage.at(0));
+        }
 
         auto report = arb::profile::make_meter_report(meters, context);
         std::cout << report;

--- a/example/single/single.cpp
+++ b/example/single/single.cpp
@@ -34,17 +34,16 @@ struct single_recipe: public arb::recipe {
     }
 
     arb::cell_size_type num_cells() const override { return 1; }
-    arb::cell_size_type num_probes(arb::cell_gid_type) const override { return 1; }
     arb::cell_size_type num_targets(arb::cell_gid_type) const override { return 1; }
 
-    arb::probe_info get_probe(arb::cell_member_type probe_id) const override {
+    std::vector<arb::probe_info> get_probes(arb::cell_gid_type) const override {
         arb::mlocation mid_soma = {0, 0.5};
         arb::cable_probe_membrane_voltage probe = {mid_soma};
 
-        // Probe info consists of: the probe id, a tag value to distinguish this probe
-        // from others for any attached sampler (unused), and the cell probe address.
+        // Probe info consists of a probe address and an optional tag, for use
+        // by the sampler callback.
 
-        return {probe_id, 0, probe};
+        return {arb::probe_info{probe, 0}};
     }
 
     arb::cell_kind get_cell_kind(arb::cell_gid_type) const override {
@@ -89,8 +88,8 @@ int main(int argc, char** argv) {
 
         // Attach a sampler to the probe described in the recipe, sampling every 0.1 ms.
 
-        arb::trace_data<double> trace;
-        sim.add_sampler(arb::all_probes, arb::regular_schedule(0.1), arb::make_simple_sampler(trace));
+        arb::trace_vector<double> traces;
+        sim.add_sampler(arb::all_probes, arb::regular_schedule(0.1), arb::make_simple_sampler(traces));
 
         // Trigger the single synapse (target is gid 0, index 0) at t = 1 ms with
         // the given weight.
@@ -100,8 +99,7 @@ int main(int argc, char** argv) {
 
         sim.run(opt.t_end, opt.dt);
 
-        std::cout << std::fixed << std::setprecision(4);
-        for (auto entry: trace) {
+        for (auto entry: traces.at(0)) {
             std::cout << entry.t << ", " << entry.v << "\n";
         }
     }

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -29,12 +29,12 @@ arb::util::unique_any py_recipe_shim::get_cell_description(arb::cell_gid_type gi
                 "Python error already thrown");
 }
 
-arb::probe_info cable_probe(std::string kind, arb::cell_member_type id, arb::mlocation loc) {
+arb::probe_info cable_loc_probe(std::string kind, arb::cell_member_type id, arb::mlocation loc) {
     if (kind == "voltage") {
-        return arb::probe_info{id, 0, arb::cable_probe_membrane_voltage{loc}};
+        return arb::cable_probe_membrane_voltage{loc};
     }
     else if (kind == "ionic current density") {
-        return arb::probe_info{id, 0, arb::cable_probe_total_ion_current_density{loc}};
+        return arb::cable_probe_total_ion_current_density{loc};
     }
     else throw pyarb_error(util::pprintf("unrecognized probe kind: {}", kind));
 };
@@ -161,25 +161,22 @@ void register_recipe(pybind11::module& m) {
         .def("gap_junctions_on", &py_recipe::gap_junctions_on,
             "gid"_a,
             "A list of the gap junctions connected to gid, [] by default.")
-        .def("num_probes", &py_recipe::num_probes,
+        .def("get_probes", &py_recipe::get_probes,
             "gid"_a,
-            "The number of probes on gid, 0 by default.")
-        .def("get_probe", &py_recipe::get_probe,
-            "id"_a,
-            "The probe(s) to allow monitoring, must be provided if num_probes() returns a non-zero value.")
+            "The probes to allow monitoring.")
         // TODO: py_recipe::global_properties
         .def("__str__",  [](const py_recipe&){return "<arbor.recipe>";})
         .def("__repr__", [](const py_recipe&){return "<arbor.recipe>";});
 
     // Probes
-    m.def("cable_probe", &cable_probe,
+    m.def("cable_probe", &cable_loc_probe,
         "Description of a probe at a location on a cable cell with id available for monitoring data of kind "\
         "where kind is one of 'voltage' or 'ionic current density'.",
         "kind"_a, "id"_a, "location"_a);
 
     pybind11::class_<arb::probe_info> probe(m, "probe");
     probe
-        .def("__repr__", [](const arb::probe_info& p){return util::pprintf("<arbor.probe: cell {}, probe {}>", p.id.gid, p.id.index);})
-        .def("__str__",  [](const arb::probe_info& p){return util::pprintf("<arbor.probe: cell {}, probe {}>", p.id.gid, p.id.index);});
+        .def("__repr__", [](const arb::probe_info& p){return util::pprintf("<arbor.probe: tag {}>", p.tag);})
+        .def("__str__",  [](const arb::probe_info& p){return util::pprintf("<arbor.probe: tag {}>", p.tag);});
 }
 } // namespace pyarb

--- a/python/recipe.hpp
+++ b/python/recipe.hpp
@@ -53,11 +53,8 @@ public:
     virtual std::vector<arb::gap_junction_connection> gap_junctions_on(arb::cell_gid_type) const {
         return {};
     }
-    virtual arb::cell_size_type num_probes(arb::cell_gid_type) const {
-        return 0;
-    }
-    virtual arb::probe_info get_probe (arb::cell_member_type id) const {
-        throw pyarb_error(util::pprintf("bad probe id {}", id));
+    virtual std::vector<arb::probe_info> get_probes(arb::cell_gid_type gid) const {
+        return {};
     }
     //TODO: virtual pybind11::object global_properties(arb::cell_kind kind) const {return pybind11::none();};
 };
@@ -100,12 +97,8 @@ public:
         PYBIND11_OVERLOAD(std::vector<arb::gap_junction_connection>, py_recipe, gap_junctions_on, gid);
     }
 
-    arb::cell_size_type num_probes(arb::cell_gid_type gid) const override {
-        PYBIND11_OVERLOAD(arb::cell_size_type, py_recipe, num_probes, gid);
-    }
-
-    arb::probe_info get_probe(arb::cell_member_type id) const override {
-        PYBIND11_OVERLOAD(arb::probe_info, py_recipe, get_probe, id);
+    std::vector<arb::probe_info> get_probes(arb::cell_gid_type gid) const override {
+        PYBIND11_OVERLOAD(std::vector<arb::probe_info>, py_recipe, get_probes, gid);
     }
 };
 
@@ -160,12 +153,8 @@ public:
         return try_catch_pyexception([&](){ return impl_->gap_junctions_on(gid); }, msg);
     }
 
-    arb::cell_size_type num_probes(arb::cell_gid_type gid) const override {
-        return try_catch_pyexception([&](){ return impl_->num_probes(gid); }, msg);
-    }
-
-    arb::probe_info get_probe(arb::cell_member_type id) const override {
-        return try_catch_pyexception([&](){ return impl_->get_probe(id); }, msg);
+    std::vector<arb::probe_info> get_probes(arb::cell_gid_type gid) const override {
+        return try_catch_pyexception([&](){ return impl_->get_probes(gid); }, msg);
     }
 
     // TODO: make thread safe

--- a/python/sampling.cpp
+++ b/python/sampling.cpp
@@ -60,8 +60,8 @@ struct sample_callback {
         sample_store(state)
     {}
 
-    void operator() (arb::cell_member_type probe_id, arb::probe_tag tag, arb::util::any_ptr meta, std::size_t n, const arb::sample_record* recs) {
-        auto& v = sample_store->probe_buffer(probe_id);
+    void operator() (arb::probe_metadata pm, std::size_t n, const arb::sample_record* recs) {
+        auto& v = sample_store->probe_buffer(pm.id);
         for (std::size_t i = 0; i<n; ++i) {
             if (auto p = arb::util::any_cast<const double*>(recs[i].data)) {
                 v.push_back({recs[i].time, *p});

--- a/python/single_cell_model.cpp
+++ b/python/single_cell_model.cpp
@@ -41,7 +41,7 @@ struct trace_callback {
 
     trace_callback(trace& t): trace_(t) {}
 
-    void operator()(arb::cell_member_type probe_id, arb::probe_tag tag, arb::util::any_ptr meta, std::size_t n, const arb::sample_record* recs) {
+    void operator()(arb::probe_metadata, std::size_t n, const arb::sample_record* recs) {
         // Push each (time, value) pair from the last epoch into trace_.
         for (std::size_t i=0; i<n; ++i) {
             if (auto p = arb::util::any_cast<const double*>(recs[i].data)) {
@@ -49,7 +49,7 @@ struct trace_callback {
                 trace_.v.push_back(*p);
             }
             else {
-                throw std::runtime_error("unexpected sample type in simple_sampler");
+                throw std::runtime_error("unexpected sample type");
             }
         }
     }
@@ -105,19 +105,13 @@ struct single_cell_recipe: arb::recipe {
 
     // probes
 
-    virtual arb::cell_size_type num_probes(arb::cell_gid_type)  const override {
-        return probes_.size();
-    }
-
-    virtual arb::probe_info get_probe(arb::cell_member_type probe_id) const override {
-        // Test that a valid probe site is requested.
-        if (probe_id.gid || probe_id.index>=probes_.size()) {
-            throw arb::bad_probe_id(probe_id);
-        }
-
+    virtual std::vector<arb::probe_info> get_probes(arb::cell_gid_type gid) const override {
         // For now only voltage can be selected for measurement.
-        const auto& loc = probes_[probe_id.index].site;
-        return arb::probe_info{probe_id, 0, arb::cable_probe_membrane_voltage{loc}};
+        std::vector<arb::probe_info> pinfo;
+        for (auto& p: probes_) {
+            pinfo.push_back(arb::cable_probe_membrane_voltage{p.site});
+        }
+        return pinfo;
     }
 
     // gap junctions

--- a/test/simple_recipes.hpp
+++ b/test/simple_recipes.hpp
@@ -24,19 +24,13 @@ public:
         cell_gprop_.default_parameters = neuron_parameter_defaults;
     }
 
-    cell_size_type num_probes(cell_gid_type i) const override {
-        return probes_.count(i)? probes_.at(i).size(): 0;
-    }
-
-    virtual probe_info get_probe(cell_member_type probe_id) const override {
-        return probes_.at(probe_id.gid).at(probe_id.index);
+    std::vector<probe_info> get_probes(cell_gid_type i) const override {
+        if (!probes_.count(i)) return {};
+        return probes_.at(i);
     }
 
     virtual void add_probe(cell_gid_type gid, probe_tag tag, util::any address) {
-        auto& pvec_ = probes_[gid];
-
-        cell_member_type probe_id{gid, cell_lid_type(pvec_.size())};
-        pvec_.push_back({probe_id, tag, std::move(address)});
+        probes_[gid].emplace_back(std::move(address), tag);
     }
 
     util::any get_global_properties(cell_kind k) const override {

--- a/test/unit-distributed/test_communicator.cpp
+++ b/test/unit-distributed/test_communicator.cpp
@@ -203,7 +203,6 @@ namespace {
 
         cell_size_type num_sources(cell_gid_type) const override { return 1; }
         cell_size_type num_targets(cell_gid_type) const override { return 1; }
-        cell_size_type num_probes(cell_gid_type) const override { return 0; }
 
         std::vector<cell_connection> connections_on(cell_gid_type gid) const override {
             // a single connection from the preceding cell, i.e. a ring
@@ -266,7 +265,6 @@ namespace {
 
         cell_size_type num_sources(cell_gid_type) const override { return 1; }
         cell_size_type num_targets(cell_gid_type) const override { return size_; }
-        cell_size_type num_probes(cell_gid_type) const override { return 0; }
 
         std::vector<cell_connection> connections_on(cell_gid_type gid) const override {
             std::vector<cell_connection> cons;

--- a/test/unit-distributed/test_domain_decomposition.cpp
+++ b/test/unit-distributed/test_domain_decomposition.cpp
@@ -53,7 +53,6 @@ namespace {
 
         cell_size_type num_sources(cell_gid_type) const override { return 0; }
         cell_size_type num_targets(cell_gid_type) const override { return 0; }
-        cell_size_type num_probes(cell_gid_type) const override { return 0; }
 
         std::vector<cell_connection> connections_on(cell_gid_type) const override {
             return {};

--- a/test/unit/test_fvm_lowered.cpp
+++ b/test/unit/test_fvm_lowered.cpp
@@ -225,7 +225,7 @@ TEST(fvm_lowered, matrix_init)
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell fvcell(context);
     fvcell.initialize({0}, cable1d_recipe(cell), cell_to_intdom, targets, probe_map);
@@ -278,7 +278,7 @@ TEST(fvm_lowered, target_handles) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     auto test_target_handles = [&](fvm_cell& cell) {
         mechanism *expsyn = find_mechanism(cell, "expsyn");
@@ -361,7 +361,7 @@ TEST(fvm_lowered, stimulus) {
     const auto& A = D.cv_area;
 
     std::vector<target_handle> targets;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell fvcell(context);
     fvcell.initialize({0}, cable1d_recipe(cells), cell_to_intdom, targets, probe_map);
@@ -449,7 +449,7 @@ TEST(fvm_lowered, derived_mechs) {
     cable1d_recipe rec(cells);
     rec.catalogue().derive("custom_kin1", "test_kin1", {{"tau", 20.0}});
 
-    cable_probe_total_ion_current_density where{{1, 0.3}};
+    cable_probe_total_ion_current_density where{mlocation{1, 0.3}};
     rec.add_probe(0, 0, where);
     rec.add_probe(1, 0, where);
     rec.add_probe(2, 0, where);
@@ -459,7 +459,7 @@ TEST(fvm_lowered, derived_mechs) {
 
         std::vector<target_handle> targets;
         std::vector<fvm_index_type> cell_to_intdom;
-        probe_association_map<fvm_probe_info> probe_map;
+        probe_association_map probe_map;
 
         arb::execution_context context(resources);
         fvm_cell fvcell(context);
@@ -491,10 +491,10 @@ TEST(fvm_lowered, derived_mechs) {
         std::vector<double> samples[3];
 
         sampler_function sampler =
-            [&](cell_member_type pid, probe_tag, util::any_ptr, std::size_t n, const sample_record* records) {
+            [&](probe_metadata pm, std::size_t n, const sample_record* records) {
                 for (std::size_t i = 0; i<n; ++i) {
                     double v = *util::any_cast<const double*>(records[i].data);
-                    samples[pid.gid].push_back(v);
+                    samples[pm.id.gid].push_back(v);
                 }
             };
 
@@ -531,7 +531,7 @@ TEST(fvm_lowered, read_valence) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     {
         std::vector<cable_cell> cells(1);
@@ -685,7 +685,7 @@ TEST(fvm_lowered, ionic_currents) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell fvcell(context);
     fvcell.initialize({0}, rec, cell_to_intdom, targets, probe_map);
@@ -730,7 +730,7 @@ TEST(fvm_lowered, point_ionic_current) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell fvcell(context);
     fvcell.initialize({0}, rec, cell_to_intdom, targets, probe_map);
@@ -810,7 +810,7 @@ TEST(fvm_lowered, weighted_write_ion) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell fvcell(context);
     fvcell.initialize({0}, rec, cell_to_intdom, targets, probe_map);

--- a/test/unit/test_lif_cell_group.cpp
+++ b/test/unit/test_lif_cell_group.cpp
@@ -72,15 +72,6 @@ public:
     cell_size_type num_targets(cell_gid_type) const override {
         return 1;
     }
-    cell_size_type num_probes(cell_gid_type) const override {
-        return 0;
-    }
-    probe_info get_probe(cell_member_type probe_id) const override {
-        return {};
-    }
-    std::vector<event_generator> event_generators(cell_gid_type) const override {
-        return {};
-    }
 
 private:
     cell_size_type n_lif_cells_;
@@ -124,15 +115,6 @@ public:
     }
     cell_size_type num_targets(cell_gid_type) const override {
         return 1;
-    }
-    cell_size_type num_probes(cell_gid_type) const override {
-        return 0;
-    }
-    probe_info get_probe(cell_member_type probe_id) const override {
-        return {};
-    }
-    std::vector<event_generator> event_generators(cell_gid_type) const override {
-        return {};
     }
 
 private:

--- a/test/unit/test_probe.cpp
+++ b/test/unit/test_probe.cpp
@@ -112,35 +112,35 @@ void run_v_i_probe_test(const context& ctx) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell lcell(*ctx);
     lcell.initialize({0}, rec, cell_to_intdom, targets, probe_map);
 
-    EXPECT_EQ(3u, rec.num_probes(0));
+    EXPECT_EQ(3u, rec.get_probes(0).size());
     EXPECT_EQ(3u, probe_map.size());
 
-    EXPECT_EQ(10, probe_map.at({0, 0}).tag);
-    EXPECT_EQ(20, probe_map.at({0, 1}).tag);
-    EXPECT_EQ(30, probe_map.at({0, 2}).tag);
+    EXPECT_EQ(10, probe_map.tag.at({0, 0}));
+    EXPECT_EQ(20, probe_map.tag.at({0, 1}));
+    EXPECT_EQ(30, probe_map.tag.at({0, 2}));
 
-    auto get_probe_handle = [&](cell_member_type x, unsigned i = 0) {
-        return probe_map.at(x).handle.raw_handle_range()[i];
+    auto get_probe_raw_handle = [&](cell_member_type x, unsigned i = 0) {
+        return probe_map.data_on(x).front().raw_handle_range()[i];
     };
 
     // Voltage probes are interpolated, so expect fvm_probe_info
     // to wrap an fvm_probe_interpolated; ion current density is
     // a scalar, so should wrap fvm_probe_scalar.
 
-    ASSERT_TRUE(util::get_if<fvm_probe_interpolated>(probe_map.at({0, 0}).handle.info));
-    ASSERT_TRUE(util::get_if<fvm_probe_interpolated>(probe_map.at({0, 1}).handle.info));
-    ASSERT_TRUE(util::get_if<fvm_probe_scalar>(probe_map.at({0, 2}).handle.info));
+    ASSERT_TRUE(util::get_if<fvm_probe_interpolated>(probe_map.data_on({0, 0}).front().info));
+    ASSERT_TRUE(util::get_if<fvm_probe_interpolated>(probe_map.data_on({0, 0}).front().info));
+    ASSERT_TRUE(util::get_if<fvm_probe_scalar>(probe_map.data_on({0, 2}).front().info));
 
-    probe_handle p0a = get_probe_handle({0, 0}, 0);
-    probe_handle p0b = get_probe_handle({0, 0}, 1);
-    probe_handle p1a = get_probe_handle({0, 1}, 0);
-    probe_handle p1b = get_probe_handle({0, 1}, 1);
-    probe_handle p2 = get_probe_handle({0, 2});
+    probe_handle p0a = get_probe_raw_handle({0, 0}, 0);
+    probe_handle p0b = get_probe_raw_handle({0, 0}, 1);
+    probe_handle p1a = get_probe_raw_handle({0, 1}, 0);
+    probe_handle p1b = get_probe_raw_handle({0, 1}, 1);
+    probe_handle p2 = get_probe_raw_handle({0, 2});
 
     // Ball-and-stick cell with default discretization policy should
     // have three CVs, one for branch 0, one trivial one covering the
@@ -208,14 +208,14 @@ void run_v_cell_probe_test(const context& ctx) {
 
         std::vector<target_handle> targets;
         std::vector<fvm_index_type> cell_to_intdom;
-        probe_association_map<fvm_probe_info> probe_map;
+        probe_association_map probe_map;
 
         fvm_cell lcell(*ctx);
         lcell.initialize({0}, rec, cell_to_intdom, targets, probe_map);
 
         ASSERT_EQ(1u, probe_map.size());
 
-        const fvm_probe_multi* h_ptr = util::get_if<fvm_probe_multi>(probe_map.at({0, 0}).handle.info);
+        const fvm_probe_multi* h_ptr = util::get_if<fvm_probe_multi>(probe_map.data_on({0, 0}).front().info);
         ASSERT_TRUE(h_ptr);
         auto& h = *h_ptr;
 
@@ -268,25 +268,25 @@ void run_expsyn_g_probe_test(const context& ctx) {
 
         std::vector<target_handle> targets;
         std::vector<fvm_index_type> cell_to_intdom;
-        probe_association_map<fvm_probe_info> probe_map;
+        probe_association_map probe_map;
 
         fvm_cell lcell(*ctx);
         lcell.initialize({0}, rec, cell_to_intdom, targets, probe_map);
 
-        EXPECT_EQ(2u, rec.num_probes(0));
+        EXPECT_EQ(2u, rec.get_probes(0).size());
         EXPECT_EQ(2u, probe_map.size());
-        ASSERT_EQ(1u, probe_map.count({0, 0}));
-        ASSERT_EQ(1u, probe_map.count({0, 1}));
+        ASSERT_EQ(1u, probe_map.data.count({0, 0}));
+        ASSERT_EQ(1u, probe_map.data.count({0, 1}));
 
-        EXPECT_EQ(10, probe_map.at({0, 0}).tag);
-        EXPECT_EQ(20, probe_map.at({0, 1}).tag);
+        EXPECT_EQ(10, probe_map.tag.at({0, 0}));
+        EXPECT_EQ(20, probe_map.tag.at({0, 1}));
 
-        auto probe_scalar_handle = [&](cell_member_type x) {
-            return probe_map.at(x).handle.raw_handle_range()[0];
+        auto get_probe_raw_handle = [&](cell_member_type x, unsigned i = 0) {
+            return probe_map.data_on(x).front().raw_handle_range()[i];
         };
 
-        probe_handle p0 = probe_scalar_handle({0, 0});
-        probe_handle p1 = probe_scalar_handle({0, 1});
+        probe_handle p0 = get_probe_raw_handle({0, 0});
+        probe_handle p1 = get_probe_raw_handle({0, 1});
 
         // Expect initial probe values to be intial synapse g == 0.
 
@@ -380,7 +380,7 @@ void run_expsyn_g_cell_probe_test(const context& ctx) {
 
         std::vector<target_handle> targets;
         std::vector<fvm_index_type> cell_to_intdom;
-        probe_association_map<fvm_probe_info> probe_map;
+        probe_association_map probe_map;
 
         fvm_cell lcell(*ctx);
         lcell.initialize({0, 1}, rec, cell_to_intdom, targets, probe_map);
@@ -407,7 +407,7 @@ void run_expsyn_g_cell_probe_test(const context& ctx) {
 
         ASSERT_EQ(2u, probe_map.size());
         for (unsigned i: {0u, 1u}) {
-            const auto* h_ptr = util::get_if<fvm_probe_multi>(probe_map.at({i, 0}).handle.info);
+            const auto* h_ptr = util::get_if<fvm_probe_multi>(probe_map.data_on({i, 0}).front().info);
             ASSERT_TRUE(h_ptr);
 
             const auto* m_ptr = util::get_if<std::vector<cable_probe_point_info>>(h_ptr->metadata);
@@ -537,7 +537,7 @@ void run_ion_density_probe_test(const context& ctx) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell lcell(*ctx);
     lcell.initialize({0}, rec, cell_to_intdom, targets, probe_map);
@@ -547,24 +547,24 @@ void run_ion_density_probe_test(const context& ctx) {
     // CV 0, and so probe (0, 8) should have been discarded. All other probes
     // should be in the map.
 
-    EXPECT_EQ(13u, rec.num_probes(0));
+    EXPECT_EQ(13u, rec.get_probes(0).size());
     EXPECT_EQ(11u, probe_map.size());
 
-    auto probe_scalar_handle = [&](cell_member_type x) {
-        return util::get<fvm_probe_scalar>(probe_map.at(x).handle.info).raw_handles[0];
+    auto get_probe_raw_handle = [&](cell_member_type x, unsigned i = 0) {
+        return probe_map.data_on(x).front().raw_handle_range()[i];
     };
 
-    probe_handle ca_int_cv0 = probe_scalar_handle({0, 0});
-    probe_handle ca_int_cv1 = probe_scalar_handle({0, 1});
-    probe_handle ca_int_cv2 = probe_scalar_handle({0, 2});
-    probe_handle ca_ext_cv0 = probe_scalar_handle({0, 3});
-    probe_handle ca_ext_cv1 = probe_scalar_handle({0, 4});
-    probe_handle ca_ext_cv2 = probe_scalar_handle({0, 5});
-    EXPECT_EQ(0u, probe_map.count({0, 6}));
-    probe_handle na_int_cv2 = probe_scalar_handle({0, 7});
-    EXPECT_EQ(0u, probe_map.count({0, 8}));
-    probe_handle write_ca2_s_cv1 = probe_scalar_handle({0, 9});
-    probe_handle write_ca2_s_cv2 = probe_scalar_handle({0, 10});
+    probe_handle ca_int_cv0 = get_probe_raw_handle({0, 0});
+    probe_handle ca_int_cv1 = get_probe_raw_handle({0, 1});
+    probe_handle ca_int_cv2 = get_probe_raw_handle({0, 2});
+    probe_handle ca_ext_cv0 = get_probe_raw_handle({0, 3});
+    probe_handle ca_ext_cv1 = get_probe_raw_handle({0, 4});
+    probe_handle ca_ext_cv2 = get_probe_raw_handle({0, 5});
+    EXPECT_EQ(0u, probe_map.data.count({0, 6}));
+    probe_handle na_int_cv2 = get_probe_raw_handle({0, 7});
+    EXPECT_EQ(0u, probe_map.data.count({0, 8}));
+    probe_handle write_ca2_s_cv1 = get_probe_raw_handle({0, 9});
+    probe_handle write_ca2_s_cv2 = get_probe_raw_handle({0, 10});
 
     // Ion concentrations should have been written in initialization.
     // For CV 1, calcium concentration should be mean of the two values
@@ -596,9 +596,9 @@ void run_ion_density_probe_test(const context& ctx) {
     // sorted by CV in the fvm_probe_weighted_multi object; this is assumed
     // below.
 
-    auto* p_ptr = util::get_if<fvm_probe_multi>(probe_map.at({0, 11}).handle.info);
+    auto* p_ptr = util::get_if<fvm_probe_multi>(probe_map.data_on({0, 11}).front().info);
     ASSERT_TRUE(p_ptr);
-    fvm_probe_multi& na_int_all_info = *p_ptr;
+    const fvm_probe_multi& na_int_all_info = *p_ptr;
 
     auto* m_ptr = util::get_if<mcable_list>(na_int_all_info.metadata);
     ASSERT_TRUE(m_ptr);
@@ -614,9 +614,9 @@ void run_ion_density_probe_test(const context& ctx) {
     EXPECT_EQ(na_int_cv2,   na_int_all_info.raw_handles[1]);
     EXPECT_EQ(na_int_cv2-1, na_int_all_info.raw_handles[0]);
 
-    p_ptr = util::get_if<fvm_probe_multi>(probe_map.at({0, 12}).handle.info);
+    p_ptr = util::get_if<fvm_probe_multi>(probe_map.data_on({0, 12}).front().info);
     ASSERT_TRUE(p_ptr);
-    fvm_probe_multi& ca_ext_all_info = *p_ptr;
+    const fvm_probe_multi& ca_ext_all_info = *p_ptr;
 
     m_ptr = util::get_if<mcable_list>(ca_ext_all_info.metadata);
     ASSERT_TRUE(m_ptr);
@@ -713,7 +713,7 @@ void run_partial_density_probe_test(const context& ctx) {
 
     std::vector<target_handle> targets;
     std::vector<fvm_index_type> cell_to_intdom;
-    probe_association_map<fvm_probe_info> probe_map;
+    probe_association_map probe_map;
 
     fvm_cell lcell(*ctx);
     lcell.initialize({0, 1}, rec, cell_to_intdom, targets, probe_map);
@@ -721,12 +721,12 @@ void run_partial_density_probe_test(const context& ctx) {
     // There should be 10 probes on each cell, but only 10 in total in the probe map,
     // as only those probes that are in the mechanism support should have an entry.
 
-    EXPECT_EQ(10u, rec.num_probes(0));
-    EXPECT_EQ(10u, rec.num_probes(1));
+    EXPECT_EQ(10u, rec.get_probes(0).size());
+    EXPECT_EQ(10u, rec.get_probes(1).size());
     EXPECT_EQ(10u, probe_map.size());
 
-    auto probe_scalar_handle = [&](cell_member_type x) {
-        return util::get<fvm_probe_scalar>(probe_map.at(x).handle.info).raw_handles[0];
+    auto get_probe_raw_handle = [&](cell_member_type x, unsigned i = 0) {
+        return probe_map.data_on(x).front().raw_handle_range()[i];
     };
 
     // Check probe values against expected values.
@@ -736,10 +736,10 @@ void run_partial_density_probe_test(const context& ctx) {
         for (cell_gid_type gid: {0, 1}) {
             cell_member_type probe_id{gid, probe_lid};
             if (std::isnan(tp.expected[gid])) {
-                EXPECT_EQ(0u, probe_map.count(probe_id));
+                EXPECT_EQ(0u, probe_map.data.count(probe_id));
             }
             else {
-                probe_handle h = probe_scalar_handle(probe_id);
+                probe_handle h = get_probe_raw_handle(probe_id);
                 EXPECT_DOUBLE_EQ(tp.expected[gid], deref(h));
             }
         }
@@ -810,14 +810,13 @@ void run_axial_and_ion_current_sampled_probe_test(const context& ctx) {
     std::vector<double> i_memb;
 
     sim.add_sampler(all_probes, explicit_schedule({20*tau}),
-        [&](cell_member_type probe_id, probe_tag tag, util::any_ptr metadata,
-           std::size_t n_sample, const sample_record* samples)
+        [&](probe_metadata pm, std::size_t n_sample, const sample_record* samples)
         {
             // Expect exactly one sample.
             ASSERT_EQ(1u, n_sample);
 
-            if (tag==1) { // (whole cell probe)
-                const mcable_list* m = util::any_cast<const mcable_list*>(metadata);
+            if (pm.tag==1) { // (whole cell probe)
+                const mcable_list* m = util::any_cast<const mcable_list*>(pm.meta);
                 ASSERT_NE(nullptr, m);
                 // Metadata should comprise one cable per CV.
                 ASSERT_EQ(n_cv, m->size());
@@ -832,15 +831,15 @@ void run_axial_and_ion_current_sampled_probe_test(const context& ctx) {
             }
             else { // axial current probe
                 // Probe id tells us which axial current this is.
-                ASSERT_LT(probe_id.index, n_axial_probe);
+                ASSERT_LT(pm.id.index, n_axial_probe);
 
-                const mlocation* m = util::any_cast<const mlocation*>(metadata);
+                const mlocation* m = util::any_cast<const mlocation*>(pm.meta);
                 ASSERT_NE(nullptr, m);
 
                 const double* s = util::any_cast<const double*>(samples[0].data);
                 ASSERT_NE(nullptr, s);
 
-                i_axial.at(probe_id.index) = *s;
+                i_axial.at(pm.id.index) = *s;
             }
         });
 
@@ -866,7 +865,8 @@ void run_axial_and_ion_current_sampled_probe_test(const context& ctx) {
 
 
 // Run given cells taking samples from the provied probes on one of the cells.
-// Use default mechanism catalogue augmented by unit test specific mechanisms.
+//
+// Use the default mechanism catalogue augmented by unit test specific mechanisms.
 // (Timestep fixed at 0.025 ms).
 
 template <typename SampleData, typename SampleMeta = void>
@@ -891,7 +891,7 @@ auto run_simple_samplers(
     };
     simulation sim(rec, partition_load_balance(rec, ctx, phints), ctx);
 
-    std::vector<trace_data<SampleData, SampleMeta>> traces(n_probe);
+    std::vector<trace_vector<SampleData, SampleMeta>> traces(n_probe);
     for (unsigned i = 0; i<n_probe; ++i) {
         sim.add_sampler(one_probe({probe_cell, i}), explicit_schedule(when), make_simple_sampler(traces[i]));
     }
@@ -913,6 +913,39 @@ auto run_simple_sampler(
 }
 
 template <typename Backend>
+void run_multi_probe_test(const context& ctx) {
+    // Construct and run thorugh simple sampler a probe defined over
+    // cell terminal points; check metadata and values.
+
+    // m_mlt_b6 has terminal branches 1, 2, 4, and 5.
+    cable_cell cell(common_morphology::m_mlt_b6);
+
+    // Paint mechanism on branches 1, 2, and 5, omitting branch 4.
+    cell.paint(reg::branch(1), mechanism_desc("param_as_state").set("p", 10.));
+    cell.paint(reg::branch(2), mechanism_desc("param_as_state").set("p", 20.));
+    cell.paint(reg::branch(5), mechanism_desc("param_as_state").set("p", 50.));
+
+    auto tracev = run_simple_sampler<double, mlocation>(ctx, 0.1, {cell}, 0, cable_probe_density_state{ls::terminal(), "param_as_state", "s"}, {0.});
+
+    // Expect to have received a sample on each of the terminals of branches 1, 2, and 5.
+    ASSERT_EQ(3u, tracev.size());
+
+    std::vector<std::pair<mlocation, double>> vals;
+    for (auto& trace: tracev) {
+        ASSERT_EQ(1u, trace.size());
+        vals.push_back({trace.meta, trace[0].v});
+    }
+
+    util::sort(vals);
+    EXPECT_EQ((mlocation{1, 1.}), vals[0].first);
+    EXPECT_EQ((mlocation{2, 1.}), vals[1].first);
+    EXPECT_EQ((mlocation{5, 1.}), vals[2].first);
+    EXPECT_EQ(10., vals[0].second);
+    EXPECT_EQ(20., vals[1].second);
+    EXPECT_EQ(50., vals[2].second);
+}
+
+template <typename Backend>
 void run_v_sampled_probe_test(const context& ctx) {
     cable_cell bs = make_cell_ball_and_stick(false);
     bs.default_parameters.discretization = cv_policy_fixed_per_branch(1);
@@ -930,13 +963,17 @@ void run_v_sampled_probe_test(const context& ctx) {
     const double t_end = 1.; // [ms]
     std::vector<double> when = {0.3, 0.6}; // Sample at 0.3 and 0.6 ms.
 
-    auto trace0 = run_simple_sampler<double, mlocation>(ctx, t_end, cells, 0, cable_probe_membrane_voltage{probe_loc}, when);
-    EXPECT_EQ(2u, trace0.size());
-    EXPECT_EQ(probe_loc, trace0.metadata.value());
+    auto trace0 = run_simple_sampler<double, mlocation>(ctx, t_end, cells, 0, cable_probe_membrane_voltage{probe_loc}, when).at(0);
+    ASSERT_TRUE(trace0);
 
-    auto trace1 = run_simple_sampler<double, mlocation>(ctx, t_end, cells, 1, cable_probe_membrane_voltage{probe_loc}, when);
+    EXPECT_EQ(probe_loc, trace0.meta);
+    EXPECT_EQ(2u, trace0.size());
+
+    auto trace1 = run_simple_sampler<double, mlocation>(ctx, t_end, cells, 1, cable_probe_membrane_voltage{probe_loc}, when).at(0);
+    ASSERT_TRUE(trace1);
+
+    EXPECT_EQ(probe_loc, trace1.meta);
     EXPECT_EQ(2u, trace1.size());
-    EXPECT_EQ(probe_loc, trace1.metadata.value());
 
     EXPECT_EQ(trace0[0].t, trace1[0].t);
     EXPECT_EQ(trace0[0].v, trace1[0].v);
@@ -997,10 +1034,10 @@ void run_total_current_probe_test(const context& ctx) {
             const double t_end = 21*tau; // [ms]
 
             traces[i] = run_simple_sampler<std::vector<double>, mcable_list>(ctx, t_end, cells, i,
-                    cable_probe_total_current_cell{}, {tau, 20*tau});
+                    cable_probe_total_current_cell{}, {tau, 20*tau}).at(0);
 
             ion_traces[i] = run_simple_sampler<std::vector<double>, mcable_list>(ctx, t_end, cells, i,
-                    cable_probe_total_ion_current_cell{}, {tau, 20*tau});
+                    cable_probe_total_ion_current_cell{}, {tau, 20*tau}).at(0);
 
             ASSERT_EQ(2u, traces[i].size());
             ASSERT_EQ(2u, ion_traces[i].size());
@@ -1014,8 +1051,8 @@ void run_total_current_probe_test(const context& ctx) {
             // Total membrane current and total ionic mebrane current should have the
             // same support and same metadata.
 
-            ASSERT_EQ((n_cv_per_branch+(int)interior_forks)*n_branch, traces[i].metadata.value().size());
-            EXPECT_EQ(ion_traces[i].metadata, traces[i].metadata);
+            ASSERT_EQ((n_cv_per_branch+(int)interior_forks)*n_branch, traces[i].meta.size());
+            EXPECT_EQ(ion_traces[i].meta, traces[i].meta);
             EXPECT_EQ(ion_traces[i][0].v.size(), traces[i][0].v.size());
             EXPECT_EQ(ion_traces[i][1].v.size(), traces[i][1].v.size());
 
@@ -1100,10 +1137,8 @@ void run_exact_sampling_probe_test(const context& ctx) {
             return cell_kind::cable;
         }
 
-        cell_size_type num_probes(cell_gid_type) const override { return 1; }
-
-        probe_info get_probe(cell_member_type pid) const override {
-            return {pid, 0, cable_probe_membrane_voltage{mlocation{1, 0.5}}};
+        std::vector<probe_info> get_probes(cell_gid_type) const override {
+            return {cable_probe_membrane_voltage{mlocation{1, 0.5}}};
         }
 
         cell_size_type num_targets(cell_gid_type) const override { return 1; }
@@ -1138,7 +1173,7 @@ void run_exact_sampling_probe_test(const context& ctx) {
     // 1. Membrane voltage is similar with and without exact sampling.
     // 2. Sample times are in fact exact with exact sampling.
 
-    std::vector<trace_data<double>> lax_traces(4), exact_traces(4);
+    std::vector<trace_vector<double>> lax_traces(4), exact_traces(4);
 
     const double max_dt = 0.001;
     const double t_end = 1.;
@@ -1167,16 +1202,21 @@ void run_exact_sampling_probe_test(const context& ctx) {
     exact_sim.run(t_end, max_dt);
 
     for (unsigned i = 0; i<n_cell; ++i) {
-        ASSERT_EQ(n_sample_time, lax_traces.at(i).size());
-        ASSERT_EQ(n_sample_time, exact_traces.at(i).size());
+        ASSERT_EQ(1u, lax_traces.at(i).size());
+        ASSERT_EQ(n_sample_time, lax_traces.at(i).at(0).size());
+        ASSERT_EQ(1u, exact_traces.at(i).size());
+        ASSERT_EQ(n_sample_time, exact_traces.at(i).at(0).size());
     }
 
     for (unsigned i = 0; i<n_cell; ++i) {
-        for (unsigned j = 0; j<n_sample_time; ++j) {
-            EXPECT_NE(sched_times.at(j), lax_traces.at(i).at(j).t);
-            EXPECT_EQ(sched_times.at(j), exact_traces.at(i).at(j).t);
+        auto& lax_trace = lax_traces[i][0];
+        auto& exact_trace = exact_traces[i][0];
 
-            EXPECT_TRUE(testing::near_relative(lax_traces.at(i).at(j).v, exact_traces.at(i).at(j).v, 0.01));
+        for (unsigned j = 0; j<n_sample_time; ++j) {
+            EXPECT_NE(sched_times.at(j), lax_trace.at(j).t);
+            EXPECT_EQ(sched_times.at(j), exact_trace.at(j).t);
+
+            EXPECT_TRUE(testing::near_relative(lax_trace.at(j).v, exact_trace.at(j).v, 0.01));
         }
     }
 }
@@ -1187,7 +1227,8 @@ void run_exact_sampling_probe_test(const context& ctx) {
 #undef PROBE_TESTS
 #define PROBE_TESTS \
     v_i, v_cell, v_sampled, expsyn_g, expsyn_g_cell, \
-    ion_density, axial_and_ion_current_sampled, partial_density, total_current, exact_sampling
+    ion_density, axial_and_ion_current_sampled, partial_density, total_current, exact_sampling, \
+    multi
 
 #undef RUN_MULTICORE
 #define RUN_MULTICORE(x) \


### PR DESCRIPTION
Resolves #957.

* Make recipe return probes as a vector.
* Remove `probe_id` from `probe_info`.
* Rename `fvm_probe_info` to `fvm_probe_data` (everything was being called info, and it was getting confusing).
* Make `probe_association_map` specific to `mc_cell_group`/`fvm_lowered_cell`.
* Change probe_association_map representation: unordered map for probe_id -> tag; unordered multimap for probe_id -> fvm_probe_data. This allows multiple probes to be associated with the same probe id.
* Call sampler callback separately for each probe with the same probe_id.
* Replace location-based probes with locset equivalents.
* Add index for probes sharing a probe id.
* Bundle all probe metadata (id, tag, index, probe-specific meta) into `probe_metadata` struct for passing to sampler callbacks.
* Change simple_sampler to work on `trace_vector`, a vector of `trace_data`. The _i_th element is the data from probe with index i.
* Consolidate hash composition and `std::hash` specialization code in new header.
* Update python lib for new API.
* Update tests and examples for new recipe, internal probe, and simple_sampler APIs.
* Update docs to suit.