### PR TITLE
Exclude branches matching /\.tmp$/ from Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@
 # Apple Clang  1100.0.33.16
 #######################################################
 
+# Ignore bors testing branches.
+if: NOT branch =~ \.tmp$
+
 language: cpp
 sudo: false
 


### PR DESCRIPTION
Fix for #1055 