### PR TITLE
No sphere here

### DIFF
--- a/arbor/include/arbor/cable_cell_param.hpp
+++ b/arbor/include/arbor/cable_cell_param.hpp
@@ -178,9 +178,6 @@ struct ion_reversal_potential_method {
 //       Position CVs so as to include fork points, as opposed
 //       to positioning them so that fork points are at the
 //       boundaries of CVs.
-//
-//   cv_policy_flag::single_root_cv:
-//       Always treat the root branch as a single CV regardless.
 
 class cable_cell;
 
@@ -221,8 +218,7 @@ namespace cv_policy_flag {
     using value = unsigned;
     enum : unsigned {
         none = 0,
-        interior_forks = 1<<0,
-        single_root_cv = 1<<1
+        interior_forks = 1<<0
     };
 }
 

--- a/arbor/include/arbor/math.hpp
+++ b/arbor/include/arbor/math.hpp
@@ -45,18 +45,6 @@ T constexpr volume_frustrum(T L, T r1, T r2) {
     return pi<T>/T(3) * (square(r1+r2) - r1*r2) * L;
 }
 
-// Volume of a sphere radius r.
-template <typename T>
-T constexpr volume_sphere(T r) {
-    return T(4)/T(3) * pi<T> * cube(r);
-}
-
-// Surface area of a sphere radius r.
-template <typename T>
-T constexpr area_sphere(T r) {
-    return T(4) * pi<T> * square(r);
-}
-
 // Linear interpolation by u in interval [a,b]: (1-u)*a + u*b.
 template <typename T, typename U>
 T constexpr lerp(T a, T b, U u) {

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -19,15 +19,11 @@ class morphology {
     std::shared_ptr<const morphology_impl> impl_;
 
 public:
-    morphology(sample_tree m, bool use_spherical_root);
     morphology(sample_tree m);
     morphology();
 
     // Empty/default-constructed morphology?
     bool empty() const;
-
-    // Whether the root of the morphology is spherical.
-    bool spherical_root() const;
 
     // The number of branches in the morphology.
     msize_t num_branches() const;

--- a/arbor/morph/mbranch.hpp
+++ b/arbor/morph/mbranch.hpp
@@ -22,7 +22,6 @@ struct mbranch {
     mbranch(std::vector<msize_t> idx, msize_t parent):
         index(std::move(idx)), parent_id(parent) {}
 
-    bool is_sphere()  const { return size()==1u; }
     msize_t size()    const { return index.size(); }
     bool has_parent() const { return parent_id!=mnpos;}
 
@@ -31,8 +30,7 @@ struct mbranch {
 };
 
 std::vector<mbranch> branches_from_parent_index(const std::vector<msize_t>& parents,
-                                                const std::vector<point_prop>& props,
-                                                bool spherical_root);
+                                                const std::vector<point_prop>& props);
 
 } // namespace impl
 } // namespace arb

--- a/arbor/morph/morphexcept.cpp
+++ b/arbor/morph/morphexcept.cpp
@@ -10,13 +10,17 @@ namespace arb {
 
 using arb::util::pprintf;
 
+static std::string msize_string(msize_t x) {
+    return x==mnpos? "mnpos": pprintf("{}", x);
+}
+
 invalid_mlocation::invalid_mlocation(mlocation loc):
     morphology_error(pprintf("invalid mlocation {}", loc)),
     loc(loc)
 {}
 
 no_such_branch::no_such_branch(msize_t bid):
-    morphology_error(pprintf("no such branch id {}", bid)),
+    morphology_error(pprintf("no such branch id {}", msize_string(bid))),
     bid(bid)
 {}
 
@@ -30,10 +34,11 @@ invalid_mcable_list::invalid_mcable_list():
 {}
 
 invalid_sample_parent::invalid_sample_parent(msize_t parent, msize_t tree_size):
-    morphology_error(pprintf("invalid sample parent {} for a sample tree of size {}", parent, tree_size)),
+    morphology_error(pprintf("invalid sample parent {} for a sample tree of size {}", msize_string(parent), tree_size)),
     parent(parent),
     tree_size(tree_size)
-{}
+{
+}
 
 label_type_mismatch::label_type_mismatch(const std::string& label):
     morphology_error(pprintf("label \"{}\" is already bound to a different type of object", label)),
@@ -41,7 +46,7 @@ label_type_mismatch::label_type_mismatch(const std::string& label):
 {}
 
 incomplete_branch::incomplete_branch(msize_t bid):
-    morphology_error(pprintf("insufficent samples to define branch id {}", bid)),
+    morphology_error(pprintf("insufficent samples to define branch id {}", msize_string(bid))),
     bid(bid)
 {}
 

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -152,15 +152,6 @@ mextent thingify_(const tagged_& reg, const mprovider& p) {
 
     for (msize_t i: util::make_span(nb)) {
         auto ids = util::make_range(m.branch_indexes(i)); // range of sample ids in branch.
-        size_t ns = util::size(ids);        // number of samples in branch.
-
-        if (ns==1) {
-            // The branch is a spherical soma
-            if (samples[0].tag==reg.tag) {
-                L.push_back({0,0,1});
-            }
-            continue;
-        }
 
         // The branch has at least 2 samples.
         // Start at begin+1 because a segment gets its tag from its distal sample.

--- a/arbor/morph/sample_tree.cpp
+++ b/arbor/morph/sample_tree.cpp
@@ -28,20 +28,13 @@ void sample_tree::reserve(msize_t n) {
 }
 
 msize_t sample_tree::append(msize_t p, const msample& s) {
-    std::cout << "+++++ " << (empty()? "empty": "initl") << " " << p << " " << size() << " " << s << std::endl;
-    //if ((empty() && p!=mnpos) || p>=size()) {
-    //   if (p!=mnpos) throw invalid_sample_parent(p, size());
-    //}
-
+    // Assert that the root (first) sample in a tree has mnpos as its parent.
     if (empty() && p!=mnpos) {
         throw invalid_sample_parent(p, size());
     }
     else if (!empty()) {
-        if (p==mnpos) {
-            // the p>=size() test would catch this case for unsigned msize_t
-            throw invalid_sample_parent(p, size());
-        }
-        else if (p>=size()) {
+        // Parent must (a) already be in the sample_tree (b) not be mnpos.
+        if (p>=size() || p==mnpos) {
             throw invalid_sample_parent(p, size());
         }
     }

--- a/arbor/morph/sample_tree.cpp
+++ b/arbor/morph/sample_tree.cpp
@@ -28,8 +28,22 @@ void sample_tree::reserve(msize_t n) {
 }
 
 msize_t sample_tree::append(msize_t p, const msample& s) {
-    if ((empty() && p!=mnpos) || p>=size()) {
-        if (p!=mnpos) throw invalid_sample_parent(p, size());
+    std::cout << "+++++ " << (empty()? "empty": "initl") << " " << p << " " << size() << " " << s << std::endl;
+    //if ((empty() && p!=mnpos) || p>=size()) {
+    //   if (p!=mnpos) throw invalid_sample_parent(p, size());
+    //}
+
+    if (empty() && p!=mnpos) {
+        throw invalid_sample_parent(p, size());
+    }
+    else if (!empty()) {
+        if (p==mnpos) {
+            // the p>=size() test would catch this case for unsigned msize_t
+            throw invalid_sample_parent(p, size());
+        }
+        else if (p>=size()) {
+            throw invalid_sample_parent(p, size());
+        }
     }
 
     auto id = size();

--- a/example/dryrun/branch_cell.hpp
+++ b/example/dryrun/branch_cell.hpp
@@ -8,6 +8,7 @@
 #include <arbor/common_types.hpp>
 #include <arbor/cable_cell.hpp>
 
+#include <string>
 #include <sup/json_params.hpp>
 
 // Parameters used to generate the random cell morphologies.
@@ -53,7 +54,8 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
 
     // Add soma.
     double soma_radius = 12.6157/2.0;
-    tree.append(arb::mnpos, {{0,0,0,soma_radius}, 1}); // For area of 500 μm².
+    tree.append(arb::mnpos, {{0, 0,-soma_radius, soma_radius}, 1}); // For area of 500 μm².
+    tree.append(         0, {{0, 0, soma_radius, soma_radius}, 1}); // For area of 500 μm².
 
     std::vector<std::vector<unsigned>> levels;
     levels.push_back({0});
@@ -103,7 +105,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     d.set("soma",      tagged(1));
     d.set("dendrites", join(tagged(3), tagged(4)));
 
-    arb::cable_cell cell(arb::morphology(tree, true), d);
+    arb::cable_cell cell(arb::morphology(tree), d);
 
     cell.paint("soma", "hh");
     cell.paint("dendrites", "pas");
@@ -113,7 +115,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     cell.place(arb::mlocation{0,0}, arb::threshold_detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
-    cell.place(arb::mlocation{1, 0.5}, "expsyn");
+    cell.place(arb::mlocation{0, 0.5}, "expsyn");
 
     // Add additional synapses that will not be connected to anything.
     for (unsigned i=1u; i<params.synapses; ++i) {

--- a/example/ring/branch_cell.hpp
+++ b/example/ring/branch_cell.hpp
@@ -8,6 +8,7 @@
 #include <arbor/common_types.hpp>
 #include <arbor/cable_cell.hpp>
 
+#include <string>
 #include <sup/json_params.hpp>
 
 // Parameters used to generate the random cell morphologies.
@@ -53,7 +54,8 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
 
     // Add soma.
     double soma_radius = 12.6157/2.0;
-    tree.append(arb::mnpos, {{0,0,0,soma_radius}, 1}); // For area of 500 μm².
+    tree.append(arb::mnpos, {{0, 0,-soma_radius, soma_radius}, 1}); // For area of 500 μm².
+    tree.append(         0, {{0, 0, soma_radius, soma_radius}, 1}); // For area of 500 μm².
 
     std::vector<std::vector<unsigned>> levels;
     levels.push_back({0});
@@ -103,7 +105,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     d.set("soma",      tagged(1));
     d.set("dendrites", join(tagged(3), tagged(4)));
 
-    arb::cable_cell cell(arb::morphology(tree, true), d);
+    arb::cable_cell cell(arb::morphology(tree), d);
 
     cell.paint("soma", "hh");
     cell.paint("dendrites", "pas");
@@ -113,7 +115,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     cell.place(arb::mlocation{0,0}, arb::threshold_detector{10});
 
     // Add a synapse to the mid point of the first dendrite.
-    cell.place(arb::mlocation{1, 0.5}, "expsyn");
+    cell.place(arb::mlocation{0, 0.5}, "expsyn");
 
     // Add additional synapses that will not be connected to anything.
     for (unsigned i=1u; i<params.synapses; ++i) {

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -42,7 +42,7 @@ struct ring_params {
     std::string name = "default";
     unsigned num_cells = 10;
     double min_delay = 10;
-    double duration = 100;
+    double duration = 200;
     cell_parameters cell;
 };
 

--- a/example/single/single.cpp
+++ b/example/single/single.cpp
@@ -130,7 +130,7 @@ options parse_options(int argc, char** argv) {
             opt.swc_file = swc.value();
         }
         else if (auto nseg = parse<unsigned>(arg, 'n', "cv-per-branch")) {
-            opt.policy = arb::cv_policy_fixed_per_branch(nseg.value(), arb::cv_policy_flag::single_root_cv);
+            opt.policy = arb::cv_policy_fixed_per_branch(nseg.value());
         }
         else {
             usage(argv[0], "[-m|--morphology SWCFILE] [-d|--dt TIME] [-t|--t-end TIME] [-w|--weight WEIGHT] [-n|--cv-per-branch N]");
@@ -148,9 +148,10 @@ options parse_options(int argc, char** argv) {
 arb::morphology default_morphology() {
     arb::sample_tree samples;
 
-    auto p = samples.append(arb::msample{{  0.0, 0.0, 0.0, 6.3}, 1});
-    p = samples.append(p, arb::msample{{  6.3, 0.0, 0.0, 0.5}, 3});
-    p = samples.append(p, arb::msample{{206.3, 0.0, 0.0, 0.2}, 3});
+    auto p = samples.append(arb::msample{{ -6.3, 0.0, 0.0, 6.3}, 1});
+    p = samples.append(p,   arb::msample{{  6.3, 0.0, 0.0, 6.3}, 1});
+    p = samples.append(p,   arb::msample{{  6.3, 0.0, 0.0, 0.5}, 3});
+    p = samples.append(p,   arb::msample{{206.3, 0.0, 0.0, 0.2}, 3});
 
     return arb::morphology(std::move(samples));
 }

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -405,8 +405,7 @@ void register_cells(pybind11::module& m) {
                 return arb::cable_cell(arb::morphology(t), labels.dict);
             }),
             "morphology"_a, "labels"_a,
-            "Construct with a morphology derived from a sample_tree, with automatic detection of whether\n"
-            "the morphology has a spherical root/soma.")
+            "Construct with a morphology derived from a sample_tree.")
         .def_property_readonly("num_branches",
             [](const arb::cable_cell& c) {return c.morphology().num_branches();},
             "The number of unbranched cable sections in the morphology.")

--- a/python/example/ring.py
+++ b/python/example/ring.py
@@ -15,8 +15,8 @@ import matplotlib.pyplot as plt
 def make_cable_cell(gid):
     b = arbor.flat_cell_builder()
 
-    # Soma with radius 6 μm.
-    s  = b.add_sphere(6, "soma")
+    # Soma with radius 6 μm, modelled as cylinder of length 2*radius
+    s  = b.add_cable(length=12, radius=6, name="soma", ncomp=1)
     # Single dendrite of length 100 μm and radius 2 μm attached to soma.
     b1 = b.add_cable(parent=s, length=100, radius=2, name="dend", ncomp=1)
     # Attach two dendrites of length 50 μm to the end of the first dendrite.

--- a/python/example/single_cell_builder.py
+++ b/python/example/single_cell_builder.py
@@ -10,29 +10,30 @@ b = arbor.flat_cell_builder()
 # The soma (at the root of the tree) is marked 's', and
 # the end of each branch i is marked 'bi'.
 #
-#               b5
+#               b4
 #              /
 #             /
-#            b2---b4
+#            b1---b3
 #           /
 #          /
-# s-------b1
+# s-------b0
 #          \
 #           \
-#            b3
+#            b2
 
-# Add a spherical soma with radius 6 um
-s  = b.add_sphere(6, "soma")
+# Start with a spherical soma with radius 6 μm,
+# approximated with a cylinder of: length = diameter = 12 μm.
+s  = b.add_cable(length=12, radius=6, name="soma", ncomp=1)
 
 # Add the dendrite cables, labelling those closest to the soma "dendn",
 # and those furthest with "dendx" because we will set different electrical
 # properties for the two regions.
-b1 = b.add_cable(parent=s,  length=100, radius=2, name="dendn", ncomp=100)
+b0 = b.add_cable(parent=s,  length=100, radius=2, name="dendn", ncomp=100)
 # Radius tapers from 2 to 0.5 over the length of the branch.
-b2 = b.add_cable(parent=b1, length= 50, radius=(2,0.5), name="dendn", ncomp=50)
-b3 = b.add_cable(parent=b1, length= 50, radius=1, name="dendn", ncomp=50)
-b4 = b.add_cable(parent=b2, length= 50, radius=1, name="dendx", ncomp=50)
-b5 = b.add_cable(parent=b2, length= 50, radius=1, name="dendx", ncomp=50)
+b1 = b.add_cable(parent=b0, length= 50, radius=(2,0.5), name="dendn", ncomp=50)
+b2 = b.add_cable(parent=b0, length= 50, radius=1, name="dendn", ncomp=50)
+b3 = b.add_cable(parent=b1, length= 50, radius=1, name="dendx", ncomp=50)
+b4 = b.add_cable(parent=b1, length= 50, radius=1, name="dendx", ncomp=50)
 
 # Combine the "dendn" and "dendx" regions into a single "dend" region.
 # The dendrites were labelled as such so that we can set different
@@ -40,7 +41,7 @@ b5 = b.add_cable(parent=b2, length= 50, radius=1, name="dendx", ncomp=50)
 # set other properties on the whole dendrites.
 b.add_label('dend', '(join (region "dendn") (region "dendx"))')
 # Location of stimuli, in the middle of branch 2.
-b.add_label('stim_site', '(location 2 0.5)')
+b.add_label('stim_site', '(location 1 0.5)')
 # The root of the tree (equivalent to '(location 0 0)')
 b.add_label('root', '(root)')
 # The tips of the dendrites (3 locations at b4, b3, b5).

--- a/python/example/single_cell_swc.py
+++ b/python/example/single_cell_swc.py
@@ -1,3 +1,13 @@
+# NOTE: deprecating spherical roots changes the behavior of this model.
+# There is no soma, because only the root sample has tag 1, which will be
+# ignored as it is always the proximal end of any cable segment.
+# The fix is to:
+#   - Write an swc interpreter that inserts a cylinder with the
+#     appropriate properties.
+#   - Extend the cable-only descriptions to handle detached cables, to
+#     preserve surface area and correct starting locations of cables
+#     attached to the soma.
+
 import arbor
 from arbor import mechanism as mech
 from arbor import location as loc
@@ -5,7 +15,8 @@ import matplotlib.pyplot as plt
 
 # Load a cell morphology from an swc file.
 # The model has 31 branches, including soma, dendrites and axon.
-tree = arbor.load_swc('../../test/unit/swc/example.swc')
+#tree = arbor.load_swc('../../test/unit/swc/example.swc')
+tree = arbor.load_swc('example.swc')
 
 # Define the regions and locsets in the model.
 defs = {'soma': '(tag 1)',  # soma has tag 1 in swc files.
@@ -34,6 +45,7 @@ cell.paint('dend', 'pas')
 cell.paint('dend', rL=500)
 # Attach stimuli that inject 0.8 nA currents for 1 ms, starting at 3 and 8 ms.
 cell.place('stim_site', arbor.iclamp(3, 1, current=0.5))
+cell.place('stim_site', arbor.iclamp(8, 1, current=1))
 # Detect spikes at the soma with a voltage threshold of -10 mV.
 cell.place('root', arbor.spike_detector(-10))
 

--- a/python/example/single_cell_swc.py
+++ b/python/example/single_cell_swc.py
@@ -12,11 +12,14 @@ defs = {'soma': '(tag 1)',  # soma has tag 1 in swc files.
         'axon': '(tag 2)',  # axon has tag 2 in swc files.
         'dend': '(tag 3)',  # dendrites have tag 3 in swc files.
         'root': '(root)',   # the start of the soma in this morphology is at the root of the cell.
-        'stim_site': '(location 1 0.5)'} # site for the stimulus, in the middle of branch 1.
+        'stim_site': '(location 0 0.5)', # site for the stimulus, in the middle of branch 1.
+        'axon_end': '(restrict (terminal) (region "axon"))'} # end of the axon.
 labels = arbor.label_dict(defs)
 
 # Combine morphology with region and locset definitions to make a cable cell.
 cell = arbor.cable_cell(tree, labels)
+
+print(cell.locations('axon_end'))
 
 # Set initial membrane potential to -55 mV
 cell.set_properties(Vm=-55)
@@ -30,8 +33,7 @@ cell.paint('dend', 'pas')
 # Increase resistivity on dendrites.
 cell.paint('dend', rL=500)
 # Attach stimuli that inject 0.8 nA currents for 1 ms, starting at 3 and 8 ms.
-cell.place('stim_site', arbor.iclamp(3, 1, current=0.8))
-cell.place('stim_site', arbor.iclamp(8, 1, 0.8))
+cell.place('stim_site', arbor.iclamp(3, 1, current=0.5))
 # Detect spikes at the soma with a voltage threshold of -10 mV.
 cell.place('root', arbor.spike_detector(-10))
 
@@ -44,8 +46,8 @@ m = arbor.single_cell_model(cell)
 # Attach voltage probes that sample at 50 kHz.
 m.probe('voltage', where='root',  frequency=50000)
 m.probe('voltage', where=loc(2,1),  frequency=50000)
-m.probe('voltage', where=loc(4,1),  frequency=50000)
-m.probe('voltage', where=loc(30,1), frequency=50000)
+m.probe('voltage', where='stim_site',  frequency=50000)
+m.probe('voltage', where='axon_end', frequency=50000)
 
 # Simulate the cell for 15 ms.
 tfinal=15
@@ -68,7 +70,7 @@ legend_labels = ['{}: {}'.format(s.variable, s.location) for s in m.traces]
 ax.legend(legend_labels)
 ax.set(xlabel='time (ms)', ylabel='voltage (mV)', title='swc morphology demo')
 plt.xlim(0,tfinal)
-plt.ylim(-80,50)
+plt.ylim(-80,80)
 ax.grid()
 
 plot_to_file=False

--- a/python/flat_cell_builder.cpp
+++ b/python/flat_cell_builder.cpp
@@ -15,8 +15,8 @@
 namespace pyarb {
 
 class flat_cell_builder {
-    // The sample tree describing the morphology: constructed on the fly as
-    // the cables/spheres are added with add_cable/add_sphere.
+    // The sample tree describing the morphology, constructed additatively with
+    // cables that are attached to existing cables using add_cable.
     arb::sample_tree tree_;
 
     // The distal sample id of each cable.

--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -182,18 +182,11 @@ void register_morphology(pybind11::module& m) {
                 [](arb::sample_tree t){
                     return arb::morphology(std::move(t));
                 }))
-        .def(pybind11::init(
-                [](arb::sample_tree t, bool spherical_root) {
-                    return arb::morphology(std::move(t), spherical_root);
-                }), "sample_tree"_a, "spherical_root"_a)
         // morphology's interface is read-only by design, so most of it can
         // be implemented as read-only properties.
         .def_property_readonly("empty",
                 [](const arb::morphology& m){return m.empty();},
                 "A list with the parent index of each sample.")
-        .def_property_readonly("spherical_root",
-                [](const arb::morphology& m){return m.spherical_root();},
-                "Whether the root of the morphology is spherical.")
         .def_property_readonly("num_branches",
                 [](const arb::morphology& m){return m.num_branches();},
                 "The number of branches in the morphology.")

--- a/test/common_cells.cpp
+++ b/test/common_cells.cpp
@@ -1,0 +1,221 @@
+#include "common_cells.hpp"
+
+namespace arb {
+
+int soma_cell_builder::get_tag(const std::string& name) {
+    auto it = tag_map.find(name);
+    // If the name is not in the map, make a unique tag.
+    // Tags start from 1.
+    if (it==tag_map.end()) {
+        tag_map[name] = ++tag_count;
+        return tag_count;
+    }
+    return it->second;
+}
+
+soma_cell_builder::soma_cell_builder(double r): soma_rad(r) {
+    auto tag = get_tag("soma");
+    tree.append({{0,0,0,r}, tag});
+    tree.append({{0,0,2*r,r}, tag});
+    cv_boundaries.push_back({0, 1.});
+    branch_distal_id.push_back(1);
+    n_soma_children = 0;
+}
+
+mlocation soma_cell_builder::location(mlocation loc) const {
+    if (loc.branch>=branch_distal_id.size()) {
+        throw cable_cell_error("location not on cable_cell.");
+    }
+    if (n_soma_children==0) {
+        return loc;
+    }
+    if (n_soma_children==1) {
+        if (loc.branch<2) {
+            double soma_len  = tree.samples()[branch_distal_id[0]].loc.z;
+            double total_len = tree.samples()[branch_distal_id[1]].loc.z;
+            // relative position of the end of the soma on the first branch
+            double split = soma_len/total_len;
+            double pos = loc.branch==0?
+                split*loc.pos:
+                split + (1-split)*loc.pos;
+            return {0, pos};
+        }
+        return {loc.branch-1, loc.pos};
+    }
+    return loc;
+}
+
+mcable soma_cell_builder::cable(mcable cab) const {
+    if (cab.branch>=branch_distal_id.size()) {
+        throw cable_cell_error("cable not on cable_cell.");
+    }
+    auto beg = location({cab.branch, cab.prox_pos});
+    auto end = location({cab.branch, cab.dist_pos});
+    return {beg.branch, beg.pos, end.pos};
+}
+
+// Add a new branch that is attached to parent_branch.
+// Returns the id of the new branch.
+msize_t soma_cell_builder::add_branch(
+        msize_t parent_branch,
+        double len, double r1, double r2, int ncomp,
+        const std::string& region)
+{
+    // Get tag id of region (add a new tag if region does not already exist).
+    int tag = get_tag(region);
+
+    msize_t p = branch_distal_id[parent_branch];
+    double z = tree.samples()[p].loc.z;
+
+    p = tree.append(p, {{0,0,z,r1}, tag});
+    if (ncomp>1) {
+        double dz = len/ncomp;
+        double dr = (r2-r1)/ncomp;
+        for (auto i=1; i<ncomp; ++i) {
+            p = tree.append(p, {{0,0,z+i*dz, r1+i*dr}, tag});
+        }
+    }
+    p = tree.append(p, {{0,0,z+len,r2}, tag});
+    branch_distal_id.push_back(p);
+
+    msize_t bid = branch_distal_id.size()-1;
+    for (int i = 0; i<ncomp; ++i) {
+        cv_boundaries.push_back(mlocation{bid, (2*i+1.)/(2.*ncomp)});
+    }
+
+    if (!parent_branch) ++n_soma_children;
+
+    return bid;
+}
+
+cable_cell soma_cell_builder::make_cell() const {
+    // Test that a valid tree was generated, that is, every branch has
+    // either 0 children, or at least 2 children.
+    for (auto i: branch_distal_id) {
+        // skip soma
+        if (i<2) continue;
+        auto prop = tree.properties()[i];
+        if (!is_fork(prop) && !is_terminal(prop)) {
+            throw cable_cell_error(
+                "attempt to construct a cable_cell from a soma_cell_builder "
+                "where a non soma branch has only one child branch.");
+        }
+    }
+
+    // Make label dictionary with one entry for each tag.
+    label_dict dict;
+    for (auto& tag: tag_map) {
+        dict.set(tag.first, reg::tagged(tag.second));
+    }
+
+    // Make cable_cell from sample tree and dictionary.
+    cable_cell c(tree, dict);
+    auto boundaries = cv_boundaries;
+    for (auto& b: boundaries) {
+        b = location(b);
+    }
+    c.default_parameters.discretization = cv_policy_explicit(boundaries);
+    return c;
+}
+
+/*
+ * Create cell with just a soma:
+ *
+ * Soma:
+ *    diameter: 18.8 µm
+ *    mechanisms: HH (default params)
+ *    bulk resistivitiy: 100 Ω·cm [default]
+ *    capacitance: 0.01 F/m² [default]
+ *
+ * Stimuli:
+ *    soma centre, t=[10 ms, 110 ms), 0.1 nA
+ */
+
+cable_cell make_cell_soma_only(bool with_stim) {
+    soma_cell_builder builder(18.8/2.0);
+
+    auto c = builder.make_cell();
+    c.paint("soma", "hh");
+    if (with_stim) {
+        c.place(builder.location({0,0.5}), i_clamp{10., 100., 0.1});
+    }
+
+    return c;
+}
+
+/*
+ * Create cell with a soma and unbranched dendrite:
+ *
+ * Common properties:
+ *    bulk resistivity: 100 Ω·cm [default]
+ *    capacitance: 0.01 F/m² [default]
+ *
+ * Soma:
+ *    mechanisms: HH (default params)
+ *    diameter: 12.6157 µm
+ *
+ * Dendrite:
+ *    mechanisms: passive (default params)
+ *    diameter: 1 µm
+ *    length: 200 µm
+ *    compartments: 4
+ *
+ * Stimulus:
+ *    end of dendrite, t=[5 ms, 85 ms), 0.3 nA
+ */
+
+cable_cell make_cell_ball_and_stick(bool with_stim) {
+    soma_cell_builder builder(12.6157/2.0);
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 4, "dend");
+
+    auto c = builder.make_cell();
+    c.paint("soma", "hh");
+    c.paint("dend", "pas");
+    if (with_stim) {
+        c.place(builder.location({1,1}), i_clamp{5, 80, 0.3});
+    }
+
+    return c;
+}
+
+/*
+ * Create cell with a soma and three-branch dendrite with single branch point:
+ *
+ * O----======
+ *
+ * Common properties:
+ *    bulk resistivity: 100 Ω·cm [default]
+ *    capacitance: 0.01 F/m² [default]
+ *
+ * Soma:
+ *    mechanisms: HH (default params)
+ *    diameter: 12.6157 µm
+ *
+ * Dendrites:
+ *    mechanisms: passive (default params)
+ *    diameter: 1 µm
+ *    length: 100 µm
+ *    compartments: 4
+ *
+ * Stimulus:
+ *    end of first terminal branch, t=[5 ms, 85 ms), 0.45 nA
+ *    end of second terminal branch, t=[40 ms, 50 ms), -0.2 nA
+ */
+
+cable_cell make_cell_ball_and_3stick(bool with_stim) {
+    soma_cell_builder builder(12.6157/2.0);
+    builder.add_branch(0, 100, 0.5, 0.5, 4, "dend");
+    builder.add_branch(1, 100, 0.5, 0.5, 4, "dend");
+    builder.add_branch(1, 100, 0.5, 0.5, 4, "dend");
+
+    auto c = builder.make_cell();
+    c.paint("soma", "hh");
+    c.paint("dend", "pas");
+    if (with_stim) {
+        c.place(builder.location({2,1}), i_clamp{5.,  80., 0.45});
+        c.place(builder.location({3,1}), i_clamp{40., 10.,-0.2});
+    }
+
+    return c;
+}
+} // namespace arb

--- a/test/common_cells.hpp
+++ b/test/common_cells.hpp
@@ -12,81 +12,26 @@ class soma_cell_builder {
     sample_tree tree;
     std::vector<msize_t> branch_distal_id;
     std::unordered_map<std::string, int> tag_map;
-    locset cv_boundaries = mlocation{0, 1.};
+    mlocation_list cv_boundaries;
     int tag_count = 0;
+    int n_soma_children = 0;
 
     // Get tag id of region.
     // Add a new tag if region with that name has not already had a tag associated with it.
-    int get_tag(const std::string& name) {
-        auto it = tag_map.find(name);
-        // If the name is not in the map, make a unique tag.
-        // Tags start from 1.
-        if (it==tag_map.end()) {
-            tag_map[name] = ++tag_count;
-            return tag_count;
-        }
-        return it->second;
-    }
+    int get_tag(const std::string& name);
 
 public:
-    soma_cell_builder(double r): soma_rad(r) {
-        tree.append({{0,0,0,r}, get_tag("soma")});
-        branch_distal_id.push_back(0);
-    }
+    soma_cell_builder(double r);
 
     // Add a new branch that is attached to parent_branch.
     // Returns the id of the new branch.
     msize_t add_branch(msize_t parent_branch, double len, double r1, double r2, int ncomp,
-                    const std::string& region)
-    {
-        // Get tag id of region (add a new tag if region does not already exist).
-        int tag = get_tag(region);
+                    const std::string& region);
 
-        msize_t p = branch_distal_id[parent_branch];
-        double z = parent_branch? tree.samples()[p].loc.z: soma_rad;
+    mlocation location(mlocation) const;
+    mcable cable(mcable) const;
 
-        p = tree.append(p, {{0,0,z,r1}, tag});
-        if (ncomp>1) {
-            double dz = len/ncomp;
-            double dr = (r2-r1)/ncomp;
-            for (auto i=1; i<ncomp; ++i) {
-                p = tree.append(p, {{0,0,z+i*dz, r1+i*dr}, tag});
-            }
-        }
-        p = tree.append(p, {{0,0,z+len,r2}, tag});
-        branch_distal_id.push_back(p);
-
-        msize_t bid = branch_distal_id.size()-1;
-        for (int i = 0; i<ncomp; ++i) {
-            cv_boundaries = sum(cv_boundaries,  mlocation{bid, (2*i+1.)/(2.*ncomp)});
-        }
-        return bid;
-    }
-
-    cable_cell make_cell() const {
-        // Test that a valid tree was generated, that is, every branch has
-        // either 0 children, or at least 2 children.
-        for (auto i: branch_distal_id) {
-            if (i==0) continue;
-            auto prop = tree.properties()[i];
-            if (!is_fork(prop) && !is_terminal(prop)) {
-                throw cable_cell_error(
-                    "attempt to construct a cable_cell from a soma_cell_builder "
-                    "where a branch has only one child branch.");
-            }
-        }
-
-        // Make label dictionary with one entry for each tag.
-        label_dict dict;
-        for (auto& tag: tag_map) {
-            dict.set(tag.first, reg::tagged(tag.second));
-        }
-
-        // Make cable_cell from sample tree and dictionary.
-        cable_cell c(tree, dict);
-        c.default_parameters.discretization = cv_policy_explicit(cv_boundaries);
-        return c;
-    }
+    cable_cell make_cell() const;
 };
 
 /*
@@ -102,17 +47,7 @@ public:
  *    soma centre, t=[10 ms, 110 ms), 0.1 nA
  */
 
-inline cable_cell make_cell_soma_only(bool with_stim = true) {
-    soma_cell_builder builder(18.8/2.0);
-
-    auto c = builder.make_cell();
-    c.paint("soma", "hh");
-    if (with_stim) {
-        c.place(mlocation{0,0.5}, i_clamp{10., 100., 0.1});
-    }
-
-    return c;
-}
+cable_cell make_cell_soma_only(bool with_stim = true);
 
 /*
  * Create cell with a soma and unbranched dendrite:
@@ -135,19 +70,7 @@ inline cable_cell make_cell_soma_only(bool with_stim = true) {
  *    end of dendrite, t=[5 ms, 85 ms), 0.3 nA
  */
 
-inline cable_cell make_cell_ball_and_stick(bool with_stim = true) {
-    soma_cell_builder builder(12.6157/2.0);
-    builder.add_branch(0, 200, 1.0/2, 1.0/2, 4, "dend");
-
-    auto c = builder.make_cell();
-    c.paint("soma", "hh");
-    c.paint("dend", "pas");
-    if (with_stim) {
-        c.place(mlocation{1,1}, i_clamp{5, 80, 0.3});
-    }
-
-    return c;
-}
+cable_cell make_cell_ball_and_stick(bool with_stim = true);
 
 /*
  * Create cell with a soma and three-branch dendrite with single branch point:
@@ -173,21 +96,6 @@ inline cable_cell make_cell_ball_and_stick(bool with_stim = true) {
  *    end of second terminal branch, t=[40 ms, 50 ms), -0.2 nA
  */
 
-inline cable_cell make_cell_ball_and_3stick(bool with_stim = true) {
-    soma_cell_builder builder(12.6157/2.0);
-    builder.add_branch(0, 100, 0.5, 0.5, 4, "dend");
-    builder.add_branch(1, 100, 0.5, 0.5, 4, "dend");
-    builder.add_branch(1, 100, 0.5, 0.5, 4, "dend");
-
-    auto c = builder.make_cell();
-    c.paint("soma", "hh");
-    c.paint("dend", "pas");
-    if (with_stim) {
-        c.place(mlocation{2,1}, i_clamp{5.,  80., 0.45});
-        c.place(mlocation{3,1}, i_clamp{40., 10.,-0.2});
-    }
-
-    return c;
-}
+cable_cell make_cell_ball_and_3stick(bool with_stim = true);
 
 } // namespace arb

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -79,6 +79,7 @@ endforeach()
 # Unit test sources
 
 set(unit_sources
+    ../common_cells.cpp
     test_algorithms.cpp
     test_any.cpp
     test_any_visitor.cpp

--- a/test/unit/common_morphologies.hpp
+++ b/test/unit/common_morphologies.hpp
@@ -20,29 +20,20 @@ inline std::vector<arb::msample> make_morph_samples(unsigned n) {
 
 static const arb::morphology m_empty;
 
-// spherical root, one branch
-static const arb::morphology m_sph_b1{arb::sample_tree(make_morph_samples(1), {arb::mnpos}), true};
-
 // regular root, one branch
-static const arb::morphology m_reg_b1{arb::sample_tree(make_morph_samples(2), {arb::mnpos, 0u}), false};
-
-// spherical root, six branches:
-// branch 0 (spherical root) has child branches 1 and 2; branch 2 has child branches 3, 4 and 5.
-static const arb::morphology m_sph_b6{arb::sample_tree(make_morph_samples(8), {arb::mnpos, 0u, 1u, 0u, 3u, 4u, 4u, 4u}), true};
+static const arb::morphology m_reg_b1{arb::sample_tree(make_morph_samples(2), {arb::mnpos, 0u})};
 
 // regular root, six branches
 // branch 0 has child branches 1 and 2; branch 2 has child branches 3, 4 and 5.
-static const arb::morphology m_reg_b6{arb::sample_tree(make_morph_samples(7), {arb::mnpos, 0u, 1u, 1u, 2u, 2u, 2u}), false};
+static const arb::morphology m_reg_b6{arb::sample_tree(make_morph_samples(7), {arb::mnpos, 0u, 1u, 1u, 2u, 2u, 2u})};
 
 // regular root, six branches, mutiple top level branches.
 // branch 0 has child branches 1 and 2; branch 3 has child branches 4 and 5.
-static const arb::morphology m_mlt_b6{arb::sample_tree(make_morph_samples(7), {arb::mnpos, 0u, 1u, 1u, 0u, 4u, 4u}), false};
+static const arb::morphology m_mlt_b6{arb::sample_tree(make_morph_samples(7), {arb::mnpos, 0u, 1u, 1u, 0u, 4u, 4u})};
 
 static std::pair<const char*, arb::morphology> test_morphologies[] = {
     {"m_empty",  m_empty},
-    {"m_sph_b1", m_sph_b1},
     {"m_reg_b1", m_reg_b1},
-    {"m_sph_b6", m_sph_b6},
     {"m_reg_b6", m_reg_b6},
     {"m_mlt_b6", m_mlt_b6}
 };

--- a/test/unit/test_cv_policy.cpp
+++ b/test/unit/test_cv_policy.cpp
@@ -34,20 +34,14 @@ namespace {
 
     const morphology m_empty;
 
-    // spherical root, one branch
-    const morphology m_sph_b1{sample_tree(make_samples(1), {mnpos}), true};
-
     // regular root, one branch
-    const morphology m_reg_b1{sample_tree(make_samples(2), {mnpos, 0u}), false};
-
-    // spherical root, six branches
-    const morphology m_sph_b6{sample_tree(make_samples(8), {mnpos, 0u, 1u, 0u, 3u, 4u, 4u, 4u}), true};
+    const morphology m_reg_b1{sample_tree(make_samples(2), {mnpos, 0u})};
 
     // regular root, six branches
-    const morphology m_reg_b6{sample_tree(make_samples(7), {mnpos, 0u, 1u, 1u, 2u, 2u, 2u}), false};
+    const morphology m_reg_b6{sample_tree(make_samples(7), {mnpos, 0u, 1u, 1u, 2u, 2u, 2u})};
 
     // regular root, six branches, mutiple top level branches.
-    const morphology m_mlt_b6{sample_tree(make_samples(7), {mnpos, 0u, 1u, 1u, 0u, 4u, 4u}), false};
+    const morphology m_mlt_b6{sample_tree(make_samples(7), {mnpos, 0u, 1u, 1u, 0u, 4u, 4u})};
 
     template <typename... A>
     locset as_locset(mlocation head, A... tail) {
@@ -60,7 +54,7 @@ TEST(cv_policy, explicit_policy) {
     locset lset = as_locset(L{0, 0},  L{0, 0.5},  L{0, 1.},  L{1,  0.5},  L{4, 0.2});
 
     cv_policy pol = cv_policy_explicit(lset);
-    for (auto& m: {m_sph_b6, m_reg_b6, m_mlt_b6}) {
+    for (auto& m: {m_reg_b6, m_mlt_b6}) {
         cable_cell cell(m);
 
         locset result = pol.cv_boundary_points(cell);
@@ -76,9 +70,9 @@ TEST(cv_policy, empty_morphology) {
 
     cv_policy policies[] = {
         cv_policy_fixed_per_branch(3),
-        cv_policy_fixed_per_branch(3, single_root_cv|interior_forks),
+        cv_policy_fixed_per_branch(3, interior_forks),
         cv_policy_max_extent(0.234),
-        cv_policy_max_extent(0.234, single_root_cv|interior_forks)
+        cv_policy_max_extent(0.234, interior_forks)
     };
 
     cable_cell cell(m_empty);
@@ -89,42 +83,12 @@ TEST(cv_policy, empty_morphology) {
     }
 }
 
-TEST(cv_policy, single_root_cv) {
-    // For policies that respect the single_root_cv flag, the boundary points should
-    // be the same as if the flag were not provided, except that the points on branch 0
-    // should only ever be (0, 0) and (0, 1) if the morphology is not empty.
-
-    using namespace cv_policy_flag;
-
-    std::pair<cv_policy, cv_policy> policy_pairs[] = {
-        {cv_policy_fixed_per_branch(3),                 cv_policy_fixed_per_branch(3, single_root_cv)},
-        {cv_policy_fixed_per_branch(3, interior_forks), cv_policy_fixed_per_branch(3, single_root_cv|interior_forks)},
-        {cv_policy_max_extent(0.234),                   cv_policy_max_extent(0.234, single_root_cv)},
-        {cv_policy_max_extent(0.234, interior_forks),   cv_policy_max_extent(0.234, single_root_cv|interior_forks)}
-    };
-
-    for (auto& morph: {m_sph_b1, m_reg_b1, m_sph_b6, m_reg_b6, m_mlt_b6}) {
-        cable_cell cell(morph);
-
-        for (auto& polpair: policy_pairs) {
-            mlocation_list p1 = thingify(polpair.first.cv_boundary_points(cell), cell.provider());
-            mlocation_list p2 = thingify(polpair.second.cv_boundary_points(cell), cell.provider());
-
-            auto p1_no_b0 = util::filter(p1, [](mlocation l) { return l.branch>0; });
-            mlocation_list expected = {{0,0}, {0,1}};
-            expected.insert(expected.end(), p1_no_b0.begin(), p1_no_b0.end());
-
-            EXPECT_EQ(expected, p2);
-        }
-    }
-}
-
 TEST(cv_policy, fixed_per_branch) {
     using namespace cv_policy_flag;
     using L = mlocation;
 
     // root branch only
-    for (auto& morph: {m_sph_b1, m_reg_b1}) {
+    for (auto& morph: {m_reg_b1}) {
         cable_cell cell(morph);
         {
             // boundary fork points
@@ -144,7 +108,7 @@ TEST(cv_policy, fixed_per_branch) {
 
     // spherical root, six branches and multiple top level branches cases:
     // expected points are the same.
-    for (auto& morph: {m_sph_b6, m_mlt_b6}) {
+    for (auto& morph: {m_mlt_b6}) {
         cable_cell cell(morph);
 
         {
@@ -175,7 +139,7 @@ TEST(cv_policy, max_extent) {
     using L = mlocation;
 
     // root branch only
-    for (auto& morph: {m_sph_b1, m_reg_b1}) {
+    for (auto& morph: {m_reg_b1}) {
         cable_cell cell(morph);
         ASSERT_EQ(1.0, cell.embedding().branch_length(0));
 
@@ -239,7 +203,7 @@ TEST(cv_policy, every_sample) {
     for (auto i: make_span(4)) ms.push_back({{i+1.,    0,  4.0, 0.5}, 5});
 
     std::vector<msize_t> parents = {mnpos, 0, 1, 2, 3, 4, 5, 6, 7, 4, 9, 10, 11 };
-    morphology m{sample_tree(ms, parents), false};
+    morphology m{sample_tree(ms, parents)};
 
     // Including all samples:
     {
@@ -250,22 +214,6 @@ TEST(cv_policy, every_sample) {
 
         mlocation_list expected = {
             {0, 0}, {0, 0.25}, {0, 0.5}, {0, 0.75}, {0, 1.},
-            {1, 0}, {1, 0.25}, {1, 0.5}, {1, 0.75}, {1, 1.},
-            {2, 0}, {2, 0.25}, {2, 0.5}, {2, 0.75}, {2, 1.}
-        };
-
-        EXPECT_EQ(expected, points);
-    }
-
-    // Single root CV:
-    {
-        cable_cell cell(m);
-        cv_policy pol = cv_policy_every_sample(single_root_cv);
-        mlocation_list points = thingify(pol.cv_boundary_points(cell), cell.provider());
-        util::sort(points);
-
-        mlocation_list expected = {
-            {0, 0}, {0, 1.},
             {1, 0}, {1, 0.25}, {1, 0.5}, {1, 0.75}, {1, 1.},
             {2, 0}, {2, 0.25}, {2, 0.5}, {2, 0.75}, {2, 1.}
         };

--- a/test/unit/test_event_delivery.cpp
+++ b/test/unit/test_event_delivery.cpp
@@ -28,7 +28,8 @@ struct test_recipe: public n_cable_cell_recipe {
 
     static cable_cell test_cell() {
         sample_tree st;
-        st.append({0,0,0,10,1});
+        st.append({{0,0, 0,10},1});
+        st.append({{0,0,20,10},1});
 
         label_dict d;
         d.set("soma", arb::reg::tagged(1));

--- a/test/unit/test_fvm_layout.cpp
+++ b/test/unit/test_fvm_layout.cpp
@@ -26,18 +26,35 @@ using util::count_along;
 using util::value_by_key;
 
 namespace {
-    std::vector<cable_cell> two_cell_system() {
+    struct system {
+        std::vector<soma_cell_builder> builders;
         std::vector<cable_cell> cells;
+    };
 
-        // Cell 0: simple ball and stick (see common_cells.hpp)
-        cells.push_back(make_cell_ball_and_stick());
+    system two_cell_system() {
+        system s;
+        auto& cells = s.cells;
+
+        // Cell 0: simple ball and stick
+        {
+            soma_cell_builder builder(12.6157/2.0);
+            builder.add_branch(0, 200, 1.0/2, 1.0/2, 4, "dend");
+
+            cells.push_back(builder.make_cell());
+            auto& cell = cells.back();
+            cell.paint("soma", "hh");
+            cell.paint("dend", "pas");
+            cell.place(builder.location({1,1}), i_clamp{5, 80, 0.3});
+
+            s.builders.push_back(std::move(builder));
+        }
 
         // Cell 1: ball and 3-stick, but with uneven dendrite
         // length and heterogeneous electrical properties:
         //
         // Bulk resistivity: 90 Ω·cm
         // capacitance:
-        //    soma:       0.01  F/m² [default]
+        //    soma:      0.01  F/m² [default]
         //    branch 1:  0.017 F/m²
         //    branch 2:  0.013 F/m²
         //    branch 3:  0.018 F/m²
@@ -60,46 +77,54 @@ namespace {
         //
         // All dendrite branches with 4 compartments.
 
-        soma_cell_builder builder(7.);
-        auto b1 = builder.add_branch(0, 200, 0.5,  0.5, 4,  "dend");
-        auto b2 = builder.add_branch(1, 300, 0.4,  0.4, 4,  "dend");
-        auto b3 = builder.add_branch(1, 180, 0.35, 0.35, 4, "dend");
-        auto cell = builder.make_cell();
+        {
+            soma_cell_builder b(7.);
+            auto b1 = b.add_branch(0, 200, 0.5,  0.5, 4,  "dend");
+            auto b2 = b.add_branch(1, 300, 0.4,  0.4, 4,  "dend");
+            auto b3 = b.add_branch(1, 180, 0.35, 0.35, 4, "dend");
+            cells.push_back(b.make_cell());
+            auto& cell = cells.back();
 
-        cell.paint("soma", "hh");
-        cell.paint("dend", "pas");
+            cell.paint("soma", "hh");
+            cell.paint("dend", "pas");
 
-        using ::arb::reg::branch;
-        cell.paint(branch(b1), membrane_capacitance{0.017});
-        cell.paint(branch(b2), membrane_capacitance{0.013});
-        cell.paint(branch(b3), membrane_capacitance{0.018});
+            using ::arb::reg::branch;
+            auto c1 = reg::cable(b1-1, b.location({b1, 0}).pos, 1);
+            auto c2 = reg::cable(b2-1, b.location({b2, 0}).pos, 1);
+            auto c3 = reg::cable(b3-1, b.location({b3, 0}).pos, 1);
+            cell.paint(c1, membrane_capacitance{0.017});
+            cell.paint(c2, membrane_capacitance{0.013});
+            cell.paint(c3, membrane_capacitance{0.018});
 
-        cell.place(mlocation{2,1}, i_clamp{5.,  80., 0.45});
-        cell.place(mlocation{3,1}, i_clamp{40., 10.,-0.2});
+            cell.place(b.location({2,1}), i_clamp{5.,  80., 0.45});
+            cell.place(b.location({3,1}), i_clamp{40., 10.,-0.2});
 
-        cell.default_parameters.axial_resistivity = 90;
+            cell.default_parameters.axial_resistivity = 90;
 
-        cells.push_back(std::move(cell));
+            s.builders.push_back(std::move(b));
+        }
 
-        return cells;
+        return s;
     }
 
     void check_two_cell_system(std::vector<cable_cell>& cells) {
         ASSERT_EQ(2u, cells.size());
-        ASSERT_EQ(2u, cells[0].morphology().num_branches());
-        ASSERT_EQ(4u, cells[1].morphology().num_branches());
+        ASSERT_EQ(1u, cells[0].morphology().num_branches());
+        ASSERT_EQ(3u, cells[1].morphology().num_branches());
     }
 } // namespace
 
 TEST(fvm_layout, mech_index) {
-    std::vector<cable_cell> cells = two_cell_system();
+    auto system = two_cell_system();
+    auto& cells = system.cells;
+    auto& builders = system.builders;
     check_two_cell_system(cells);
 
     // Add four synapses of two varieties across the cells.
-    cells[0].place(mlocation{1, 0.4}, "expsyn");
-    cells[0].place(mlocation{1, 0.4}, "expsyn");
-    cells[1].place(mlocation{2, 0.4}, "exp2syn");
-    cells[1].place(mlocation{3, 0.4}, "expsyn");
+    cells[0].place(builders[0].location({1, 0.4}), "expsyn");
+    cells[0].place(builders[0].location({1, 0.4}), "expsyn");
+    cells[1].place(builders[1].location({2, 0.4}), "exp2syn");
+    cells[1].place(builders[1].location({3, 0.4}), "expsyn");
 
     cable_cell_global_properties gprop;
     gprop.default_parameters = neuron_parameter_defaults;
@@ -208,13 +233,16 @@ TEST(fvm_layout, coalescing_synapses) {
 
     using L=std::initializer_list<unsigned>;
 
-    {
-        cable_cell cell = make_cell_ball_and_stick();
+    soma_cell_builder builder(12.6157/2.0);
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 4, "dend");
 
-        cell.place(mlocation{1, 0.3}, "expsyn");
-        cell.place(mlocation{1, 0.5}, "expsyn");
-        cell.place(mlocation{1, 0.7}, "expsyn");
-        cell.place(mlocation{1, 0.9}, "expsyn");
+    {
+        auto cell = builder.make_cell();
+
+        cell.place(builder.location({1, 0.3}), "expsyn");
+        cell.place(builder.location({1, 0.5}), "expsyn");
+        cell.place(builder.location({1, 0.7}), "expsyn");
+        cell.place(builder.location({1, 0.9}), "expsyn");
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -224,13 +252,13 @@ TEST(fvm_layout, coalescing_synapses) {
         EXPECT_EQ(ivec({1, 1, 1, 1}), expsyn_config.multiplicity);
     }
     {
-        cable_cell cell = make_cell_ball_and_stick();
+        auto cell = builder.make_cell();
 
         // Add synapses of two varieties.
-        cell.place(mlocation{1, 0.3}, "expsyn");
-        cell.place(mlocation{1, 0.5}, "exp2syn");
-        cell.place(mlocation{1, 0.7}, "expsyn");
-        cell.place(mlocation{1, 0.9}, "exp2syn");
+        cell.place(builder.location({1, 0.3}), "expsyn");
+        cell.place(builder.location({1, 0.5}), "exp2syn");
+        cell.place(builder.location({1, 0.7}), "expsyn");
+        cell.place(builder.location({1, 0.9}), "exp2syn");
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -244,12 +272,12 @@ TEST(fvm_layout, coalescing_synapses) {
         EXPECT_EQ(ivec({1, 1}), exp2syn_config.multiplicity);
     }
     {
-        cable_cell cell = make_cell_ball_and_stick();
+        auto cell = builder.make_cell();
 
-        cell.place(mlocation{1, 0.3}, "expsyn");
-        cell.place(mlocation{1, 0.5}, "expsyn");
-        cell.place(mlocation{1, 0.7}, "expsyn");
-        cell.place(mlocation{1, 0.9}, "expsyn");
+        cell.place(builder.location({1, 0.3}), "expsyn");
+        cell.place(builder.location({1, 0.5}), "expsyn");
+        cell.place(builder.location({1, 0.7}), "expsyn");
+        cell.place(builder.location({1, 0.9}), "expsyn");
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_no_coalesce, {cell}, D);
@@ -259,13 +287,13 @@ TEST(fvm_layout, coalescing_synapses) {
         EXPECT_TRUE(expsyn_config.multiplicity.empty());
     }
     {
-        cable_cell cell = make_cell_ball_and_stick();
+        auto cell = builder.make_cell();
 
         // Add synapses of two varieties.
-        cell.place(mlocation{1, 0.3}, "expsyn");
-        cell.place(mlocation{1, 0.5}, "exp2syn");
-        cell.place(mlocation{1, 0.7}, "expsyn");
-        cell.place(mlocation{1, 0.9}, "exp2syn");
+        cell.place(builder.location({1, 0.3}), "expsyn");
+        cell.place(builder.location({1, 0.5}), "exp2syn");
+        cell.place(builder.location({1, 0.7}), "expsyn");
+        cell.place(builder.location({1, 0.9}), "exp2syn");
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_no_coalesce, {cell}, D);
@@ -279,13 +307,13 @@ TEST(fvm_layout, coalescing_synapses) {
         EXPECT_TRUE(exp2syn_config.multiplicity.empty());
     }
     {
-        cable_cell cell = make_cell_ball_and_stick();
+        auto cell = builder.make_cell();
 
         // Add synapses of two varieties.
-        cell.place(mlocation{1, 0.3}, "expsyn");
-        cell.place(mlocation{1, 0.3}, "expsyn");
-        cell.place(mlocation{1, 0.7}, "expsyn");
-        cell.place(mlocation{1, 0.7}, "expsyn");
+        cell.place(builder.location({1, 0.3}), "expsyn");
+        cell.place(builder.location({1, 0.3}), "expsyn");
+        cell.place(builder.location({1, 0.7}), "expsyn");
+        cell.place(builder.location({1, 0.7}), "expsyn");
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -295,13 +323,13 @@ TEST(fvm_layout, coalescing_synapses) {
         EXPECT_EQ(ivec({2, 2}), expsyn_config.multiplicity);
     }
     {
-        cable_cell cell = make_cell_ball_and_stick();
+        auto cell = builder.make_cell();
 
         // Add synapses of two varieties.
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 0.2));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 0.2));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0.1, 0.2));
-        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 0.1, 0.2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn", 0, 0.2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn", 0, 0.2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn", 0.1, 0.2));
+        cell.place(builder.location({1, 0.7}), syn_desc("expsyn", 0.1, 0.2));
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -317,17 +345,17 @@ TEST(fvm_layout, coalescing_synapses) {
         }
     }
     {
-        cable_cell cell = make_cell_ball_and_stick();
+        auto cell = builder.make_cell();
 
         // Add synapses of two varieties.
-        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 0, 3));
-        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 1, 3));
-        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 0, 3));
-        cell.place(mlocation{1, 0.7}, syn_desc("expsyn", 1, 3));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 2));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 1, 2));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 0, 2));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn", 1, 2));
+        cell.place(builder.location({1, 0.7}), syn_desc("expsyn", 0, 3));
+        cell.place(builder.location({1, 0.7}), syn_desc("expsyn", 1, 3));
+        cell.place(builder.location({1, 0.7}), syn_desc("expsyn", 0, 3));
+        cell.place(builder.location({1, 0.7}), syn_desc("expsyn", 1, 3));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn", 0, 2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn", 1, 2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn", 0, 2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn", 1, 2));
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -344,19 +372,19 @@ TEST(fvm_layout, coalescing_synapses) {
         }
     }
     {
-        cable_cell cell = make_cell_ball_and_stick();
+        auto cell = builder.make_cell();
 
         // Add synapses of two varieties.
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  1, 2));
-        cell.place(mlocation{1, 0.3}, syn_desc_2("exp2syn", 4, 1));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  1, 2));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  5, 1));
-        cell.place(mlocation{1, 0.3}, syn_desc_2("exp2syn", 1, 3));
-        cell.place(mlocation{1, 0.3}, syn_desc("expsyn",  1, 2));
-        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 2));
-        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 1));
-        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 1));
-        cell.place(mlocation{1, 0.7}, syn_desc_2("exp2syn", 2, 2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn",  1, 2));
+        cell.place(builder.location({1, 0.3}), syn_desc_2("exp2syn", 4, 1));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn",  1, 2));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn",  5, 1));
+        cell.place(builder.location({1, 0.3}), syn_desc_2("exp2syn", 1, 3));
+        cell.place(builder.location({1, 0.3}), syn_desc("expsyn",  1, 2));
+        cell.place(builder.location({1, 0.7}), syn_desc_2("exp2syn", 2, 2));
+        cell.place(builder.location({1, 0.7}), syn_desc_2("exp2syn", 2, 1));
+        cell.place(builder.location({1, 0.7}), syn_desc_2("exp2syn", 2, 1));
+        cell.place(builder.location({1, 0.7}), syn_desc_2("exp2syn", 2, 2));
 
         fvm_cv_discretization D = fvm_cv_discretize({cell}, neuron_parameter_defaults);
         fvm_mechanism_data M = fvm_build_mechanism_data(gprop_coalesce, {cell}, D);
@@ -376,7 +404,9 @@ TEST(fvm_layout, coalescing_synapses) {
 }
 
 TEST(fvm_layout, synapse_targets) {
-    std::vector<cable_cell> cells = two_cell_system();
+    auto system = two_cell_system();
+    auto& cells = system.cells;
+    auto& builders = system.builders;
 
     // Add synapses with different parameter values so that we can
     // ensure: 1) CVs for each synapse mechanism are sorted while
@@ -393,14 +423,14 @@ TEST(fvm_layout, synapse_targets) {
         return mechanism_desc(name).set("e", syn_e.at(idx));
     };
 
-    cells[0].place(mlocation{1, 0.9}, syn_desc("expsyn", 0));
-    cells[0].place(mlocation{0, 0.5}, syn_desc("expsyn", 1));
-    cells[0].place(mlocation{1, 0.4}, syn_desc("expsyn", 2));
+    cells[0].place(builders[0].location({1, 0.9}), syn_desc("expsyn", 0));
+    cells[0].place(builders[0].location({0, 0.5}), syn_desc("expsyn", 1));
+    cells[0].place(builders[0].location({1, 0.4}), syn_desc("expsyn", 2));
 
-    cells[1].place(mlocation{2, 0.4}, syn_desc("exp2syn", 3));
-    cells[1].place(mlocation{1, 0.4}, syn_desc("exp2syn", 4));
-    cells[1].place(mlocation{3, 0.4}, syn_desc("expsyn", 5));
-    cells[1].place(mlocation{3, 0.7}, syn_desc("exp2syn", 6));
+    cells[1].place(builders[1].location({2, 0.4}), syn_desc("exp2syn", 3));
+    cells[1].place(builders[1].location({1, 0.4}), syn_desc("exp2syn", 4));
+    cells[1].place(builders[1].location({3, 0.4}), syn_desc("expsyn", 5));
+    cells[1].place(builders[1].location({3, 0.7}), syn_desc("exp2syn", 6));
 
     cable_cell_global_properties gprop;
     gprop.default_parameters = neuron_parameter_defaults;
@@ -522,11 +552,11 @@ TEST(fvm_layout, density_norm_area) {
     std::vector<double> expected_gl(ncv, dflt_gl);
 
     // Last 1/6 of branch 1
-    double seg1_area_right = cells[0].embedding().integrate_area(mcable{1, 5./6., 1.});
+    double seg1_area_right = cells[0].embedding().integrate_area(builder.cable({1, 5./6., 1.}));
     // First 1/6 of branch 2
-    double seg2_area_left = cells[0].embedding().integrate_area(mcable{2, 0., 1./6.});
+    double seg2_area_left = cells[0].embedding().integrate_area(builder.cable({2, 0., 1./6.}));
     // First 1/6 of branch 3
-    double seg3_area_left = cells[0].embedding().integrate_area(mcable{3, 0., 1./6.});
+    double seg3_area_left = cells[0].embedding().integrate_area(builder.cable({3, 0., 1./6.}));
 
     // CV 0: soma
     // CV1: left of branch 1
@@ -610,19 +640,19 @@ TEST(fvm_layout, density_norm_area_partial) {
     auto cell = builder.make_cell();
     cell.default_parameters.discretization = cv_policy_fixed_per_branch(1);
 
-    cell.paint(mcable{1, 0., 0.3}, hh_begin);
-    cell.paint(mcable{1, 0.4, 1.}, hh_end);
+    cell.paint(builder.cable({1, 0., 0.3}), hh_begin);
+    cell.paint(builder.cable({1, 0.4, 1.}), hh_end);
 
     std::vector<cable_cell> cells{std::move(cell)};
 
+    // Area of whole cell (which is area of the 1 branch)
+    double area = cells[0].embedding().integrate_area({0, 0., 1});
     // First 30% of branch 1.
-    double b1_area_begin = cells[0].embedding().integrate_area(mcable{1, 0., 0.3});
+    double b1_area_begin = cells[0].embedding().integrate_area(builder.cable({1, 0., 0.3}));
     // Last 60% of branch 1.
-    double b1_area_end = cells[0].embedding().integrate_area(mcable{1, 0.4, 1.});
-    // All of branch 1.
-    double b1_area = cells[0].embedding().integrate_area(mcable{1, 0., 1.});
+    double b1_area_end = cells[0].embedding().integrate_area(builder.cable({1, 0.4, 1.}));
 
-    double expected_norm_area = (b1_area_begin+b1_area_end)/b1_area;
+    double expected_norm_area = (b1_area_begin+b1_area_end)/area;
     double expected_gnabar = dflt_gnabar;
     double expected_gkbar = (dflt_gkbar*b1_area_begin + end_gkbar*b1_area_end)/(b1_area_begin + b1_area_end);
     double expected_gl = (dflt_gl*b1_area_begin + end_gl*b1_area_end)/(b1_area_begin + b1_area_end);
@@ -708,13 +738,10 @@ TEST(fvm_layout, ion_weights) {
     // the same as a 100µm dendrite, which makes it easier to describe the
     // expected weights.
 
-    auto construct_cell = []() {
-        soma_cell_builder builder(5);
-        builder.add_branch(0, 100, 0.5, 0.5, 1, "dend");
-        builder.add_branch(1, 200, 0.5, 0.5, 1, "dend");
-        builder.add_branch(1, 100, 0.5, 0.5, 1, "dend");
-        return builder.make_cell();
-    };
+    soma_cell_builder builder(5);
+    builder.add_branch(0, 100, 0.5, 0.5, 1, "dend");
+    builder.add_branch(1, 200, 0.5, 0.5, 1, "dend");
+    builder.add_branch(1, 100, 0.5, 0.5, 1, "dend");
 
     using uvec = std::vector<fvm_size_type>;
     using ivec = std::vector<fvm_index_type>;
@@ -746,10 +773,11 @@ TEST(fvm_layout, ion_weights) {
 
     for (auto run: count_along(mech_branches)) {
         SCOPED_TRACE("run "+std::to_string(run));
-        auto c = construct_cell();
+        auto c = builder.make_cell();
 
         for (auto i: mech_branches[run]) {
-            c.paint(reg::branch(i), "test_ca");
+            auto cab = builder.cable({i, 0, 1});
+            c.paint(reg::cable(cab.branch, cab.prox_pos, cab.dist_pos), "test_ca");
         }
 
         std::vector<cable_cell> cells{std::move(c)};

--- a/test/unit/test_fvm_lowered.cpp
+++ b/test/unit/test_fvm_lowered.cpp
@@ -265,12 +265,12 @@ TEST(fvm_lowered, target_handles) {
         make_cell_ball_and_3stick()
     };
 
-    EXPECT_EQ(cells[0].morphology().num_branches(), 2u);
-    EXPECT_EQ(cells[1].morphology().num_branches(), 4u);
+    EXPECT_EQ(cells[0].morphology().num_branches(), 1u);
+    EXPECT_EQ(cells[1].morphology().num_branches(), 3u);
 
     // (in increasing target order)
-    cells[0].place(mlocation{1, 0.4}, "expsyn");
-    cells[0].place(mlocation{0, 0.5}, "expsyn");
+    cells[0].place(mlocation{0, 0.7}, "expsyn");
+    cells[0].place(mlocation{0, 0.3}, "expsyn");
     cells[1].place(mlocation{2, 0.2}, "exp2syn");
     cells[1].place(mlocation{2, 0.8}, "expsyn");
 
@@ -281,9 +281,9 @@ TEST(fvm_lowered, target_handles) {
     probe_association_map<fvm_probe_info> probe_map;
 
     auto test_target_handles = [&](fvm_cell& cell) {
-        mechanism *expsyn = find_mechanism(cell, "expsyn");
+        mechanism* expsyn = find_mechanism(cell, "expsyn");
         ASSERT_TRUE(expsyn);
-        mechanism *exp2syn = find_mechanism(cell, "exp2syn");
+        mechanism* exp2syn = find_mechanism(cell, "exp2syn");
         ASSERT_TRUE(exp2syn);
 
         unsigned expsyn_id = expsyn->mechanism_id();
@@ -340,8 +340,10 @@ TEST(fvm_lowered, stimulus) {
     std::vector<cable_cell> cells;
     cells.push_back(make_cell_ball_and_stick(false));
 
-    cells[0].place(mlocation{1,1},   i_clamp{5., 80., 0.3});
-    cells[0].place(mlocation{0,0.5}, i_clamp{1., 2.,  0.1});
+    // At end of stick
+    cells[0].place(mlocation{0,1},   i_clamp{5., 80., 0.3});
+    // On the soma CV, which is over the approximate interval: (cable 0 0 0.1)
+    cells[0].place(mlocation{0,0.05}, i_clamp{1., 2.,  0.1});
 
     const fvm_size_type soma_cv = 0u;
     const fvm_size_type tip_cv = 5u;
@@ -426,9 +428,9 @@ TEST(fvm_lowered, derived_mechs) {
 
     std::vector<cable_cell> cells;
     cells.reserve(3);
+    soma_cell_builder builder(6);
+    builder.add_branch(0, 100, 0.5, 0.5, 4, "dend");
     for (int i = 0; i<3; ++i) {
-        soma_cell_builder builder(6);
-        builder.add_branch(0, 100, 0.5, 0.5, 4, "dend");
         auto cell = builder.make_cell();
 
         switch (i) {
@@ -449,7 +451,7 @@ TEST(fvm_lowered, derived_mechs) {
     cable1d_recipe rec(cells);
     rec.catalogue().derive("custom_kin1", "test_kin1", {{"tau", 20.0}});
 
-    cable_probe_total_ion_current_density where{{1, 0.3}};
+    cable_probe_total_ion_current_density where{builder.location({1, 0.3})};
     rec.add_probe(0, 0, where);
     rec.add_probe(1, 0, where);
     rec.add_probe(2, 0, where);
@@ -771,10 +773,10 @@ TEST(fvm_lowered, weighted_write_ion) {
     // 1/2 of branch 1 and the initial 1/2 of branches 2 and 3.
     //
     // Geometry:
-    //   soma 0: radius 5 µm
-    //   dend 1: 100 µm long, 1 µm diameter cylinder
-    //   dend 2: 200 µm long, 1 µm diameter cylinder
-    //   dend 3: 100 µm long, 1 µm diameter cylinder
+    //   soma 0:  10 µm long, 10 µm diameter cylinder: area = 100 πμm²
+    //   dend 1: 100 µm long,  1 µm diameter cylinder: area = 100 πμm²
+    //   dend 2: 200 µm long,  1 µm diameter cylinder: area = 200 πμm²
+    //   dend 3: 100 µm long,  1 µm diameter cylinder: area = 100 πμm²
     //
     // The radius of the soma is chosen such that the surface area of soma is
     // the same as a 100 µm dendrite, which makes it easier to describe the
@@ -800,10 +802,12 @@ TEST(fvm_lowered, weighted_write_ion) {
     const double con_ext = 120;
 
     // Ca ion reader test_kinlva on CV 2 and 3 via branch 2:
-    c.paint(reg::branch(2), "test_kinlva");
+    //c.paint(reg::branch(2), "test_kinlva");
+    c.paint(reg::branch(1), "test_kinlva");
 
     // Ca ion writer test_ca on CV 2 and 4 via branch 3:
-    c.paint(reg::branch(3), "test_ca");
+    //c.paint(reg::branch(3), "test_ca");
+    c.paint(reg::branch(2), "test_ca");
 
     cable1d_recipe rec(c);
     rec.add_ion("ca", 2, con_int, con_ext, 0.0);
@@ -894,7 +898,7 @@ TEST(fvm_lowered, gj_coords_simple) {
         soma_cell_builder b(2.1);
         b.add_branch(0, 10, 0.3, 0.2, 5, "dend");
         auto c = b.make_cell();
-        c.place(mlocation{1, 0.8}, gap_junction_site{});
+        c.place(b.location({1, 0.8}), gap_junction_site{});
         cells.push_back(std::move(c));
     }
 
@@ -902,7 +906,7 @@ TEST(fvm_lowered, gj_coords_simple) {
         soma_cell_builder b(2.4);
         b.add_branch(0, 10, 0.3, 0.2, 2, "dend");
         auto c = b.make_cell();
-        c.place(mlocation{1, 1}, gap_junction_site{});
+        c.place(b.location({1, 1}), gap_junction_site{});
         cells.push_back(std::move(c));
     }
 
@@ -977,7 +981,7 @@ TEST(fvm_lowered, gj_coords_complex) {
     b0.add_branch(0, 8, 0.3, 0.2, 4, "dend");
 
     auto c0 = b0.make_cell();
-    mlocation c0_gj[2] = {{1, 1}, {1, 0.5}};
+    mlocation c0_gj[2] = {b0.location({1, 1}), b0.location({1, 0.5})};
 
     c0.place(c0_gj[0], gap_junction_site{});
     c0.place(c0_gj[1], gap_junction_site{});
@@ -988,7 +992,7 @@ TEST(fvm_lowered, gj_coords_complex) {
     b1.add_branch(1,  5, 0.2, 0.2, 5, "dend");
 
     auto c1 = b1.make_cell();
-    mlocation c1_gj[4] = {{2, 1}, {1, 1}, {1, 0.45}, {1, 0.1}};
+    mlocation c1_gj[4] = {b1.location({2, 1}), b1.location({1, 1}), b1.location({1, 0.45}), b1.location({1, 0.1})};
 
     c1.place(c1_gj[0], gap_junction_site{});
     c1.place(c1_gj[1], gap_junction_site{});
@@ -1004,7 +1008,7 @@ TEST(fvm_lowered, gj_coords_complex) {
     b2.add_branch(2, 4, 0.2, 0.2, 2, "dend");
 
     auto c2 = b2.make_cell();
-    mlocation c2_gj[3] = {{1, 0.5}, {4, 1}, {2, 1}};
+    mlocation c2_gj[3] = {b2.location({1, 0.5}), b2.location({4, 1}), b2.location({2, 1})};
 
     c2.place(c2_gj[0], gap_junction_site{});
     c2.place(c2_gj[1], gap_junction_site{});

--- a/test/unit/test_mc_cell_group.cpp
+++ b/test/unit/test_mc_cell_group.cpp
@@ -26,8 +26,8 @@ namespace {
         cable_cell c = builder.make_cell();
         c.paint("soma", "hh");
         c.paint("dend", "pas");
-        c.place(mlocation{1,1}, i_clamp{5, 80, 0.3});
-        c.place(mlocation{0, 0}, threshold_detector{0});
+        c.place(builder.location({1,1}), i_clamp{5, 80, 0.3});
+        c.place(builder.location({0, 0}), threshold_detector{0});
         return c;
     }
 }
@@ -66,7 +66,7 @@ TEST(mc_cell_group, sources) {
     for (int i=0; i<20; ++i) {
         cells.push_back(make_cell());
         if (i==0 || i==3 || i==17) {
-            cells.back().place(mlocation{1, 0.3}, threshold_detector{2.3});
+            cells.back().place(mlocation{0, 0.3}, threshold_detector{2.3});
         }
 
         EXPECT_EQ(1u + (i==0 || i==3 || i==17), cells.back().detectors().size());

--- a/test/unit/test_mc_cell_group_gpu.cpp
+++ b/test/unit/test_mc_cell_group_gpu.cpp
@@ -27,8 +27,8 @@ namespace {
         cable_cell c = builder.make_cell();
         c.paint("soma", "hh");
         c.paint("dend", "pas");
-        c.place(mlocation{1,1}, i_clamp{5, 80, 0.3});
-        c.place(mlocation{0, 0}, threshold_detector{0});
+        c.place(builder.location({1, 1}), i_clamp{5, 80, 0.3});
+        c.place(builder.location({0, 0}), threshold_detector{0});
         return c;
     }
 }

--- a/test/unit/test_morph_embedding.cpp
+++ b/test/unit/test_morph_embedding.cpp
@@ -52,7 +52,7 @@ TEST(embedding, samples_and_branch_length) {
             {{ 10,  0,  0,  2}, 1},
         };
         sample_tree sm(samples, parents);
-        morphology m(sm, false);
+        morphology m(sm);
 
         embedding em(m);
 
@@ -73,73 +73,37 @@ TEST(embedding, samples_and_branch_length) {
     //          2   4
     //             5 6
     //                7
-    {   // Spherical root.
-        pvec parents = {mnpos, 0, 1, 0, 3, 4, 4, 6};
+    pvec parents = {mnpos, 0, 1, 0, 3, 4, 4, 6};
 
-        svec samples = {
-            {{  0,  0,  0, 10}, 1},
-            {{ 10,  0,  0,  2}, 3},
-            {{100,  0,  0,  2}, 3},
-            {{  0, 10,  0,  2}, 3},
-            {{  0,100,  0,  2}, 3},
-            {{100,100,  0,  2}, 3},
-            {{  0,200,  0,  2}, 3},
-            {{  0,300,  0,  2}, 3},
-        };
-        sample_tree sm(samples, parents);
-        morphology m(sm, true);
-        ASSERT_EQ(5u, m.num_branches());
+    svec samples = {
+        {{  0,  0,  0,  2}, 1},
+        {{ 10,  0,  0,  2}, 3},
+        {{100,  0,  0,  2}, 3},
+        {{  0, 10,  0,  2}, 3},
+        {{  0,100,  0,  2}, 3},
+        {{100,100,  0,  2}, 3},
+        {{  0,130,  0,  2}, 3},
+        {{  0,300,  0,  2}, 3},
+    };
+    sample_tree sm(samples, parents);
+    morphology m(sm);
+    ASSERT_EQ(4u, m.num_branches());
 
-        embedding em(m);
+    embedding em(m);
 
-        EXPECT_TRUE(location_eq(m, em.sample_location(0), (loc{0,0.5})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(1), (loc{1,0})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(2), (loc{1,1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(3), (loc{2,0})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(4), (loc{2,1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(5), (loc{3,1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(6), (loc{4,0.5})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(7), (loc{4,1})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(0), (loc{0,0})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(1), (loc{0,0.1})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(2), (loc{0,1})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(3), (loc{1,0.1})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(4), (loc{1,1})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(5), (loc{2,1})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(6), (loc{3,0.15})));
+    EXPECT_TRUE(location_eq(m, em.sample_location(7), (loc{3,1})));
 
-        EXPECT_EQ(20.,  em.branch_length(0));
-        EXPECT_EQ(90.,  em.branch_length(1));
-        EXPECT_EQ(90.,  em.branch_length(2));
-        EXPECT_EQ(100., em.branch_length(3));
-        EXPECT_EQ(200., em.branch_length(4));
-    }
-    {   // No Spherical root
-        pvec parents = {mnpos, 0, 1, 0, 3, 4, 4, 6};
-
-        svec samples = {
-            {{  0,  0,  0,  2}, 1},
-            {{ 10,  0,  0,  2}, 3},
-            {{100,  0,  0,  2}, 3},
-            {{  0, 10,  0,  2}, 3},
-            {{  0,100,  0,  2}, 3},
-            {{100,100,  0,  2}, 3},
-            {{  0,130,  0,  2}, 3},
-            {{  0,300,  0,  2}, 3},
-        };
-        sample_tree sm(samples, parents);
-        morphology m(sm, false);
-        ASSERT_EQ(4u, m.num_branches());
-
-        embedding em(m);
-
-        EXPECT_TRUE(location_eq(m, em.sample_location(0), (loc{0,0})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(1), (loc{0,0.1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(2), (loc{0,1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(3), (loc{1,0.1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(4), (loc{1,1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(5), (loc{2,1})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(6), (loc{3,0.15})));
-        EXPECT_TRUE(location_eq(m, em.sample_location(7), (loc{3,1})));
-
-        EXPECT_EQ(100., em.branch_length(0));
-        EXPECT_EQ(100., em.branch_length(1));
-        EXPECT_EQ(100., em.branch_length(2));
-        EXPECT_EQ(200., em.branch_length(3));
-    }
+    EXPECT_EQ(100., em.branch_length(0));
+    EXPECT_EQ(100., em.branch_length(1));
+    EXPECT_EQ(100., em.branch_length(2));
+    EXPECT_EQ(200., em.branch_length(3));
 }
 
 // TODO: integrator tests
@@ -159,7 +123,7 @@ TEST(embedding, partial_branch_length) {
         {{ 30,  0, 50, 5},  2}
     };
 
-    morphology m(sample_tree(samples, parents), false);
+    morphology m(sample_tree(samples, parents));
     embedding em(m);
 
     EXPECT_DOUBLE_EQ(30., em.branch_length(0));
@@ -196,7 +160,7 @@ TEST(embedding, partial_area) {
         {{ 30,  0, 50, 5},  2}
     };
 
-    morphology m(sample_tree(samples, parents), false);
+    morphology m(sample_tree(samples, parents));
     embedding em(m);
 
     // Cable 1: single truncated cone, length L = 10,

--- a/test/unit/test_morphology.cpp
+++ b/test/unit/test_morphology.cpp
@@ -153,55 +153,30 @@ TEST(morphology, branches_from_parent_index) {
         return st;
     };
 
-    {   // single sample: can only be used to build a morphology with one spherical branch
-        pvec parents{npos};
-        auto tree = make_tree(parents);
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), true);
-        EXPECT_EQ(1u, bc.size());
-        EXPECT_EQ(mb({0}, npos), bc[0]);
-
-        // A cable morphology can't be constructed from a single sample.
-        EXPECT_THROW(arb::impl::branches_from_parent_index(parents, tree.properties(), false),
-                     arb::incomplete_branch);
-    }
     {
         pvec parents = {npos, 0};
         auto tree = make_tree(parents);
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), false);
+        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties());
         EXPECT_EQ(1u, bc.size());
         EXPECT_EQ(mb({0,1}, npos), bc[0]);
-
-        // A morphology can't be constructed with a spherical soma from two samples.
-        EXPECT_THROW(arb::impl::branches_from_parent_index(parents, tree.properties(), true),
-                     arb::incomplete_branch);
     }
 
     {
         pvec parents{npos, 0, 1};
 
-        // With cable soma: one cable with 3 samples.
+        // One cable with 3 samples.
         auto tree = make_tree(parents);
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), false);
+        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties());
         EXPECT_EQ(1u, bc.size());
         EXPECT_EQ(mb({0,1,2},npos), bc[0]);
-
-        // With spherical soma: one sphere and a 2-segment cable.
-        // The cable branch is attached to the sphere (i.e. the sphere is the parent branch).
-        auto bs = arb::impl::branches_from_parent_index(parents, tree.properties(), true);
-        EXPECT_EQ(2u, bs.size());
-        EXPECT_EQ(mb({0},npos), bs[0]);
-        EXPECT_EQ(mb({1,2},0), bs[1]);
     }
 
     {
         pvec parents{npos, 0, 0};
         auto tree = make_tree(parents);
 
-        // A spherical root is not valid: each cable branch would have only one sample.
-        EXPECT_THROW(arb::impl::branches_from_parent_index(parents, tree.properties(), true), arb::incomplete_branch);
-
         // Two cables, with two samples each, with the first sample in each being the root
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), false);
+        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties());
         EXPECT_EQ(2u, bc.size());
         EXPECT_EQ(mb({0,1},npos), bc[0]);
         EXPECT_EQ(mb({0,2},npos), bc[1]);
@@ -211,72 +186,45 @@ TEST(morphology, branches_from_parent_index) {
         pvec parents{npos, 0, 1, 2};
         auto tree = make_tree(parents);
 
-        // With cable soma: one cable with 4 samples.
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), false);
+        // One cable with 4 samples.
+        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties());
         EXPECT_EQ(1u, bc.size());
         EXPECT_EQ(mb({0,1,2,3},npos), bc[0]);
-
-        // With spherical soma: one sphere and on 3-segment cable.
-        // The cable branch is attached to the sphere (i.e. the sphere is the parent branch).
-        auto bs = arb::impl::branches_from_parent_index(parents, tree.properties(), true);
-        EXPECT_EQ(2u, bs.size());
-        EXPECT_EQ(mb({0},npos), bs[0]);
-        EXPECT_EQ(mb({1,2,3},0), bs[1]);
     }
 
     {
         pvec parents{npos, 0, 1, 0};
         auto tree = make_tree(parents);
 
-        // With cable soma: two cables with 3 and 2 samples respectively.
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), false);
+        // Two cables attached to root, with 3 and 2 samples respectively.
+        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties());
         EXPECT_EQ(2u, bc.size());
         EXPECT_EQ(mb({0,1,2},npos), bc[0]);
         EXPECT_EQ(mb({0,3},npos), bc[1]);
-
-        // A spherical root is not valid: the second cable branch would have only one sample.
-        EXPECT_THROW(arb::impl::branches_from_parent_index(parents, tree.properties(), true), arb::incomplete_branch);
     }
 
     {
         pvec parents{npos, 0, 1, 0, 3};
         auto tree = make_tree(parents);
 
-        // With cable soma: two cables with 3 samples each [0,1,2] and [0,3,4]
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), false);
+        // Two cables attached to root, with 3 samples each [0,1,2] and [0,3,4]
+        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties());
         EXPECT_EQ(2u, bc.size());
         EXPECT_EQ(mb({0,1,2},npos), bc[0]);
         EXPECT_EQ(mb({0,3,4},npos), bc[1]);
-
-        // With spherical soma: one sphere and 2 2-sample cables.
-        // each of the cable branches is attached to the sphere (i.e. the sphere is the parent branch).
-        auto bs = arb::impl::branches_from_parent_index(parents, tree.properties(), true);
-        EXPECT_EQ(3u, bs.size());
-        EXPECT_EQ(mb({0},npos), bs[0]);
-        EXPECT_EQ(mb({1,2},0),  bs[1]);
-        EXPECT_EQ(mb({3,4},0),  bs[2]);
     }
 
     {
         pvec parents{npos, 0, 1, 0, 3, 4, 4, 6};
         auto tree = make_tree(parents);
 
-        // With cable soma: 4 cables: [0,1,2] [0,3,4] [4,5] [4,6,7]
-        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties(), false);
+        // 4 cables: [0,1,2] [0,3,4] [4,5] [4,6,7]
+        auto bc = arb::impl::branches_from_parent_index(parents, tree.properties());
         EXPECT_EQ(4u, bc.size());
         EXPECT_EQ(mb({0,1,2},npos), bc[0]);
         EXPECT_EQ(mb({0,3,4},npos), bc[1]);
         EXPECT_EQ(mb({4,5},  1),    bc[2]);
         EXPECT_EQ(mb({4,6,7},1),    bc[3]);
-
-        // With spherical soma: 1 sphere and 4 cables: [1,2] [3,4] [4,5] [4,6,7]
-        auto bs = arb::impl::branches_from_parent_index(parents, tree.properties(), true);
-        EXPECT_EQ(5u, bs.size());
-        EXPECT_EQ(mb({0},   npos), bs[0]);
-        EXPECT_EQ(mb({1,2}, 0),    bs[1]);
-        EXPECT_EQ(mb({3,4}, 0),    bs[2]);
-        EXPECT_EQ(mb({4,5}, 2),    bs[3]);
-        EXPECT_EQ(mb({4,6,7}, 2),  bs[4]);
     }
 }
 
@@ -299,78 +247,52 @@ TEST(morphology, construction) {
     }
     {
         pvec p = {npos, 0, 1};
-        { // 2-segment cable (1 seg soma, 1 seg dendrite)
-            std::vector<ms> s = {
-                {{0.0, 0.0, 0.0, 5.0}, 1},
-                {{0.0, 0.0, 5.0, 1.0}, 1},
-                {{0.0, 0.0, 8.0, 1.0}, 2} };
+        // 2-segment cable
+        std::vector<ms> s = {
+            {{0.0, 0.0, 0.0, 5.0}, 1},
+            {{0.0, 0.0, 1.0, 1.0}, 2},
+            {{0.0, 0.0, 8.0, 1.0}, 2} };
 
-            arb::sample_tree sm(s, p);
-            auto m = arb::morphology(sm);
+        arb::sample_tree sm(s, p);
+        auto m = arb::morphology(sm);
 
-            EXPECT_EQ(1u, m.num_branches());
-        }
-        { // spherical soma and single-segment cable
-            std::vector<ms> s = {
-                {{0.0, 0.0, 0.0, 5.0}, 1},
-                {{0.0, 0.0, 1.0, 1.0}, 2},
-                {{0.0, 0.0, 8.0, 1.0}, 2} };
-
-            arb::sample_tree sm(s, p);
-            auto m = arb::morphology(sm);
-
-            EXPECT_EQ(2u, m.num_branches());
-        }
+        EXPECT_EQ(1u, m.num_branches());
     }
     {
         //              0       |
         //            1   3     |
         //          2           |
         pvec p = {npos, 0, 1, 0};
-        {
-            // two cables: 1x2 segments, 1x1 segment.
-            std::vector<ms> s = {
-                {{0.0, 0.0, 0.0, 5.0}, 1},
-                {{0.0, 0.0, 5.0, 1.0}, 1},
-                {{0.0, 0.0, 6.0, 1.0}, 2},
-                {{0.0, 4.0, 0.0, 1.0}, 1}};
+        // two cables: 1x2 segments, 1x1 segment.
+        std::vector<ms> s = {
+            {{0.0, 0.0, 0.0, 5.0}, 1},
+            {{0.0, 0.0, 5.0, 1.0}, 1},
+            {{0.0, 0.0, 6.0, 1.0}, 2},
+            {{0.0, 4.0, 0.0, 1.0}, 1}};
 
-            arb::sample_tree sm(s, p);
-            auto m = arb::morphology(sm);
+        arb::sample_tree sm(s, p);
+        auto m = arb::morphology(sm);
 
-            EXPECT_EQ(2u, m.num_branches());
-        }
-        {
-            // error: spherical soma with a single point cable attached via sample 3
-            std::vector<ms> s = {
-                {{0.0, 0.0, 0.0, 5.0}, 1},
-                {{0.0, 0.0, 5.0, 1.0}, 2},
-                {{0.0, 0.0, 8.0, 1.0}, 2},
-                {{0.0, 5.0, 0.0, 1.0}, 2}};
-
-            arb::sample_tree sm(s, p);
-            EXPECT_THROW((arb::morphology(sm)), arb::incomplete_branch);
-        }
+        EXPECT_EQ(2u, m.num_branches());
     }
     {
         //              0       |
         //            1   3     |
         //          2       4    |
         pvec p = {npos, 0, 1, 0, 3};
-        {
-            // two cables: 1x2 segments, 1x1 segment.
-            std::vector<ms> s = {
-                {{0.0, 0.0, 0.0, 5.0}, 1},
-                {{0.0, 0.0, 5.0, 1.0}, 2},
-                {{0.0, 0.0, 8.0, 1.0}, 2},
-                {{0.0, 5.0, 0.0, 1.0}, 2},
-                {{0.0, 8.0, 0.0, 1.0}, 2}};
 
-            arb::sample_tree sm(s, p);
-            auto m = arb::morphology(sm);
+        // two cables: 2 segments each
+        std::vector<ms> s = {
+            {{0.0, 0.0, 0.0, 5.0}, 1},
+            {{0.0, 0.0, 5.0, 1.0}, 2},
+            {{0.0, 0.0, 8.0, 1.0}, 2},
+            {{0.0, 5.0, 0.0, 1.0}, 2},
+            {{0.0, 8.0, 0.0, 1.0}, 2}};
 
-            EXPECT_EQ(3u, m.num_branches());
-        }
+        arb::sample_tree sm(s, p);
+        auto m = arb::morphology(sm);
+
+        EXPECT_EQ(2u, m.num_branches());
     }
 }
 
@@ -391,21 +313,6 @@ TEST(morphology, branches) {
     };
 
     {
-        // 0
-        pvec parents = {npos};
-        svec samples = {
-            {{ 0,0,0,3}, 1},
-        };
-        arb::sample_tree sm(samples, parents);
-        arb::morphology m(sm);
-
-        EXPECT_EQ(1u, m.num_branches());
-        EXPECT_EQ(npos, m.branch_parent(0));
-        EXPECT_EQ(pvec{}, m.branch_children(0));
-
-        check_terminal_branches(m);
-    }
-    {
         // 0 - 1
         pvec parents = {npos, 0};
         svec samples = {
@@ -425,7 +332,7 @@ TEST(morphology, branches) {
         // 0 - 1 - 2
         pvec parents = {npos, 0, 1};
         {
-            // All samples have same tag -> the morphology is a single unbranched cable.
+            // the morphology is a single unbranched cable.
             svec samples = {
                 {{ 0,0,0,3}, 1},
                 {{10,0,0,3}, 1},
@@ -437,24 +344,6 @@ TEST(morphology, branches) {
             EXPECT_EQ(1u, m.num_branches());
             EXPECT_EQ(npos, m.branch_parent(0));
             EXPECT_EQ(pvec{}, m.branch_children(0));
-
-            check_terminal_branches(m);
-        }
-        {
-            // First sample has unique tag -> spherical soma attached to a single-segment cable.
-            svec samples = {
-                {{  0,0,0,10}, 1},
-                {{ 10,0,0, 3}, 3},
-                {{100,0,0, 3}, 3},
-            };
-            arb::sample_tree sm(samples, parents);
-            arb::morphology m(sm);
-
-            EXPECT_EQ(2u, m.num_branches());
-            EXPECT_EQ(npos, m.branch_parent(0));
-            EXPECT_EQ(0u,   m.branch_parent(1));
-            EXPECT_EQ(pvec{1}, m.branch_children(0));
-            EXPECT_EQ(pvec{},  m.branch_children(1));
 
             check_terminal_branches(m);
         }
@@ -480,18 +369,6 @@ TEST(morphology, branches) {
         check_terminal_branches(m);
     }
     {
-        // 0 - 1 - 2 - 3
-        pvec parents = {npos, 0, 1, 2};
-    }
-    {
-        //              0       |
-        //             / \      |
-        //            1   3     |
-        //           /          |
-        //          2           |
-        pvec parents = {npos, 0, 1, 0};
-    }
-    {
         // Eight samples
         //
         //              0           |
@@ -504,60 +381,30 @@ TEST(morphology, branches) {
         //                     \    |
         //                      7   |
         pvec parents = {npos, 0, 1, 0, 3, 4, 4, 6};
-        {
-            svec samples = {
-                {{  0,  0,  0, 10}, 1},
-                {{ 10,  0,  0,  2}, 3},
-                {{100,  0,  0,  2}, 3},
-                {{  0, 10,  0,  2}, 3},
-                {{  0,100,  0,  2}, 3},
-                {{100,100,  0,  2}, 3},
-                {{  0,200,  0,  2}, 3},
-                {{  0,300,  0,  2}, 3},
-            };
-            arb::sample_tree sm(samples, parents);
-            arb::morphology m(sm);
+        svec samples = {
+            {{  0,  0,  0, 10}, 3},
+            {{ 10,  0,  0,  2}, 3},
+            {{100,  0,  0,  2}, 3},
+            {{  0, 10,  0,  2}, 3},
+            {{  0,100,  0,  2}, 3},
+            {{100,100,  0,  2}, 3},
+            {{  0,200,  0,  2}, 3},
+            {{  0,300,  0,  2}, 3},
+        };
+        arb::sample_tree sm(samples, parents);
+        arb::morphology m(sm);
 
-            EXPECT_EQ(5u, m.num_branches());
-            EXPECT_EQ(npos, m.branch_parent(0));
-            EXPECT_EQ(0u,   m.branch_parent(1));
-            EXPECT_EQ(0u,   m.branch_parent(2));
-            EXPECT_EQ(2u,   m.branch_parent(3));
-            EXPECT_EQ(2u,   m.branch_parent(4));
-            EXPECT_EQ((pvec{1,2}), m.branch_children(0));
-            EXPECT_EQ((pvec{}),    m.branch_children(1));
-            EXPECT_EQ((pvec{3,4}), m.branch_children(2));
-            EXPECT_EQ((pvec{}),    m.branch_children(3));
-            EXPECT_EQ((pvec{}),    m.branch_children(4));
+        EXPECT_EQ(4u, m.num_branches());
+        EXPECT_EQ(npos, m.branch_parent(0));
+        EXPECT_EQ(npos, m.branch_parent(1));
+        EXPECT_EQ(1u,   m.branch_parent(2));
+        EXPECT_EQ(1u,   m.branch_parent(3));
+        EXPECT_EQ((pvec{}),    m.branch_children(0));
+        EXPECT_EQ((pvec{2,3}), m.branch_children(1));
+        EXPECT_EQ((pvec{}),    m.branch_children(2));
+        EXPECT_EQ((pvec{}),    m.branch_children(3));
 
-            check_terminal_branches(m);
-        }
-        {
-            svec samples = {
-                {{  0,  0,  0, 10}, 3},
-                {{ 10,  0,  0,  2}, 3},
-                {{100,  0,  0,  2}, 3},
-                {{  0, 10,  0,  2}, 3},
-                {{  0,100,  0,  2}, 3},
-                {{100,100,  0,  2}, 3},
-                {{  0,200,  0,  2}, 3},
-                {{  0,300,  0,  2}, 3},
-            };
-            arb::sample_tree sm(samples, parents);
-            arb::morphology m(sm);
-
-            EXPECT_EQ(4u, m.num_branches());
-            EXPECT_EQ(npos, m.branch_parent(0));
-            EXPECT_EQ(npos, m.branch_parent(1));
-            EXPECT_EQ(1u,   m.branch_parent(2));
-            EXPECT_EQ(1u,   m.branch_parent(3));
-            EXPECT_EQ((pvec{}),    m.branch_children(0));
-            EXPECT_EQ((pvec{2,3}), m.branch_children(1));
-            EXPECT_EQ((pvec{}),    m.branch_children(2));
-            EXPECT_EQ((pvec{}),    m.branch_children(3));
-
-            check_terminal_branches(m);
-        }
+        check_terminal_branches(m);
     }
 }
 
@@ -581,7 +428,7 @@ TEST(morphology, swc) {
 
     // Test that the morphology contains the expected number of branches.
     auto m = arb::morphology(sm);
-    EXPECT_EQ(31u, m.num_branches());
+    EXPECT_EQ(30u, m.num_branches());
 }
 #endif
 
@@ -592,13 +439,12 @@ TEST(morphology, minset) {
     constexpr auto npos = arb::mnpos;
 
     // Eight samples
-    //                  no-sphere  sphere
-    //          sample   branch    branch
-    //            0         0         0
-    //           1 3       0 1       1 2
-    //          2   4     0   1     1   2
-    //             5 6       2 3       3 4
-    //                7         3         4
+    //          sample   branch
+    //            0         0
+    //           1 3       0 1
+    //          2   4     0   1
+    //             5 6       2 3
+    //                7         3
     pvec parents = {npos, 0, 1, 0, 3, 4, 4, 6};
     svec samples = {
         {{  0,  0,  0,  2}, 3},
@@ -611,29 +457,18 @@ TEST(morphology, minset) {
         {{  0,300,  0,  2}, 3},
     };
     arb::sample_tree sm(samples, parents);
-    {
-        arb::morphology m(sm, false);
 
-        EXPECT_EQ((ll{}), minset(m, ll{}));
-        EXPECT_EQ((ll{{2,0.1}}), minset(m, ll{{2,0.1}}));
-        EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), minset(m, ll{{0,0.5}, {1,0.5}}));
-        EXPECT_EQ((ll{{0,0.5}}), minset(m, ll{{0,0.5}}));
-        EXPECT_EQ((ll{{0,0}, {1,0}}), minset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
-        EXPECT_EQ((ll{{0,0}, {1,0.5}}), minset(m, ll{{0,0}, {0,0.5}, {1,0.5}, {2,0.5}}));
-        EXPECT_EQ((ll{{0,0}, {2,0.5}}), minset(m, ll{{0,0}, {0,0.5}, {2,0.5}}));
-        EXPECT_EQ((ll{{0,0}, {2,0.5}, {3,0}}), minset(m, ll{{0,0}, {0,0.5}, {2,0.5}, {3,0}, {3,1}}));
-        EXPECT_EQ((ll{{0,0}, {1,0}}), minset(m, ll{{0,0}, {0,0.5}, {1,0}, {2,0.5}, {3,0}, {3,1}}));
-    }
-    {
-        arb::morphology m(sm, true);
+    arb::morphology m(sm);
 
-        EXPECT_EQ((ll{}), minset(m, ll{}));
-        EXPECT_EQ((ll{{2,0.1}}), minset(m, ll{{2,0.1}}));
-        EXPECT_EQ((ll{{0,0.5}}), minset(m, ll{{0,0.5}, {1,0.5}}));
-        EXPECT_EQ((ll{{0,0.5}}), minset(m, ll{{0,0.5}}));
-        EXPECT_EQ((ll{{0,0}}), minset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
-        EXPECT_EQ((ll{{1,0.5}, {3,0.1}, {4,0.5}}), minset(m, ll{{1,0.5}, {1,1}, {3,0.1}, {4,0.5}, {4,0.7}}));
-    }
+    EXPECT_EQ((ll{}), minset(m, ll{}));
+    EXPECT_EQ((ll{{2,0.1}}), minset(m, ll{{2,0.1}}));
+    EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), minset(m, ll{{0,0.5}, {1,0.5}}));
+    EXPECT_EQ((ll{{0,0.5}}), minset(m, ll{{0,0.5}}));
+    EXPECT_EQ((ll{{0,0}, {1,0}}), minset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
+    EXPECT_EQ((ll{{0,0}, {1,0.5}}), minset(m, ll{{0,0}, {0,0.5}, {1,0.5}, {2,0.5}}));
+    EXPECT_EQ((ll{{0,0}, {2,0.5}}), minset(m, ll{{0,0}, {0,0.5}, {2,0.5}}));
+    EXPECT_EQ((ll{{0,0}, {2,0.5}, {3,0}}), minset(m, ll{{0,0}, {0,0.5}, {2,0.5}, {3,0}, {3,1}}));
+    EXPECT_EQ((ll{{0,0}, {1,0}}), minset(m, ll{{0,0}, {0,0.5}, {1,0}, {2,0.5}, {3,0}, {3,1}}));
 }
 
 TEST(morphology, maxset) {
@@ -643,13 +478,12 @@ TEST(morphology, maxset) {
     constexpr auto npos = arb::mnpos;
 
     // Eight samples
-    //                  no-sphere  sphere
-    //          sample   branch    branch
-    //            0         0         0
-    //           1 3       0 1       1 2
-    //          2   4     0   1     1   2
-    //             5 6       2 3       3 4
-    //                7         3         4
+    //          sample   branch
+    //            0         0
+    //           1 3       0 1
+    //          2   4     0   1
+    //             5 6       2 3
+    //                7         3
     pvec parents = {npos, 0, 1, 0, 3, 4, 4, 6};
     svec samples = {
         {{  0,  0,  0,  2}, 3},
@@ -662,29 +496,17 @@ TEST(morphology, maxset) {
         {{  0,300,  0,  2}, 3},
     };
     arb::sample_tree sm(samples, parents);
-    {
-        arb::morphology m(sm, false);
+    arb::morphology m(sm);
 
-        EXPECT_EQ((ll{}), maxset(m, ll{}));
-        EXPECT_EQ((ll{{2,0.1}}), maxset(m, ll{{2,0.1}}));
-        EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), maxset(m, ll{{0,0.5}, {1,0.5}}));
-        EXPECT_EQ((ll{{0,0.5}}), maxset(m, ll{{0,0.5}}));
-        EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
-        EXPECT_EQ((ll{{0,0.5}, {2,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0.5}, {2,0.5}}));
-        EXPECT_EQ((ll{{0,0.5}, {2,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {2,0.5}}));
-        EXPECT_EQ((ll{{0,0.5}, {2,0.5}, {3,1}}), maxset(m, ll{{0,0}, {0,0.5}, {2,0.5}, {3,0}, {3,1}}));
-        EXPECT_EQ((ll{{2,0.5}, {3,0.5}}), maxset(m, ll{{1,0.5}, {2,0.5}, {3,0}, {3,0.2}, {3,0.5}}));
-    }
-    {
-        arb::morphology m(sm, true);
-
-        EXPECT_EQ((ll{}), maxset(m, ll{}));
-        EXPECT_EQ((ll{{2,0.1}}), maxset(m, ll{{2,0.1}}));
-        EXPECT_EQ((ll{{1,0.5}}), maxset(m, ll{{0,0.5}, {1,0.5}}));
-        EXPECT_EQ((ll{{1,0}, {2,0}}), maxset(m, ll{{2,0}, {1,0}, {0,0}}));
-        EXPECT_EQ((ll{{1,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
-        EXPECT_EQ((ll{{1,1}, {3,0.1}, {4,0.7}}), maxset(m, ll{{1,0.5}, {1,1}, {3,0.1}, {4,0.5}, {4,0.7}}));
-    }
+    EXPECT_EQ((ll{}), maxset(m, ll{}));
+    EXPECT_EQ((ll{{2,0.1}}), maxset(m, ll{{2,0.1}}));
+    EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), maxset(m, ll{{0,0.5}, {1,0.5}}));
+    EXPECT_EQ((ll{{0,0.5}}), maxset(m, ll{{0,0.5}}));
+    EXPECT_EQ((ll{{0,0.5}, {1,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0}, {1,0.5}}));
+    EXPECT_EQ((ll{{0,0.5}, {2,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {1,0.5}, {2,0.5}}));
+    EXPECT_EQ((ll{{0,0.5}, {2,0.5}}), maxset(m, ll{{0,0}, {0,0.5}, {2,0.5}}));
+    EXPECT_EQ((ll{{0,0.5}, {2,0.5}, {3,1}}), maxset(m, ll{{0,0}, {0,0.5}, {2,0.5}, {3,0}, {3,1}}));
+    EXPECT_EQ((ll{{2,0.5}, {3,0.5}}), maxset(m, ll{{1,0.5}, {2,0.5}, {3,0}, {3,0.2}, {3,0.5}}));
 }
 
 // Testing mextent; intersection and join operations are
@@ -699,7 +521,6 @@ TEST(mextent, invariants) {
     using cl = mcable_list;
 
     // Eight samples
-    //                  no-sphere
     //          sample   branch
     //            0         0
     //           1 3       0 1
@@ -718,8 +539,8 @@ TEST(mextent, invariants) {
         {{  0,300,  0,  2}, 3},
     };
 
-    // Instantiate morphology with spherical_root=false.
-    morphology m(sample_tree(samples, parents), false);
+    // Instantiate morphology
+    morphology m(sample_tree(samples, parents));
 
     mextent x1(cl{{1, 0.25, 0.75}});
     ASSERT_TRUE(x1.test_invariants(m));
@@ -754,7 +575,6 @@ TEST(mextent, intersects) {
     using cl = mcable_list;
 
     // Eight samples
-    //                  no-sphere
     //          sample   branch
     //            0         0
     //           1 3       0 1

--- a/test/unit/test_probe.cpp
+++ b/test/unit/test_probe.cpp
@@ -94,7 +94,11 @@ void run_v_i_probe_test(const context& ctx) {
     using fvm_cell = typename backend_access<Backend>::fvm_cell;
     auto deref = [](const fvm_value_type* p) { return backend_access<Backend>::deref(p); };
 
-    cable_cell bs = make_cell_ball_and_stick(false);
+    soma_cell_builder builder(12.6157/2.0);
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+    cable_cell bs = builder.make_cell();
+
     bs.default_parameters.discretization = cv_policy_fixed_per_branch(1);
 
     i_clamp stim(0, 100, 0.3);
@@ -256,7 +260,10 @@ void run_expsyn_g_probe_test(const context& ctx) {
     mlocation loc0{1, 0.8};
     mlocation loc1{1, 1.0};
 
-    cable_cell bs = make_cell_ball_and_stick(false);
+    soma_cell_builder builder(12.6157/2.0);
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+    cable_cell bs = builder.make_cell();
     bs.place(loc0, "expsyn");
     bs.place(loc1, "expsyn");
     bs.default_parameters.discretization = cv_policy_fixed_per_branch(2);
@@ -914,7 +921,12 @@ auto run_simple_sampler(
 
 template <typename Backend>
 void run_v_sampled_probe_test(const context& ctx) {
-    cable_cell bs = make_cell_ball_and_stick(false);
+    soma_cell_builder builder(12.6157/2.0);
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+    builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+
+    cable_cell bs = builder.make_cell();
+
     bs.default_parameters.discretization = cv_policy_fixed_per_branch(1);
 
     std::vector<cable_cell> cells = {bs, bs};
@@ -1079,7 +1091,11 @@ void run_exact_sampling_probe_test(const context& ctx) {
         adhoc_recipe() {
             gprop_.default_parameters = neuron_parameter_defaults;
 
-            cells_.assign(4, make_cell_ball_and_stick(false));
+            soma_cell_builder builder(12.6157/2.0);
+            builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+            builder.add_branch(0, 200, 1.0/2, 1.0/2, 1, "dend");
+
+            cells_.assign(4, builder.make_cell());
             cells_[0].place(mlocation{1, 0.1}, "expsyn");
             cells_[1].place(mlocation{1, 0.1}, "exp2syn");
             cells_[2].place(mlocation{1, 0.9}, "expsyn");


### PR DESCRIPTION
Remove support for spherical segments, and by extension "spherical somas".

* remove `cv_olicy_flag::single_root_cv`, which will only produce the intended results when all all cables attached to the soma are separate branches.
* remove `arb::math::{volume/area}_sphere`, which were not being used anywhere in the code before this.
* `arb::morphology`:
  * remove constructor that auto-detects whether the cell has spherical root
  * remove `spherical_root` query from API
  * remove spherical root logic from implementation
* remove a fair bit of special casing for spheres from different locations, such as the `pw_lin` code.
* arbor exception types print parents as `mnpos` instead of numeric values where appropriate
* fixed a memory violation (out of bounds access) in the sample tree on invalid use input
* update unit tests and python wrapper to reflect the changes.

Fixes #1060 