### PR TITLE
Python wrapper: catalogues and global properties

### DIFF
--- a/arbor/include/arbor/mechcat.hpp
+++ b/arbor/include/arbor/mechcat.hpp
@@ -75,6 +75,8 @@ public:
                 const std::vector<std::pair<std::string, double>>& global_params,
                 const std::vector<std::pair<std::string, std::string>>& ion_remap = {});
 
+    void derive(const std::string& name, const std::string& parent);
+
     // Remove mechanism from catalogue, together with any derivations of it.
     void remove(const std::string& name);
 

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -536,6 +536,10 @@ void mechanism_catalogue::derive(const std::string& name, const std::string& par
     state_->bind(name, value(state_->derive(name, parent, global_params, ion_remap_vec)));
 }
 
+void mechanism_catalogue::derive(const std::string& name, const std::string& parent) {
+    state_->bind(name, value(state_->derive(parent)));
+}
+
 void mechanism_catalogue::remove(const std::string& name) {
     if (!has(name)) {
         throw no_such_mechanism(name);

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -416,7 +416,7 @@ struct radius_ge_ {
 };
 
 region radius_ge(region reg, double val) {
-    return region(radius_gt_{reg, val});
+    return region(radius_ge_{reg, val});
 }
 
 mextent thingify_(const radius_ge_& r, const mprovider& p) {

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,6 +23,7 @@ set(pyarb_source
     event_generator.cpp
     flat_cell_builder.cpp
     identifiers.cpp
+    mechanism.cpp
     morphology.cpp
     morph_parse.cpp
     mpi.cpp

--- a/python/cells.hpp
+++ b/python/cells.hpp
@@ -2,8 +2,17 @@
 
 #include <pybind11/pybind11.h>
 
+#include <arbor/cable_cell_param.hpp>
+#include <arbor/mechcat.hpp>
 #include <arbor/util/unique_any.hpp>
 
 namespace pyarb {
 arb::util::unique_any convert_cell(pybind11::object o);
+
+struct global_props_shim {
+    arb::mechanism_catalogue cat;
+    arb::cable_cell_global_properties props;
+    global_props_shim();
+};
+
 }

--- a/python/conversion.hpp
+++ b/python/conversion.hpp
@@ -78,6 +78,8 @@ arb::util::optional<T> py2optional(pybind11::object o, const char* msg) {
 // to cast is not an error.
 template <typename T>
 arb::util::optional<T> try_cast(pybind11::object o) {
+    if (o.is_none()) return arb::util::nullopt;
+
     try {
         return o.cast<T>();
     }

--- a/python/example/single_cell_swc.py
+++ b/python/example/single_cell_swc.py
@@ -1,4 +1,4 @@
-import arbor
+mport arbor
 from arbor import mechanism as mech
 from arbor import location as loc
 import matplotlib.pyplot as plt

--- a/python/example/single_cell_swc.py
+++ b/python/example/single_cell_swc.py
@@ -1,4 +1,4 @@
-mport arbor
+import arbor
 from arbor import mechanism as mech
 from arbor import location as loc
 import matplotlib.pyplot as plt

--- a/python/mechanism.cpp
+++ b/python/mechanism.cpp
@@ -1,0 +1,180 @@
+#include <pybind11/pybind11.h>
+#include "pybind11/pytypes.h"
+#include <pybind11/stl.h>
+
+#include <arbor/cable_cell_param.hpp>
+#include <arbor/mechanism.hpp>
+#include <arbor/mechcat.hpp>
+#include <arbor/util/optional.hpp>
+#include <stdexcept>
+
+#include "arbor/mechinfo.hpp"
+
+#include "conversion.hpp"
+#include "strprintf.hpp"
+
+namespace pyarb {
+
+void apply_derive(arb::mechanism_catalogue& m,
+            const std::string& name,
+            const std::string& parent,
+            const std::unordered_map<std::string, double>& globals,
+            const std::unordered_map<std::string, std::string>& ions)
+{
+    if (globals.empty() && ions.empty()) {
+        m.derive(name, parent);
+        return;
+    }
+    std::vector<std::pair<std::string, double>> G;
+    for (auto& g: globals) {
+        G.push_back({g.first, g.second});
+    }
+    std::vector<std::pair<std::string, std::string>> I;
+    for (auto& i: ions) {
+        I.push_back({i.first, i.second});
+    }
+    m.derive(name, parent, G, I);
+}
+
+void register_mechanisms(pybind11::module& m) {
+    using arb::util::optional;
+    using namespace pybind11::literals;
+
+    pybind11::class_<arb::mechanism_field_spec> field_spec(m, "mechanism_field",
+        "Basic information about a mechanism field.");
+    field_spec
+        .def(pybind11::init<const arb::mechanism_field_spec&>())
+        .def_readonly("units",   &arb::mechanism_field_spec::units)
+        .def_readonly("default", &arb::mechanism_field_spec::default_value)
+        .def_readonly("min",     &arb::mechanism_field_spec::lower_bound)
+        .def_readonly("max",     &arb::mechanism_field_spec::upper_bound)
+        .def("__repr__",
+                [](const arb::mechanism_field_spec& spec) {
+                    return util::pprintf("{units: '{}', default: {}, min: {}, max: {}}",
+                                         (spec.units.size()? spec.units.c_str(): "1"), spec.default_value,
+                                         spec.lower_bound, spec.upper_bound); })
+        .def("__str__",
+                [](const arb::mechanism_field_spec& spec) {
+                    return util::pprintf("{units: '{}', default: {}, min: {}, max: {}}",
+                                         (spec.units.size()? spec.units.c_str(): "1"), spec.default_value,
+                                         spec.lower_bound, spec.upper_bound); });
+
+    pybind11::class_<arb::ion_dependency> ion_dep(m, "ion_dependency",
+        "Information about a mechanism's dependence on an ion species.");
+    ion_dep
+        .def(pybind11::init<const arb::ion_dependency&>())
+        .def_readonly("write_int_con", &arb::ion_dependency::write_concentration_int)
+        .def_readonly("write_ext_con", &arb::ion_dependency::write_concentration_ext)
+        .def_readonly("write_rev_pot", &arb::ion_dependency::write_reversal_potential)
+        .def_readonly("read_rev_pot",  &arb::ion_dependency::read_reversal_potential)
+        .def("__repr__",
+                [](const arb::ion_dependency& dep) {
+                    auto tf = [](bool x) {return x? "True": "False";};
+                    return util::pprintf("{write_int_con: {}, write_ext_con: {}, write_rev_pot: {}, read_rev_pot: {}}",
+                                         tf(dep.write_concentration_int), tf(dep.write_concentration_ext),
+                                         tf(dep.write_reversal_potential), tf(dep.read_reversal_potential)); })
+        .def("__str__",
+                [](const arb::ion_dependency& dep) {
+                    auto tf = [](bool x) {return x? "True": "False";};
+                    return util::pprintf("{write_int_con: {}, write_ext_con: {}, write_rev_pot: {}, read_rev_pot: {}}",
+                                         tf(dep.write_concentration_int), tf(dep.write_concentration_ext),
+                                         tf(dep.write_reversal_potential), tf(dep.read_reversal_potential)); })
+        ;
+
+    pybind11::class_<arb::mechanism_info> mech_inf(m, "mechanism_info",
+        "Meta data about a mechanism's fields and ion dependendencies.");
+    mech_inf
+        .def(pybind11::init<const arb::mechanism_info&>())
+        .def_readonly("globals", &arb::mechanism_info::globals,
+            "Global fields have one value common to an instance of a mechanism, are constant in time and set at instantiation.")
+        .def_readonly("parameters", &arb::mechanism_info::parameters,
+            "Parameter fields may vary across the extent of a mechanism, but are constant in time and set at instantiation.")
+        .def_readonly("state", &arb::mechanism_info::state,
+            "State fields vary in time and across the extent of a mechanism, and potentially can be sampled at run-time.")
+        .def_readonly("ions", &arb::mechanism_info::ions,
+            "Ion dependencies.")
+        .def_readonly("linear", &arb::mechanism_info::linear,
+            "True if a synapse mechanism has linear current contributions so that multiple instances on the same compartment can be coalesed.")
+        .def("__repr__",
+                [](const arb::mechanism_info& inf) {
+                    return util::pprintf("(arbor.mechanism_info)"); })
+        .def("__str__",
+                [](const arb::mechanism_info& inf) {
+                    return util::pprintf("(arbor.mechanism_info)"); });
+
+    pybind11::class_<arb::mechanism_catalogue> cat(m, "mechanism_catalogue");
+    cat
+        .def(pybind11::init<const arb::mechanism_catalogue&>())
+        .def("has", &arb::mechanism_catalogue::has,
+                "name"_a, "Is 'name' in the catalogue?")
+        .def("is_derived", &arb::mechanism_catalogue::is_derived,
+                "name"_a, "Is 'name' a derived mechanism or can it be implicitly derived?")
+        .def("__getitem__",
+            [](arb::mechanism_catalogue& c, const char* name) {
+                try {
+                    return c[name];
+                }
+                catch (...) {
+                    throw std::runtime_error(util::pprintf("\nKeyError: '{}'", name));
+                }
+            })
+        .def("derive", &apply_derive,
+                "name"_a, "parent"_a,
+                "globals"_a=std::unordered_map<std::string, double>{},
+                "ions"_a=std::unordered_map<std::string, std::string>{})
+        .def("__repr__",
+                [](const arb::mechanism_catalogue& cat) {
+                    return util::pprintf("<arbor.mechanism_catalogue>"); })
+        .def("__str__",
+                [](const arb::mechanism_catalogue& cat) {
+                    return util::pprintf("<arbor.mechanism_catalogue>"); });
+
+    m.def("default_catalogue", [](){return arb::global_default_catalogue();});
+
+    // arb::mechanism_desc
+    // For specifying a mechanism in the cable_cell interface.
+
+    pybind11::class_<arb::mechanism_desc> mechanism_desc(m, "mechanism");
+    mechanism_desc
+        .def(pybind11::init([](const char* n) {return arb::mechanism_desc{n};}))
+        // allow construction of a description with parameters provided in a dictionary:
+        //      mech = arbor.mechanism('mech_name', {'param1': 1.2, 'param2': 3.14})
+        .def(pybind11::init(
+            [](const char* name, std::unordered_map<std::string, double> params) {
+                arb::mechanism_desc md(name);
+                for (const auto& p: params) md.set(p.first, p.second);
+                return md;
+            }),
+            "name"_a, "The name of the mechanism",
+            "params"_a, "A dictionary of parameter values, with parameter name as key.",
+            "Example usage setting pararmeters:\n"
+            "  m = arbor.mechanism('expsyn', {'tau': 1.4})\n"
+            "will create parameters for the 'expsyn' mechanism, with the provided value\n"
+            "for 'tau' overrides the default. If a parameter is not set, the default\n"
+            "(as defined in NMODL) is used.\n\n"
+            "Example overriding a global parameter:\n"
+            "  m = arbor.mechanism('nernst/R=8.3145,F=96485')")
+        .def("set",
+            [](arb::mechanism_desc& md, std::string name, double value) {
+                md.set(name, value);
+            },
+            "name"_a, "value"_a, "Set parameter value.")
+        .def_property_readonly("name",
+            [](const arb::mechanism_desc& md) {
+                return md.name();
+            },
+            "The name of the mechanism.")
+        .def_property_readonly("values",
+            [](const arb::mechanism_desc& md) {
+                return md.values();
+            }, "A dictionary of parameter values with parameter name as key.")
+        .def("__repr__",
+                [](const arb::mechanism_desc& md) {
+                    return util::pprintf("<arbor.mechanism: name '{}', parameters {}", md.name(), util::dictionary_csv(md.values())); })
+        .def("__str__",
+                [](const arb::mechanism_desc& md) {
+                    return util::pprintf("('{}' {})", md.name(), util::dictionary_csv(md.values())); });
+
+}
+
+} // namespace pyarb

--- a/python/pyarb.cpp
+++ b/python/pyarb.cpp
@@ -13,6 +13,7 @@ void register_domain_decomposition(pybind11::module& m);
 void register_event_generators(pybind11::module& m);
 void register_flat_builder(pybind11::module& m);
 void register_identifiers(pybind11::module& m);
+void register_mechanisms(pybind11::module& m);
 void register_morphology(pybind11::module& m);
 void register_profiler(pybind11::module& m);
 void register_recipe(pybind11::module& m);
@@ -38,6 +39,7 @@ PYBIND11_MODULE(_arbor, m) {
     pyarb::register_event_generators(m);
     pyarb::register_flat_builder(m);
     pyarb::register_identifiers(m);
+    pyarb::register_mechanisms(m);
     pyarb::register_morphology(m);
     pyarb::register_profiler(m);
     pyarb::register_recipe(m);

--- a/python/s_expr.cpp
+++ b/python/s_expr.cpp
@@ -38,6 +38,9 @@ std::ostream& operator<<(std::ostream& o, const tok& t) {
 }
 
 std::ostream& operator<<(std::ostream& o, const token& t) {
+    if (t.kind==tok::string) {
+        return o << util::pprintf("\"{}\"", t.spelling);
+    }
     return o << util::pprintf("{}", t.spelling);
 }
 
@@ -111,6 +114,9 @@ private:
                     character();
                     continue;   // skip to next character
 
+                case ';':
+                    eat_comment();
+                    continue;
                 case '(':
                     token_ = {loc_, tok::lparen, {character()}};
                     return;
@@ -152,6 +158,14 @@ private:
         }
         token_ = {loc_, tok::eof, "eof"s};
         return;
+    }
+
+    // Consumes characters in the stream until end of stream or a new line.
+    // Assumes that the current_ location is the `;` that starts the comment.
+    void eat_comment() {
+        while (*current_ && *current_!='\n') {
+            character();
+        }
     }
 
     // Parse alphanumeric sequence that starts with an alphabet character,

--- a/python/s_expr.hpp
+++ b/python/s_expr.hpp
@@ -90,7 +90,7 @@ struct s_expr {
     // with a std::shared_ptr.
 
     using pair_type = s_pair<value_wrapper<s_expr>>;
-    arb::util::either<token, pair_type> state;
+    arb::util::either<token, pair_type> state = token{-1, tok::nil, "nil"};
 
     s_expr(const s_expr& s): state(s.state) {}
     s_expr() = default;

--- a/python/sampling.cpp
+++ b/python/sampling.cpp
@@ -14,7 +14,7 @@ namespace pyarb {
 
 // TODO: trace entry of different types/container (e.g. vector of doubles to get all samples of a cell)
 
-struct trace_entry {
+struct trace_sample {
     arb::time_type t;
     double v;
 };
@@ -22,9 +22,9 @@ struct trace_entry {
 // A helper struct (state) ensuring that only one thread can write to the probe_buffers holding the trace entries (mapped by probe id)
 struct sampler_state {
     std::mutex mutex;
-    std::unordered_map<arb::cell_member_type, std::vector<trace_entry>> probe_buffers;
+    std::unordered_map<arb::cell_member_type, std::vector<trace_sample>> probe_buffers;
 
-    std::vector<trace_entry>& probe_buffer(arb::cell_member_type pid) {
+    std::vector<trace_sample>& probe_buffer(arb::cell_member_type pid) {
         // lock the mutex, s.t. other threads cannot write
         std::lock_guard<std::mutex> lock(mutex);
         // return or create entry
@@ -37,20 +37,20 @@ struct sampler_state {
     }
 
     // helper function to push back to locked vector
-    void push_back(arb::cell_member_type pid, trace_entry value) {
+    void push_back(arb::cell_member_type pid, trace_sample value) {
         auto& v = probe_buffer(pid);
         v.push_back(std::move(value));
     }
 
     // Access the probe buffers
-    const std::unordered_map<arb::cell_member_type, std::vector<trace_entry>>& samples() const {
+    const std::unordered_map<arb::cell_member_type, std::vector<trace_sample>>& samples() const {
         return probe_buffers;
     }
 };
 
 // A functor that models arb::sampler_function.
-// Holds a shared pointer to the trace_entry used to store the samples, so that if
-// the trace_entry in sampler is garbage collected in Python, stores will
+// Holds a shared pointer to the trace_sample used to store the samples, so that if
+// the trace_sample in sampler is garbage collected in Python, stores will
 // not seg fault.
 
 struct sample_callback {
@@ -89,7 +89,7 @@ struct sampler {
         return sample_callback(sample_store);
     }
 
-    const std::vector<trace_entry>& samples(arb::cell_member_type pid) const {
+    const std::vector<trace_sample>& samples(arb::cell_member_type pid) const {
         if (!sample_store->has_pid(pid)) {
             throw std::runtime_error(util::pprintf("probe id {} does not exist", pid));
         }
@@ -117,7 +117,7 @@ std::shared_ptr<sampler> attach_sampler(arb::simulation& sim, arb::time_type int
     return r;
 }
 
-std::string sample_str(const trace_entry& s) {
+std::string sample_str(const trace_sample& s) {
         return util::pprintf("<arbor.sample: time {} ms, \tvalue {}>", s.t, s.v);
 }
 
@@ -125,10 +125,10 @@ void register_sampling(pybind11::module& m) {
     using namespace pybind11::literals;
 
     // Sample
-    pybind11::class_<trace_entry> sample(m, "sample");
-    sample
-        .def_readonly("time", &trace_entry::t, "The sample time [ms] at a specific probe.")
-        .def_readonly("value", &trace_entry::v, "The sample record at a specific probe.")
+    pybind11::class_<trace_sample> trace_sample(m, "trace_sample");
+    trace_sample
+        .def_readonly("time", &trace_sample::t, "The sample time [ms] at a specific probe.")
+        .def_readonly("value", &trace_sample::v, "The sample record at a specific probe.")
         .def("__str__",  &sample_str)
         .def("__repr__", &sample_str);
 

--- a/python/single_cell_model.cpp
+++ b/python/single_cell_model.cpp
@@ -10,6 +10,7 @@
 #include <arbor/simulation.hpp>
 
 #include "error.hpp"
+#include "cells.hpp"
 
 namespace pyarb {
 
@@ -133,7 +134,6 @@ class single_cell_model {
     arb::cable_cell cell_;
     arb::context ctx_;
     bool run_ = false;
-    arb::cable_cell_global_properties gprop_;
 
     std::vector<probe_site> probes_;
     std::unique_ptr<arb::simulation> sim_;
@@ -142,10 +142,15 @@ class single_cell_model {
     std::vector<trace> traces_;
 
 public:
+    // Make gprop public to make it possible to expose it as a field in Python:
+    //      model.properties.catalogue = my_custom_cat
+    //arb::cable_cell_global_properties gprop;
+    global_props_shim gprop;
+
     single_cell_model(arb::cable_cell c):
         cell_(std::move(c)), ctx_(arb::make_context())
     {
-        gprop_.default_parameters = arb::neuron_parameter_defaults;
+        gprop.props.default_parameters = arb::neuron_parameter_defaults;
     }
 
     // example use:
@@ -167,12 +172,8 @@ public:
         }
     }
 
-    void add_ion(const std::string& ion, double valence, double int_con, double ext_con, double rev_pot) {
-        gprop_.add_ion(ion, valence, int_con, ext_con, rev_pot);
-    }
-
     void run(double tfinal, double dt) {
-        single_cell_recipe rec(cell_, probes_, gprop_);
+        single_cell_recipe rec(cell_, probes_, gprop.props);
 
         auto domdec = arb::partition_load_balance(rec, ctx_);
 
@@ -254,20 +255,14 @@ void register_single_cell(pybind11::module& m) {
             " what:      Name of the variable to record (currently only 'voltage').\n"
             " where:     Location on cell morphology at which to sample the variable.\n"
             " frequency: The target frequency at which to sample [Hz].")
-        .def("add_ion", &single_cell_model::add_ion,
-            "ion"_a, "valence"_a, "int_con"_a, "ext_con"_a, "rev_pot"_a,
-            "Add a new ion species to the model.\n"
-            " ion: name of the ion species.\n"
-            " valence: valence of the ion species.\n"
-            " int_con: initial internal concentration [mM].\n"
-            " ext_con: initial external concentration [mM].\n"
-            " rev_pot: reversal potential [mV].")
         .def_property_readonly("spikes",
             [](const single_cell_model& m) {
                 return m.spike_times();}, "Holds spike times [ms] after a call to run().")
         .def_property_readonly("traces",
             [](const single_cell_model& m) {
-                return m.traces();}, "Holds sample traces after a call to run().")
+                return m.traces();},
+            "Holds sample traces after a call to run().")
+        .def_readwrite("properties", &single_cell_model::gprop, "Global properties.")
         .def("__repr__", [](const single_cell_model&){return "<arbor.single_cell_model>";})
         .def("__str__",  [](const single_cell_model&){return "<arbor.single_cell_model>";});
 }

--- a/python/strprintf.hpp
+++ b/python/strprintf.hpp
@@ -13,6 +13,8 @@
 
 #include <arbor/util/optional.hpp>
 
+#include "s_expr.hpp"
+
 namespace pyarb {
 namespace util {
 
@@ -202,13 +204,15 @@ impl::sepval_lim<Seq> csv(const Seq& seq, unsigned n) {
 // Print dictionary: this could be done easily with range adaptors in C++17
 template <typename Key, typename T>
 std::string dictionary_csv(const std::unordered_map<Key, T>& dict) {
-    constexpr bool string_key = std::is_same<std::string, std::decay_t<Key>>::value;
+    constexpr bool string_key   = std::is_same<std::string, std::decay_t<Key>>::value;
+    constexpr bool string_value = std::is_same<std::string, std::decay_t<T>>::value;
+    std::string format = pprintf("{}: {}", string_key? "\"{}\"": "{}", string_value? "\"{}\"": "{}");
     std::string s = "{";
     bool first = true;
     for (auto& p: dict) {
         if (!first) s += ", ";
         first = false;
-        s += pprintf(string_key? "'{}': {}": "{}: {}", p.first, p.second);
+        s += pprintf(format.c_str(), p.first, p.second);
     }
     s += "}";
     return s;
@@ -221,5 +225,4 @@ std::ostream& operator<<(std::ostream& o, const arb::util::optional<T>& x) {
     return o << (x? util::to_string(*x): "None");
 }
 
-} // namespace pyarb
-
+}

--- a/python/strprintf.hpp
+++ b/python/strprintf.hpp
@@ -220,9 +220,13 @@ std::string dictionary_csv(const std::unordered_map<Key, T>& dict) {
 
 } // namespace util
 
-template <typename T>
-std::ostream& operator<<(std::ostream& o, const arb::util::optional<T>& x) {
-    return o << (x? util::to_string(*x): "None");
 }
 
+namespace arb {
+namespace util {
+template <typename T>
+std::ostream& operator<<(std::ostream& o, const arb::util::optional<T>& x) {
+    return o << (x? pyarb::util::to_string(*x): "None");
+}
+}
 }

--- a/python/test/cpp/s_expr.cpp
+++ b/python/test/cpp/s_expr.cpp
@@ -5,6 +5,7 @@
 
 #include <morph_parse.hpp>
 #include <s_expr.hpp>
+#include <strprintf.hpp>
 
 using namespace pyarb;
 using namespace std::string_literals;
@@ -89,4 +90,23 @@ TEST(s_expr, parse) {
     auto rhs = arb::util::any_cast<arb::region>(*eval(parse("(all)")));
 
     EXPECT_EQ(util::pprintf("{}", join(lhs,rhs)), "(join (region \"dend\") (all))");
+}
+
+TEST(s_expr, comments) {
+    auto round_trip_reg = [](const char* in) {
+        auto x = eval(parse(in));
+        return util::pprintf("{}", arb::util::any_cast<arb::region>(*x));
+    };
+
+    EXPECT_EQ("(all)",  round_trip_reg("(all) ; a comment"));
+    const char *multi_line = 
+        "; comment at start\n"
+        "(radius_lt\n"
+        "    (join\n"
+        "        (tag 3) ; end of line\n"
+        " ;comment on whole line\n"
+        "        (tag 4))\n"
+        "    0.5) ; end of string";
+    EXPECT_EQ("(radius_lt (join (tag 3) (tag 4)) 0.5)",
+              round_trip_reg(multi_line));
 }

--- a/python/tutorial/example1.py
+++ b/python/tutorial/example1.py
@@ -12,20 +12,20 @@ cell = arbor.cable_cell(tree, labels)
 cell.set_properties(Vm=-40)
 # Put hh dynamics on soma, and passive properties on the dendrites.
 cell.paint('soma', 'hh')
-# Attach stimuli with duration of 2 ms and current of 0.8 nA.
-cell.place('center', arbor.iclamp( 10, 1, 0.8))
+# Attach stimuli with duration of 1 ms and current of 0.8 nA.
+cell.place('center', arbor.iclamp( 10, duration=1, current=0.8))
 # Add a spike detector with threshold of -10 mV.
 cell.place('center', arbor.spike_detector(-10))
 
 # Make single cell model.
 m = arbor.single_cell_model(cell)
 
-# Attach voltage probes, sampling at 10 kHz.
-m.probe('voltage', 'center',  100000)
+# Attach voltage probes, sampling at 1 MHz.
+m.probe('voltage', 'center',  1000000)
 
-# Run simulation for 100 ms of simulated activity.
+# Run simulation for tfinal ms with time steps of 1 μs.
 tfinal=30
-m.run(tfinal)
+m.run(tfinal, dt=0.001)
 
 # Print spike times.
 if len(m.spikes)>0:

--- a/python/tutorial/example1.py
+++ b/python/tutorial/example1.py
@@ -2,7 +2,7 @@ import arbor
 
 # Create a sample tree with a single sample of radius 3 μm
 tree = arbor.sample_tree()
-tree.append(arbor.msample(x=0, y=0, z=0, radius=3, tag=2))
+tree.append(arbor.sample(x=0, y=0, z=0, radius=3, tag=2))
 
 labels = arbor.label_dict({'soma': '(tag 2)', 'center': '(location 0 0.5)'})
 
@@ -13,7 +13,7 @@ cell.set_properties(Vm=-40)
 # Put hh dynamics on soma, and passive properties on the dendrites.
 cell.paint('soma', 'hh')
 # Attach stimuli with duration of 2 ms and current of 0.8 nA.
-cell.place('center', arbor.iclamp( 10, 2, 0.8))
+cell.place('center', arbor.iclamp( 10, 1, 0.8))
 # Add a spike detector with threshold of -10 mV.
 cell.place('center', arbor.spike_detector(-10))
 
@@ -21,7 +21,7 @@ cell.place('center', arbor.spike_detector(-10))
 m = arbor.single_cell_model(cell)
 
 # Attach voltage probes, sampling at 10 kHz.
-m.probe('voltage', 'center',  10000)
+m.probe('voltage', 'center',  100000)
 
 # Run simulation for 100 ms of simulated activity.
 tfinal=30
@@ -45,7 +45,7 @@ legend_labels = ['{}: {}'.format(s.variable, s.location) for s in m.traces]
 ax.legend(legend_labels)
 ax.set(xlabel='time (ms)', ylabel='voltage (mV)', title='cell builder demo')
 plt.xlim(0,tfinal)
-plt.ylim(-80,50)
+plt.ylim(-80,80)
 ax.grid()
 
 # Set to True to save the image to file instead of opening a plot window.

--- a/test/unit/test_morph_expr.cpp
+++ b/test/unit/test_morph_expr.cpp
@@ -567,7 +567,7 @@ TEST(region, thingify_moderate_morphologies) {
         EXPECT_TRUE(region_eq(mp, radius_le(all(), 2), cl{{0,0,0.55}, {1,0,0.325}, {2,1,1}, {3,0.375,0.75}}));
         EXPECT_TRUE(region_eq(mp, radius_le(all(), 3), cl{{0,0,1}, {1,0,0.55}, {2,6.0/9.0,1}, {3,0.25,1}}));
         EXPECT_TRUE(region_eq(mp, radius_ge(all(), 2), cl{{0,0.55,1}, {1,0.325,1}, {2,0,1}, {3,0,0.375}, {3,0.75,1}}));
-        EXPECT_TRUE(region_eq(mp, radius_ge(all(), 3), cl{{1,0.55,1}, {2,0,6.0/9.0}, {3,0,0.25}}));
+        EXPECT_TRUE(region_eq(mp, radius_ge(all(), 3), cl{{0,1,1}, {1,0.55,1}, {2,0,6.0/9.0}, {3,0,0.25}, {3,1,1}}));
 
         EXPECT_TRUE(region_eq(mp, radius_lt(reg_a_, 2), cl{{0,0.1,0.4},{3,0.375,0.4}}));
         EXPECT_TRUE(region_eq(mp, radius_gt(reg_a_, 2), cl{{2,0,1},{3,0.1,0.375}}));


### PR DESCRIPTION
Add support for mechanism catalogues, global properties, ion species specifications and so on to the Python wrapper.