### PR TITLE
Fix compiler warnings for simd code 

### DIFF
--- a/modcc/functionexpander.cpp
+++ b/modcc/functionexpander.cpp
@@ -12,9 +12,9 @@ expression_ptr insert_unique_local_assignment(expr_list_type& stmts, Expression*
     stmts.push_front(std::move(exprs.assignment));
     stmts.push_front(std::move(exprs.local_decl));
 
-    auto ass =  make_expression<AssignmentExpression>(e->location(), exprs.id->clone(),  e->clone());
-    ass->semantic(e->scope());
-    stmts.push_back(std::move(ass));
+    auto assign =  make_expression<AssignmentExpression>(e->location(), exprs.id->clone(),  e->clone());
+    assign->semantic(e->scope());
+    stmts.push_back(std::move(assign));
 
     return std::move(exprs.id);
 }

--- a/modcc/functionexpander.cpp
+++ b/modcc/functionexpander.cpp
@@ -6,9 +6,15 @@
 #include "functionexpander.hpp"
 
 expression_ptr insert_unique_local_assignment(expr_list_type& stmts, Expression* e) {
-    auto exprs = make_unique_local_assign(e->scope(), e);
+    auto zero = make_expression<NumberExpression>(e->location(), 0.);
+    auto exprs = make_unique_local_assign(e->scope(), zero);
     stmts.push_front(std::move(exprs.local_decl));
     stmts.push_back(std::move(exprs.assignment));
+
+    auto ass =  make_expression<AssignmentExpression>(e->location(), exprs.id->clone(),  e->clone());
+    ass->semantic(e->scope());
+    stmts.push_back(std::move(ass));
+
     return std::move(exprs.id);
 }
 

--- a/modcc/functionexpander.cpp
+++ b/modcc/functionexpander.cpp
@@ -8,8 +8,9 @@
 expression_ptr insert_unique_local_assignment(expr_list_type& stmts, Expression* e) {
     auto zero = make_expression<NumberExpression>(e->location(), 0.);
     auto exprs = make_unique_local_assign(e->scope(), zero);
+
+    stmts.push_front(std::move(exprs.assignment));
     stmts.push_front(std::move(exprs.local_decl));
-    stmts.push_back(std::move(exprs.assignment));
 
     auto ass =  make_expression<AssignmentExpression>(e->location(), exprs.id->clone(),  e->clone());
     ass->semantic(e->scope());

--- a/test/unit-modcc/test_fn_rewriters.cpp
+++ b/test/unit-modcc/test_fn_rewriters.cpp
@@ -132,21 +132,29 @@ TEST(lower_functions, compound_args) {
         {
             "{ a = g(c, a + b)\n }",
             "{ LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = a + b\n"
             "  a = g(c, ll0_)\n }"
         },
         {
             "{ a = f(1, 2, a)\n }",
-            "{ LOCAL ll0_\n ll0_ = f(1, 2, a)\n a = ll0_\n }"
+            "{ LOCAL ll0_\n "
+            "  ll0_ = 0\n"
+            "  ll0_ = f(1, 2, a)\n "
+            "  a = ll0_\n }"
         },
         {
             "{ a = h(b + c)\n"
             "  b = g(a + b, b)\n"
             "  c = f(a, b, c)\n }",
             "{ LOCAL ll3_\n"
+            "  ll3_ = 0\n"
             "  LOCAL ll2_\n"
+            "  ll2_ = 0\n"
             "  LOCAL ll1_\n"
+            "  ll1_ = 0\n"
             "  LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = b + c\n"
             "  a = h(ll0_)\n"
             "  ll1_ = a + b\n"
@@ -178,8 +186,11 @@ TEST(lower_functions, compound_rhs) {
         {
             "{ a = f(b, c) + g(a, a + b)\n }",
             "{ LOCAL ll2_\n"
+            "  ll2_ = 0\n"
             "  LOCAL ll1_\n"
+            "  ll1_ = 0\n"
             "  LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = f(b, c)\n"
             "  ll1_ = a + b\n"
             "  ll2_ = g(a, ll1_)\n"
@@ -188,6 +199,7 @@ TEST(lower_functions, compound_rhs) {
         {
             "{ a = log(exp(h(b)))\n }",
             "{ LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = h(b)\n"
             "  a = log(exp(ll0_))\n }"
         }
@@ -214,7 +226,9 @@ TEST(lower_functions, nested_calls) {
         {
             "{ a = h(g(a, a + b))\n }",
             "{ LOCAL ll1_\n"
+            "  ll1_ = 0\n"
             "  LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = a + b\n"
             "  ll1_ = g(a, ll0_)\n"
             "  a = h(ll1_)\n }"
@@ -222,8 +236,11 @@ TEST(lower_functions, nested_calls) {
         {
             "{ p2(g(a, b), h(h(c)))\n }",
             "{ LOCAL ll2_\n"
+            "  ll2_ = 0\n"
             "  LOCAL ll1_\n"
+            "  ll1_ = 0\n"
             "  LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = g(a, b)\n"
             "  ll1_ = h(c)\n"
             "  ll2_ = h(ll1_)\n"
@@ -269,13 +286,16 @@ TEST(lower_functions, ifexpr) {
         {
             "{ if (f(a, 1, c)) { p1(a)\n }\n }",
             "{ LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = f(a, 1, c)\n"
             "  if (ll0_ != 0) { p1(a)\n }\n }"
         },
         {
             "{ if (h(a + 2) > 1) { p1(a)\n }\n }",
             "{ LOCAL ll1_\n"
+            "  ll1_ = 0\n"
             "  LOCAL ll0_\n"
+            "  ll0_ = 0\n"
             "  ll0_ = a + 2\n"
             "  ll1_ = h(ll0_)\n"
             "  if (ll1_ > 1) { p1(a)\n }\n }"
@@ -377,6 +397,7 @@ TEST(inline_functions, twice_assign) {
 
     const char* after_defn =
         "{ LOCAL ll0_\n"
+        "  ll0_ = 0\n"
         "  ll0_ = a * 2\n"
         "  if (a<2) {\n"
         "      ll0_ = 2\n"

--- a/test/unit-modcc/test_printers.cpp
+++ b/test/unit-modcc/test_printers.cpp
@@ -200,6 +200,10 @@ TEST(CPrinter, proc_body_const) {
 
 TEST(CPrinter, proc_body_inlined) {
     const char* expected =
+        "ll0_ = 0.;\n"
+        "r_6_ = 0.;\n"
+        "r_7_ = 0.;\n"
+        "r_8_ = 0.;\n"
         "r_9_=s2[i_]*0.33333333333333331;\n"
         "r_8_=s1[i_]+2;\n"
         "if(s1[i_]==3){\n"
@@ -207,6 +211,8 @@ TEST(CPrinter, proc_body_inlined) {
         "}\n"
         "else{\n"
         "   if(s1[i_]==4){\n"
+        "       r_11_ = 0.;\n"
+        "       r_12_ = 0.;\n"
         "       r_12_=6+s1[i_];\n"
         "       r_11_=r_12_;\n"
         "       r_7_=r_8_*r_11_;\n"
@@ -216,6 +222,8 @@ TEST(CPrinter, proc_body_inlined) {
         "       r_7_=r_10_*s1[i_];\n"
         "   }\n"
         "}\n"
+        "r_13_=0.;\n"
+        "r_14_=0.;\n"
         "r_14_=r_9_/s2[i_];\n"
         "r_15_=log(r_14_);\n"
         "r_13_=42*r_15_;\n"
@@ -228,6 +236,8 @@ TEST(CPrinter, proc_body_inlined) {
         "}\n"
         "else{\n"
         "   if(ll0_==4){\n"
+        "       r_17_=0.;\n"
+        "       r_18_=0.;\n"
         "       r_18_=6+ll0_;\n"
         "       r_17_=r_18_;\n"
         "       t2=5*r_17_;\n"


### PR DESCRIPTION
initialize variables generated when expanding and inlining functions to zero before first use. 
 
Addresses #1076 