### PR TITLE
Use `simd::assign` in generated simd code 

### DIFF
--- a/arbor/include/arbor/simd/simd.hpp
+++ b/arbor/include/arbor/simd/simd.hpp
@@ -39,13 +39,8 @@ namespace detail {
 using detail::simd_impl;
 using detail::simd_mask_impl;
 
-template <typename Impl, typename V>
-void assign(simd_impl<Impl>& a, const detail::indirect_expression<V>& b) {
-    a.copy_from(b);
-}
-
-template <typename Impl, typename ImplIndex, typename V>
-void assign(simd_impl<Impl>& a, const detail::indirect_indexed_expression<ImplIndex, V>& b) {
+template <typename Impl, typename Other>
+void assign(simd_impl<Impl>& a, const Other& b) {
     a.copy_from(b);
 }
 
@@ -467,6 +462,15 @@ namespace detail {
         void copy_to(indirect_indexed_expression<Index, scalar_type> pi) const {
             using IndexImpl = typename Index::simd_base;
             Impl::scatter(tag<IndexImpl>{}, value_, pi.p, pi.index);
+        }
+
+        template <typename Other, typename = std::enable_if_t<width==simd_traits<Other>::width>>
+        void copy_from(const simd_impl<Other>& x) {
+            value_ = Impl::cast_from(tag<Other>{}, x.value_);
+        }
+
+        void copy_from(const scalar_type p) {
+            value_ = Impl::broadcast(p);
         }
 
         void copy_from(const scalar_type* p) {

--- a/arbor/include/arbor/simd/simd.hpp
+++ b/arbor/include/arbor/simd/simd.hpp
@@ -72,6 +72,30 @@ simd_impl<Impl> name(const simd_impl<Impl>& a, typename simd_impl<Impl>::scalar_
 template <typename Impl>\
 simd_impl<Impl> name(const typename simd_impl<Impl>::scalar_type a, simd_impl<Impl> b) {\
     return simd_impl<Impl>::wrap(Impl::name(Impl::broadcast(a), b.value_));\
+};\
+template <typename Impl>\
+simd_impl<Impl> name(const simd_impl<Impl>& a, typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> b) {\
+    simd_impl<Impl> t;\
+    t.copy_from(b);\
+    return simd_impl<Impl>::wrap(Impl::name(a.value_, t.value_));\
+};\
+template <typename Impl>\
+simd_impl<Impl> name(const typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> a, simd_impl<Impl> b) {\
+    simd_impl<Impl> t;\
+    t.copy_from(a);\
+    return simd_impl<Impl>::wrap(Impl::name(t.value_, b.value_));\
+};\
+template <typename Impl>\
+simd_impl<Impl> name(const typename simd_impl<Impl>::scalar_type& a, typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> b) {\
+    simd_impl<Impl> t;\
+    t.copy_from(b);\
+    return simd_impl<Impl>::wrap(Impl::name(Impl::broadcast(a), t.value_));\
+};\
+template <typename Impl>\
+simd_impl<Impl> name(const typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> a, typename simd_impl<Impl>::scalar_type& b) {\
+    simd_impl<Impl> t;\
+    t.copy_from(a);\
+    return simd_impl<Impl>::wrap(Impl::name(t.value_, Impl::broadcast(b)));\
 };
 
 #define ARB_BINARY_COMPARISON_(name)\
@@ -667,7 +691,16 @@ namespace detail {
         template <typename T>\
         friend simd_impl<T> arb::simd::name(const simd_impl<T>& a, typename simd_impl<T>::scalar_type b);\
         template <typename T>\
-        friend simd_impl<T> arb::simd::name(const typename simd_impl<T>::scalar_type a, simd_impl<T> b);
+        friend simd_impl<T> arb::simd::name(const typename simd_impl<T>::scalar_type a, simd_impl<T> b);\
+        template <typename T>\
+        friend simd_impl<T> arb::simd::name(const simd_impl<T> a, typename detail::indirect_expression<typename simd_impl<T>::scalar_type> b);\
+        template <typename T>\
+        friend simd_impl<T> arb::simd::name(const typename detail::indirect_expression<typename simd_impl<T>::scalar_type> a, simd_impl<T> b);\
+        template <typename T>\
+        friend simd_impl<T> arb::simd::name(const typename simd_impl<T>::scalar_type a, typename detail::indirect_expression<typename simd_impl<T>::scalar_type> b);\
+        template <typename T>\
+        friend simd_impl<T> arb::simd::name(const typename detail::indirect_expression<typename simd_impl<T>::scalar_type> a, typename simd_impl<T>::scalar_type b);
+
 
         #define ARB_DECLARE_BINARY_COMPARISON_(name)\
         template <typename T>\

--- a/arbor/include/arbor/simd/simd.hpp
+++ b/arbor/include/arbor/simd/simd.hpp
@@ -36,51 +36,48 @@ namespace detail {
 }
 
 // Top level functions for second API
-using detail::simd_impl;
-using detail::simd_mask_impl;
-
 template <typename Impl, typename Other>
-void assign(simd_impl<Impl>& a, const Other& b) {
+void assign(detail::simd_impl<Impl>& a, const Other& b) {
     a.copy_from(b);
 }
 
 template <typename Impl>
-typename simd_impl<Impl>::scalar_type sum(const simd_impl<Impl>& a) {
+typename detail::simd_impl<Impl>::scalar_type sum(const detail::simd_impl<Impl>& a) {
     return a.sum();
 };
 
 #define ARB_UNARY_ARITHMETIC_(name)\
 template <typename Impl>\
-simd_impl<Impl> name(const simd_impl<Impl>& a) {\
-    return simd_impl<Impl>::wrap(Impl::name(a.value_));\
+detail::simd_impl<Impl> name(const detail::simd_impl<Impl>& a) {\
+    return detail::simd_impl<Impl>::wrap(Impl::name(a.value_));\
 };
 
 #define ARB_BINARY_ARITHMETIC_(name)\
 template <typename Impl>\
-simd_impl<Impl> name(const simd_impl<Impl>& a, simd_impl<Impl> b) {\
-    return simd_impl<Impl>::wrap(Impl::name(a.value_, b.value_));\
+detail::simd_impl<Impl> name(const detail::simd_impl<Impl>& a, detail::simd_impl<Impl> b) {\
+    return detail::simd_impl<Impl>::wrap(Impl::name(a.value_, b.value_));\
 };\
 template <typename Impl>\
-simd_impl<Impl> name(const simd_impl<Impl>& a, typename simd_impl<Impl>::scalar_type b) {\
-    return simd_impl<Impl>::wrap(Impl::name(a.value_, Impl::broadcast(b)));\
+detail::simd_impl<Impl> name(const detail::simd_impl<Impl>& a, typename detail::simd_impl<Impl>::scalar_type b) {\
+    return detail::simd_impl<Impl>::wrap(Impl::name(a.value_, Impl::broadcast(b)));\
 };\
 template <typename Impl>\
-simd_impl<Impl> name(const typename simd_impl<Impl>::scalar_type a, simd_impl<Impl> b) {\
-    return simd_impl<Impl>::wrap(Impl::name(Impl::broadcast(a), b.value_));\
+detail::simd_impl<Impl> name(const typename detail::simd_impl<Impl>::scalar_type a, detail::simd_impl<Impl> b) {\
+    return detail::simd_impl<Impl>::wrap(Impl::name(Impl::broadcast(a), b.value_));\
 };
 
 #define ARB_BINARY_COMPARISON_(name)\
 template <typename Impl>\
-typename simd_impl<Impl>::simd_mask name(const simd_impl<Impl>& a, simd_impl<Impl> b) {\
-    return simd_impl<Impl>::mask(Impl::name(a.value_, b.value_));\
+typename detail::simd_impl<Impl>::simd_mask name(const detail::simd_impl<Impl>& a, detail::simd_impl<Impl> b) {\
+    return detail::simd_impl<Impl>::mask(Impl::name(a.value_, b.value_));\
 };\
 template <typename Impl>\
-typename simd_impl<Impl>::simd_mask name(const simd_impl<Impl>& a, typename simd_impl<Impl>::scalar_type b) {\
-    return simd_impl<Impl>::mask(Impl::name(a.value_, Impl::broadcast(b)));\
+typename detail::simd_impl<Impl>::simd_mask name(const detail::simd_impl<Impl>& a, typename detail::simd_impl<Impl>::scalar_type b) {\
+    return detail::simd_impl<Impl>::mask(Impl::name(a.value_, Impl::broadcast(b)));\
 };\
 template <typename Impl>\
-typename simd_impl<Impl>::simd_mask name(const typename simd_impl<Impl>::scalar_type a, simd_impl<Impl> b) {\
-    return simd_impl<Impl>::mask(Impl::name(Impl::broadcast(a), b.value_));\
+typename detail::simd_impl<Impl>::simd_mask name(const typename detail::simd_impl<Impl>::scalar_type a, detail::simd_impl<Impl> b) {\
+    return detail::simd_impl<Impl>::mask(Impl::name(Impl::broadcast(a), b.value_));\
 };
 
 ARB_PP_FOREACH(ARB_BINARY_ARITHMETIC_, add, sub, mul, div, pow, max, min)
@@ -92,23 +89,23 @@ ARB_PP_FOREACH(ARB_UNARY_ARITHMETIC_,  neg, abs, sin, cos, exp, log, expm1, expr
 #undef ARB_UNARY_ARITHMETIC_
 
 template <typename T>
-simd_mask_impl<T> logical_and(const simd_mask_impl<T>& a, simd_mask_impl<T> b) {
+detail::simd_mask_impl<T> logical_and(const detail::simd_mask_impl<T>& a, detail::simd_mask_impl<T> b) {
     return a && b;
 }
 
 template <typename T>
-simd_mask_impl<T> logical_or(const simd_mask_impl<T>& a, simd_mask_impl<T> b) {
+detail::simd_mask_impl<T> logical_or(const detail::simd_mask_impl<T>& a, detail::simd_mask_impl<T> b) {
     return a || b;
 }
 
 template <typename T>
-simd_mask_impl<T> logical_not(const simd_mask_impl<T>& a) {
+detail::simd_mask_impl<T> logical_not(const detail::simd_mask_impl<T>& a) {
     return !a;
 }
 
 template <typename T>
-simd_impl<T> fma(const simd_impl<T> a, simd_impl<T> b, simd_impl<T> c) {
-    return simd_impl<T>::wrap(T::fma(a.value_, b.value_, c.value_));
+detail::simd_impl<T> fma(const detail::simd_impl<T> a, detail::simd_impl<T> b, detail::simd_impl<T> c) {
+    return detail::simd_impl<T>::wrap(T::fma(a.value_, b.value_, c.value_));
 }
 
 namespace detail {

--- a/arbor/include/arbor/simd/simd.hpp
+++ b/arbor/include/arbor/simd/simd.hpp
@@ -72,30 +72,6 @@ simd_impl<Impl> name(const simd_impl<Impl>& a, typename simd_impl<Impl>::scalar_
 template <typename Impl>\
 simd_impl<Impl> name(const typename simd_impl<Impl>::scalar_type a, simd_impl<Impl> b) {\
     return simd_impl<Impl>::wrap(Impl::name(Impl::broadcast(a), b.value_));\
-};\
-template <typename Impl>\
-simd_impl<Impl> name(const simd_impl<Impl>& a, typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> b) {\
-    simd_impl<Impl> t;\
-    t.copy_from(b);\
-    return simd_impl<Impl>::wrap(Impl::name(a.value_, t.value_));\
-};\
-template <typename Impl>\
-simd_impl<Impl> name(const typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> a, simd_impl<Impl> b) {\
-    simd_impl<Impl> t;\
-    t.copy_from(a);\
-    return simd_impl<Impl>::wrap(Impl::name(t.value_, b.value_));\
-};\
-template <typename Impl>\
-simd_impl<Impl> name(const typename simd_impl<Impl>::scalar_type& a, typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> b) {\
-    simd_impl<Impl> t;\
-    t.copy_from(b);\
-    return simd_impl<Impl>::wrap(Impl::name(Impl::broadcast(a), t.value_));\
-};\
-template <typename Impl>\
-simd_impl<Impl> name(const typename detail::indirect_expression<typename simd_impl<Impl>::scalar_type> a, typename simd_impl<Impl>::scalar_type& b) {\
-    simd_impl<Impl> t;\
-    t.copy_from(a);\
-    return simd_impl<Impl>::wrap(Impl::name(t.value_, Impl::broadcast(b)));\
 };
 
 #define ARB_BINARY_COMPARISON_(name)\
@@ -691,16 +667,7 @@ namespace detail {
         template <typename T>\
         friend simd_impl<T> arb::simd::name(const simd_impl<T>& a, typename simd_impl<T>::scalar_type b);\
         template <typename T>\
-        friend simd_impl<T> arb::simd::name(const typename simd_impl<T>::scalar_type a, simd_impl<T> b);\
-        template <typename T>\
-        friend simd_impl<T> arb::simd::name(const simd_impl<T> a, typename detail::indirect_expression<typename simd_impl<T>::scalar_type> b);\
-        template <typename T>\
-        friend simd_impl<T> arb::simd::name(const typename detail::indirect_expression<typename simd_impl<T>::scalar_type> a, simd_impl<T> b);\
-        template <typename T>\
-        friend simd_impl<T> arb::simd::name(const typename simd_impl<T>::scalar_type a, typename detail::indirect_expression<typename simd_impl<T>::scalar_type> b);\
-        template <typename T>\
-        friend simd_impl<T> arb::simd::name(const typename detail::indirect_expression<typename simd_impl<T>::scalar_type> a, typename simd_impl<T>::scalar_type b);
-
+        friend simd_impl<T> arb::simd::name(const typename simd_impl<T>::scalar_type a, simd_impl<T> b);
 
         #define ARB_DECLARE_BINARY_COMPARISON_(name)\
         template <typename T>\

--- a/arbor/include/arbor/simd/sve.hpp
+++ b/arbor/include/arbor/simd/sve.hpp
@@ -827,6 +827,10 @@ class const_where_expression;
 
 template <typename To>
 struct simd_cast_impl {
+    static To cast(const To& a) {
+        return a;
+    }
+
     template <typename V>
     static To cast(const V& a) {
         return detail::sve_type_to_impl<To>::type::broadcast(a);
@@ -887,13 +891,8 @@ struct simd_cast_impl {
     }
 };
 
-template <typename T, typename V>
-void assign(T& a, const detail::indirect_expression<V>& b) {
-    a = detail::simd_cast_impl<T>::cast(b);
-}
-
-template <typename T, typename I, typename V>
-void assign(T& a, const detail::indirect_indexed_expression<I, V>& b) {
+template <typename T, typename Other>
+void assign(T& a, const Other& b) {
     a = detail::simd_cast_impl<T>::cast(b);
 }
 

--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -620,14 +620,14 @@ void SimdPrinter::visit(AssignmentExpression* e) {
             if (auto sym = rhs->symbol()) {
                 if (sym->is_variable() && sym->is_variable()->is_range()) {
                     out_ << "assign(" << lhs->name() << ", indirect(" << rhs->name() << ", simd_width_))";
+                    return;
                 }
             }
-        } else {
-            out_ << lhs->name() << " = ";
-            if (cast) out_ << "simd_cast<simd_value>(";
-            e->rhs()->accept(this);
-            if (cast) out_ << ")";
         }
+        out_ << lhs->name() << " = ";
+        if (cast) out_ << "simd_cast<simd_value>(";
+        e->rhs()->accept(this);
+        if (cast) out_ << ")";
     }
 }
 

--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -576,9 +576,9 @@ void SimdPrinter::visit(LocalVariable* sym) {
 void SimdPrinter::visit(VariableExpression *sym) {
     if (sym->is_range()) {
         if(is_indirect_)
-            out_ << "simd_cast<simd_value>(indirect(" << sym->name() << "+index_, simd_width_))";
+            out_ << "indirect(" << sym->name() << "+index_, simd_width_)";
         else
-            out_ << "simd_cast<simd_value>(indirect(" << sym->name() << "+i_, simd_width_))";
+            out_ << "indirect(" << sym->name() << "+i_, simd_width_)";
     }
     else {
         out_ << sym->name();
@@ -595,8 +595,14 @@ void SimdPrinter::visit(AssignmentExpression* e) {
     bool cast = false;
     if (auto id = e->rhs()->is_identifier()) {
         if (scalars_.count(id->name())) cast = true;
+        if (auto sym = id->symbol()) {
+            if (sym->is_variable() && sym->is_variable()->is_range()) {
+                cast = true;
+            }
+        }
     }
     if (e->rhs()->is_number()) cast = true;
+
     if (scalars_.count(e->lhs()->is_identifier()->name()))  cast = false;
 
     if (lhs->is_variable() && lhs->is_variable()->is_range()) {


### PR DESCRIPTION
Use `simd::assign` to reduce verbosity of simd variable assignments from memory.

Addresses #1077 