### PR TITLE
Fix issues found in device_coordinator.hpp.

### DIFF
--- a/arbor/memory/device_coordinator.hpp
+++ b/arbor/memory/device_coordinator.hpp
@@ -81,7 +81,14 @@ public:
     }
 
     device_reference& operator=(const device_reference& ref) {
-        gpu_memcpy_d2d(pointer_, ref.pointer_, sizeof(T));
+        if (this != &ref) {
+            gpu_memcpy_d2d(pointer_, ref.pointer_, sizeof(T));
+        }
+        return *this;
+    }
+        
+    device_reference(const device_reference& ref) {
+        *this = ref;
     }
 
     operator T() const {
@@ -115,9 +122,10 @@ public:
     using rebind = device_coordinator<Tother, Allocator>;
 
     view_type allocate(size_type n) {
-        Allocator allocator;
-
-        pointer ptr = n>0 ? allocator.allocate(n) : nullptr;
+        pointer ptr = nullptr;
+        if (n > 0) {
+            ptr = Allocator{}.allocate(n);
+        }
 
         #ifdef VERBOSE
         std::cerr << util::type_printer<device_coordinator>::print()

--- a/arbor/memory/device_coordinator.hpp
+++ b/arbor/memory/device_coordinator.hpp
@@ -80,16 +80,18 @@ public:
         return *this;
     }
 
+    // Assigning to a reference will copy the referenced memory
     device_reference& operator=(const device_reference& ref) {
         if (this != &ref) {
             gpu_memcpy_d2d(pointer_, ref.pointer_, sizeof(T));
         }
         return *this;
     }
-        
-    device_reference(const device_reference& ref) {
-        *this = ref;
-    }
+
+    // No empty references
+    device_reference() = delete;
+    // Copying a reference is a shallow copy
+    device_reference(const device_reference& ref) = default;
 
     operator T() const {
         T tmp;
@@ -122,10 +124,9 @@ public:
     using rebind = device_coordinator<Tother, Allocator>;
 
     view_type allocate(size_type n) {
-        pointer ptr = nullptr;
-        if (n > 0) {
-            ptr = Allocator{}.allocate(n);
-        }
+        Allocator allocator;
+
+        pointer ptr = n>0 ? allocator.allocate(n) : nullptr;
 
         #ifdef VERBOSE
         std::cerr << util::type_printer<device_coordinator>::print()


### PR DESCRIPTION
Issue found by static analyser, see #1084.

Device reference: 
- has assignment, but no copy constructor. 
- assignment not protected against self assign. 
- assignment does not return self.

Device coordinator: 
- Ternary constructs temporary.