### PR TITLE
Fix circumvention of virtual dispatch in constructor.

### DIFF
--- a/arbor/benchmark_cell_group.cpp
+++ b/arbor/benchmark_cell_group.cpp
@@ -22,17 +22,21 @@ benchmark_cell_group::benchmark_cell_group(const std::vector<cell_gid_type>& gid
         cells_.push_back(util::any_cast<benchmark_cell>(rec.get_cell_description(gid)));
     }
 
-    reset();
+    reset_();
 }
 
-void benchmark_cell_group::reset() {
+void benchmark_cell_group::reset_(){
     t_ = 0;
 
     for (auto& c: cells_) {
         c.time_sequence.reset();
     }
 
-    clear_spikes();
+    spikes_.clear();
+}
+
+void benchmark_cell_group::reset() {
+        reset_();
 }
 
 cell_kind benchmark_cell_group::get_cell_kind() const {

--- a/arbor/benchmark_cell_group.hpp
+++ b/arbor/benchmark_cell_group.hpp
@@ -34,6 +34,8 @@ public:
     void remove_all_samplers() override {}
 
 private:
+    void reset_();
+
     time_type t_;
 
     std::vector<benchmark_cell> cells_;


### PR DESCRIPTION
Fix a potential issue when extending the class hierachy. There is no virtual dispatch in constructors, so 
the constructor might end up calling the wrong `reset_`