### PR TITLE
Support Allen/SONATA-style single sample somata in SWC.

### DIFF
--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -65,13 +65,11 @@ arb::segment_tree load_swc_allen(const std::string& fname, bool no_gaps=false) {
 
             // Model the spherical soma as a cylinder with length=2*radius.
             // The cylinder is centred on the origin, and extended along the z axis.
-            tree.append(mnpos, {0, 0, -sloc.radius, sloc.radius}, {0, 0, sloc.radius, sloc.radius}, 1);
-
-            std::unordered_map<msize_t, msize_t> pmap;
-
             double soma_rad = sloc.radius;
+            tree.append(mnpos, {0, 0, -soma_rad, soma_rad}, {0, 0, soma_rad, soma_rad}, 1);
 
             // Build branches off soma.
+            std::unordered_map<msize_t, msize_t> pmap;
             for (unsigned i=1; i<nrec; ++i) {
                 const auto& r = records[i];
                 // If sample i has the root as its parent don't create a segment.
@@ -79,7 +77,7 @@ arb::segment_tree load_swc_allen(const std::string& fname, bool no_gaps=false) {
                     if (no_gaps) {
                         // Assert that this branch starts on the "surface" of the spherical soma.
                         auto d = std::fabs(soma_rad - std::sqrt(r.x*r.x + r.y*r.y + r.z*r.z));
-                        if (d<1e-6) {
+                        if (d>1e-3) { // 1 nm tolerance
                             throw pyarb_error("No gaps are allowed between the soma and any axons, dendrites or apical dendrites");
                         }
                     }


### PR DESCRIPTION
Add an `load_swc_allen(str fname, bool no_gaps=False)` function to the python wrapper that
generates a segment tree from an SWC file following the rules prescribed by                                                                                                                            
AllenDB and Sonata. Specifically:

 * The first sample (the root) is treated as the center of the soma.
 * The first morphology is translated such that the soma is centered at (0,0,0).
 * The first sample has tag 1 (soma).
 * All other samples have tags 2, 3 or 4 (axon, apic and dend respectively)

SONATA prescribes that there should be no gaps, however the models in AllenDB
have gaps between the start of sections and the soma. The flag `no_gaps` can be
used to enforce this requirement.

Arbor does not support modeling the soma as a sphere, so a cylinder with length
equal to the soma diameter is used. The cylinder is centered on the origin, and
aligned along the z axis.
Axons and apical dendrites are attached to the proximal end of the cylinder, and
dendrites to the distal end, with a gap between the start of each branch and the
end of the soma cylinder to which it is attached.