### PR TITLE
Fix python examples

### DIFF
--- a/python/example/single_cell_swc.py
+++ b/python/example/single_cell_swc.py
@@ -50,7 +50,7 @@ cell.place('stim_site', arbor.iclamp(8, 1, current=1))
 cell.place('root', arbor.spike_detector(-10))
 
 # Have one compartment between each sample point.
-cell.compartments_on_samples()
+cell.compartments_on_segments()
 
 # Make single cell model.
 m = arbor.single_cell_model(cell)

--- a/python/flat_cell_builder.cpp
+++ b/python/flat_cell_builder.cpp
@@ -78,9 +78,8 @@ public:
         double dr = (r2-r1)/ncomp;
         for (auto i=0; i<ncomp; ++i) {
             p = tree_.append(p, {0,0,z+i*dz, r1+i*dr}, {0,0,z+(i+1)*dz, r1+(i+1)*dr}, tag);
+            cable_distal_segs_.push_back(p);
         }
-
-        cable_distal_segs_.push_back(p);
 
         return size()-1;
     }

--- a/python/flat_cell_builder.cpp
+++ b/python/flat_cell_builder.cpp
@@ -78,10 +78,11 @@ public:
         double dr = (r2-r1)/ncomp;
         for (auto i=0; i<ncomp; ++i) {
             p = tree_.append(p, {0,0,z+i*dz, r1+i*dr}, {0,0,z+(i+1)*dz, r1+(i+1)*dr}, tag);
-            cable_distal_segs_.push_back(p);
         }
 
-        return size()-1;
+        cable_distal_segs_.push_back(p);
+
+        return cable_distal_segs_.size()-1;
     }
 
     void add_label(const char* name, const char* description) {


### PR DESCRIPTION
Fixes typo in `single_cell_swc.py` 
Fixes bug in `flat_cell_builder.cpp` that was causing a segmentation fault in `single_cell_builder.py`. The bug is caused by returning the compartment index instead of the cable index in the `add_cable` function.