### PR TITLE
Set the status on the commit from the PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,14 @@ build codecov:
     DEPLOY_DOCKERFILE: ci/codecov/deploy.Dockerfile
     DEPLOY_IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
 
+notify_github_start:
+  stage: build
+  allow_failure: true
+  only: ['master', 'staging', 'trying']
+  tags: ['kubernetes']
+  image: stabbles/git-curl
+  script: ./ci/set_github_status.sh pending
+
 
 # Some variables used for running on daint
 variables:
@@ -159,3 +167,19 @@ deallocate codecov:
   extends: .daint_dealloc
   variables:
     ALLOCATION_NAME: arbor-ci-codecov-$CI_PIPELINE_ID
+
+notify_github_success:
+  stage: cleanup
+  when: on_success
+  only: ['master', 'staging', 'trying']
+  tags: ['kubernetes']
+  image: stabbles/git-curl
+  script: ./ci/set_github_status.sh success
+
+notify_github_failure:
+  stage: cleanup
+  when: on_failure
+  only: ['master', 'staging', 'trying']
+  tags: ['kubernetes']
+  image: stabbles/git-curl
+  script: ./ci/set_github_status.sh failure

--- a/ci/set_github_status.sh
+++ b/ci/set_github_status.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+function submit() {
+    local commit_status=${1}
+    local commit_sha=${2}
+
+    curl --verbose \
+        --url "https://api.github.com/repos/arbor-sim/arbor/statuses/${commit_sha}" \
+        --header 'Content-Type: application/json' \
+        --header "authorization: Bearer ${GITHUB_TOKEN}" \
+        --data "{ \"state\": \"${commit_status}\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"All Gitlab pipelines\", \"context\": \"ci/gitlab/full-pipeline\" }"
+}
+
+commit_status=${1}
+
+# always submit for the current commit
+submit "${commit_status}" "$CI_COMMIT_SHA"
+
+# For Bors: get the latest commit before the merge to set the status.
+if [[ $CI_COMMIT_REF_NAME =~ ^(trying|staging)$ ]]; then
+    parent_sha=`git rev-parse --verify -q "$CI_COMMIT_SHA"^2`
+    if [[ $? -eq 0 ]]; then
+        submit "${commit_status}" "${parent_sha}"
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
This is copied from DLA Future. It should set the CI status on the commit from the PR instead of just on the Bors commit. This way the gitlab CI status also appears in the checks section below the PR.