### PR TITLE
Retrieve probe metadata from simulator object.

### DIFF
--- a/arbor/cell_group.hpp
+++ b/arbor/cell_group.hpp
@@ -37,6 +37,13 @@ public:
     virtual void add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function, sampling_policy) = 0;
     virtual void remove_sampler(sampler_association_handle) = 0;
     virtual void remove_all_samplers() = 0;
+
+    // Probe metadata queries might also be called while a simulation is running, and so should
+    // also be thread-safe.
+
+    virtual std::vector<probe_metadata> get_probe_metadata(cell_member_type) const {
+        return {};
+    }
 };
 
 using cell_group_ptr = std::unique_ptr<cell_group>;

--- a/arbor/include/arbor/morph/locset.hpp
+++ b/arbor/include/arbor/morph/locset.hpp
@@ -159,6 +159,11 @@ locset uniform(region reg, unsigned left, unsigned right, uint64_t seed);
 // Proportional location on every branch.
 locset on_branches(double pos);
 
+// Proportional locations on each component:
+// For each component C of the region, find locations L
+// s.t. dist(h, L) = r * max {dist(h, t) | t is a distal point in C}.
+locset on_components(double relpos, region reg);
+
 // Support of a locset (x s.t. x in locset).
 locset support(locset);
 

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -133,10 +133,10 @@ region branch(msize_t);
 // Region with all segments with segment tag id.
 region tagged(int id);
 
-// Region with all segments distal from another region
+// Region up to `distance` distal from points in `start`.
 region distal_interval(locset start, double distance);
 
-// Region with all segments proximal from another region
+// Region up to `distance` proximal from points in `start`.
 region proximal_interval(locset end, double distance);
 
 // Region with all segments with radius less than/less than or equal to r

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -39,6 +39,10 @@ public:
 
     void remove_all_samplers();
 
+    // Return probe metadata, one entry per probe associated with supplied probe id,
+    // or an empty vector if no local match for probe id.
+    std::vector<probe_metadata> get_probe_metadata(cell_member_type probe_id) const;
+
     std::size_t num_spikes() const;
 
     // Set event binning policy on all our groups.

--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -62,8 +62,8 @@ void mc_cell_group::reset() {
     spikes_.clear();
 
     sample_events_.clear();
-    for (auto &assoc: sampler_map_) {
-        assoc.sched.reset();
+    for (auto &entry: sampler_map_) {
+        entry.second.sched.reset();
     }
 
     for (auto& b: binners_) {
@@ -133,10 +133,7 @@ void run_samples(
        sample_records.push_back(sample_record{time_type(raw_times[i]), &raw_samples[i]});
     }
 
-    // Metadata may be an mlocation or cell_lid_type (for point mechanism state probes).
-    util::visit(
-        [&](auto& metadata) { sc.sampler({sc.probe_id, sc.tag, sc.index, &metadata}, n_sample, sample_records.data()); },
-        p.metadata);
+    sc.sampler({sc.probe_id, sc.tag, sc.index, p.get_metadata_ptr()}, n_sample, sample_records.data());
 }
 
 void run_samples(
@@ -166,7 +163,7 @@ void run_samples(
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &ctmp[j]});
     }
 
-    sc.sampler({sc.probe_id, sc.tag, sc.index, &p.metadata}, n_sample, sample_records.data());
+    sc.sampler({sc.probe_id, sc.tag, sc.index, p.get_metadata_ptr()}, n_sample, sample_records.data());
 }
 
 void run_samples(
@@ -196,10 +193,7 @@ void run_samples(
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }
 
-    // Metadata may be an mlocation_list or mcable_list.
-    util::visit(
-        [&](auto& metadata) { sc.sampler({sc.probe_id, sc.tag, sc.index, &metadata}, n_sample, sample_records.data()); },
-        p.metadata);
+    sc.sampler({sc.probe_id, sc.tag, sc.index, p.get_metadata_ptr()}, n_sample, sample_records.data());
 }
 
 void run_samples(
@@ -242,8 +236,7 @@ void run_samples(
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }
 
-    // (Unlike fvm_probe_multi, we only have mcable_list metadata.)
-    sc.sampler({sc.probe_id, sc.tag, sc.index, &p.metadata}, n_sample, sample_records.data());
+    sc.sampler({sc.probe_id, sc.tag, sc.index, p.get_metadata_ptr()}, n_sample, sample_records.data());
 }
 
 void run_samples(
@@ -305,7 +298,7 @@ void run_samples(
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }
 
-    sc.sampler({sc.probe_id, sc.tag, sc.index, &p.metadata}, n_sample, sample_records.data());
+    sc.sampler({sc.probe_id, sc.tag, sc.index, p.get_metadata_ptr()}, n_sample, sample_records.data());
 }
 
 // Generic run_samples dispatches on probe info variant type.
@@ -391,37 +384,44 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
 
     std::vector<deliverable_event> exact_sampling_events;
 
-    for (auto& sa: sampler_map_) {
-        auto sample_times = util::make_range(sa.sched.events(tstart, ep.tfinal));
-        if (sample_times.empty()) {
-            continue;
-        }
+    {
+        std::lock_guard<std::mutex> guard(sampler_mex_);
 
-        sample_size_type n_times = sample_times.size();
-        max_samples_per_call = std::max(max_samples_per_call, n_times);
+        for (auto& sm_entry: sampler_map_) {
+            // Ignore sampler_association_handle, just need the association itself.
+            sampler_association& sa = sm_entry.second;
 
-        for (cell_member_type pid: sa.probe_ids) {
-            auto cell_index = gid_index_map_.at(pid.gid);
+            auto sample_times = util::make_range(sa.sched.events(tstart, ep.tfinal));
+            if (sample_times.empty()) {
+                continue;
+            }
 
-            probe_tag tag = probe_map_.tag.at(pid);
-            unsigned index = 0;
-            for (const fvm_probe_data& pdata: probe_map_.data_on(pid)) {
-                call_info.push_back({sa.sampler, pid, tag, index++, &pdata, n_samples, n_samples + n_times*pdata.n_raw()});
-                auto intdom = cell_to_intdom_[cell_index];
+            sample_size_type n_times = sample_times.size();
+            max_samples_per_call = std::max(max_samples_per_call, n_times);
 
-                for (auto t: sample_times) {
-                    for (probe_handle h: pdata.raw_handle_range()) {
-                        sample_event ev{t, (cell_gid_type)intdom, {h, n_samples++}};
-                        sample_events.push_back(ev);
-                    }
-                    if (sa.policy==sampling_policy::exact) {
-                        target_handle h(-1, 0, intdom);
-                        exact_sampling_events.push_back({t, h, 0.f});
+            for (cell_member_type pid: sa.probe_ids) {
+                auto cell_index = gid_index_map_.at(pid.gid);
+
+                probe_tag tag = probe_map_.tag.at(pid);
+                unsigned index = 0;
+                for (const fvm_probe_data& pdata: probe_map_.data_on(pid)) {
+                    call_info.push_back({sa.sampler, pid, tag, index++, &pdata, n_samples, n_samples + n_times*pdata.n_raw()});
+                    auto intdom = cell_to_intdom_[cell_index];
+
+                    for (auto t: sample_times) {
+                        for (probe_handle h: pdata.raw_handle_range()) {
+                            sample_event ev{t, (cell_gid_type)intdom, {h, n_samples++}};
+                            sample_events.push_back(ev);
+                        }
+                        if (sa.policy==sampling_policy::exact) {
+                            target_handle h(-1, 0, intdom);
+                            exact_sampling_events.push_back({t, h, 0.f});
+                        }
                     }
                 }
             }
+            arb_assert(n_samples==call_info.back().end_offset);
         }
-        arb_assert(n_samples==call_info.back().end_offset);
     }
 
     // Sort exact sampling events into staged events for delivery.
@@ -481,20 +481,45 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
 void mc_cell_group::add_sampler(sampler_association_handle h, cell_member_predicate probe_ids,
                                 schedule sched, sampler_function fn, sampling_policy policy)
 {
+    std::lock_guard<std::mutex> guard(sampler_mex_);
+
     std::vector<cell_member_type> probeset =
         util::assign_from(util::filter(util::keys(probe_map_.tag), probe_ids));
 
     if (!probeset.empty()) {
-        sampler_map_.add(h, sampler_association{std::move(sched), std::move(fn), std::move(probeset), policy});
+        auto result = sampler_map_.insert({h, sampler_association{std::move(sched), std::move(fn), std::move(probeset), policy}});
+        arb_assert(result.second);
     }
 }
 
 void mc_cell_group::remove_sampler(sampler_association_handle h) {
-    sampler_map_.remove(h);
+    std::lock_guard<std::mutex> guard(sampler_mex_);
+    sampler_map_.erase(h);
 }
 
 void mc_cell_group::remove_all_samplers() {
+    std::lock_guard<std::mutex> guard(sampler_mex_);
     sampler_map_.clear();
+}
+
+std::vector<probe_metadata> mc_cell_group::get_probe_metadata(cell_member_type probe_id) const {
+    // Probe associations are fixed after construction, so we do not need to grab the mutex.
+
+    util::optional<probe_tag> maybe_tag = util::value_by_key(probe_map_.tag, probe_id);
+    if (!maybe_tag) {
+        return {};
+    }
+
+    auto data = probe_map_.data_on(probe_id);
+
+    std::vector<probe_metadata> result;
+    result.reserve(data.size());
+    unsigned index = 0;
+    for (const fvm_probe_data& item: data) {
+        result.push_back(probe_metadata{probe_id, *maybe_tag, index++, item.get_metadata_ptr()});
+    }
+
+    return result;
 }
 
 } // namespace arb

--- a/arbor/mc_cell_group.hpp
+++ b/arbor/mc_cell_group.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -57,6 +58,8 @@ public:
 
     void remove_all_samplers() override;
 
+    std::vector<probe_metadata> get_probe_metadata(cell_member_type probe_id) const override;
+
 private:
     // List of the gids of the cells in the group.
     std::vector<cell_gid_type> gids_;
@@ -93,6 +96,9 @@ private:
 
     // Collection of samplers to be run against probes in this group.
     sampler_association_map sampler_map_;
+
+    // Mutex for thread-safe access to sampler associations.
+    std::mutex sampler_mex_;
 
     // Lookup table for target ids -> local target handle indices.
     std::vector<std::size_t> target_handle_divisions_;

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -358,6 +358,7 @@ mlocation_list thingify_(const on_components_& n, const mprovider& p) {
 
                 if (d>diameter) {
                     most_distal = {x};
+                    diameter = d;
                 }
                 else if (d==diameter) {
                     most_distal.push_back(x);

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -260,14 +260,13 @@ mlocation_list thingify_(const boundary_& n, const mprovider& p) {
     mlocation_list L;
 
     for (const mextent& comp: comps) {
-        mlocation_list proximal_set, distal_set;
+        arb_assert(!comp.empty());
+        arb_assert(thingify_(most_proximal_{region{comp}}, p).size()==1u);
 
-        for (const mcable& c: comp) {
-            proximal_set.push_back({c.branch, c.prox_pos});
-            distal_set.push_back({c.branch, c.dist_pos});
-        }
+        mlocation_list distal_set;
+        util::assign(distal_set, util::transform_view(comp, [](auto c) { return dist_loc(c); }));
 
-        L = sum(L, minset(p.morphology(), proximal_set));
+        L = sum(L, {prox_loc(comp.front())});
         L = sum(L, maxset(p.morphology(), distal_set));
     }
     return support(std::move(L));
@@ -297,13 +296,16 @@ mlocation_list thingify_(const cboundary_& n, const mprovider& p) {
     mlocation_list L;
 
     for (const mextent& comp: comps) {
-        mlocation_list proximal_set, distal_set;
-
         mextent ccomp = thingify(reg::complete(comp), p);
-        for (const mcable& c: ccomp.cables()) {
-            proximal_set.push_back({c.branch, c.prox_pos});
-            distal_set.push_back({c.branch, c.dist_pos});
-        }
+
+        // Note: if component contains the head of a top-level cable,
+        // the completion might not be connected (!).
+
+        mlocation_list proximal_set;
+        util::assign(proximal_set, util::transform_view(ccomp, [](auto c) { return prox_loc(c); }));
+
+        mlocation_list distal_set;
+        util::assign(distal_set, util::transform_view(ccomp, [](auto c) { return dist_loc(c); }));
 
         L = sum(L, minset(p.morphology(), proximal_set));
         L = sum(L, maxset(p.morphology(), distal_set));
@@ -313,6 +315,82 @@ mlocation_list thingify_(const cboundary_& n, const mprovider& p) {
 
 std::ostream& operator<<(std::ostream& o, const cboundary_& x) {
     return o << "(cboundary " << x.reg << ")";
+}
+
+// Proportional on components of a region.
+
+struct on_components_: locset_tag {
+    explicit on_components_(double relpos, region reg):
+        relpos(relpos), reg(std::move(reg)) {}
+    double relpos;
+    region reg;
+};
+
+locset on_components(double relpos, region reg) {
+    return locset(on_components_(relpos, std::move(reg)));
+}
+
+mlocation_list thingify_(const on_components_& n, const mprovider& p) {
+    if (n.relpos<0 || n.relpos>1) {
+        return {};
+    }
+
+    std::vector<mextent> comps = components(p.morphology(), thingify(n.reg, p));
+    std::vector<mlocation> L;
+
+    for (const mextent& comp: comps) {
+        arb_assert(!comp.empty());
+        arb_assert(thingify_(most_proximal_{region{comp}}, p).size()==1u);
+
+        mlocation prox = prox_loc(comp.front());
+        auto d_from_prox = [&](mlocation x) { return p.embedding().integrate_length(prox, x); };
+
+        if (n.relpos==0) {
+            L.push_back(prox);
+        }
+        else if (n.relpos==1) {
+            double diameter = 0;
+            mlocation_list most_distal = {prox};
+
+            for (mcable c: comp) {
+                mlocation x = dist_loc(c);
+                double d = d_from_prox(x);
+
+                if (d>diameter) {
+                    most_distal = {x};
+                }
+                else if (d==diameter) {
+                    most_distal.push_back(x);
+                }
+            }
+
+            util::append(L, most_distal);
+        }
+        else {
+            double diameter = util::max_value(util::transform_view(comp,
+                [&](auto c) { return d_from_prox(dist_loc(c)); }));
+
+            double d = n.relpos*diameter;
+            for (mcable c: comp) {
+                double d0 = d_from_prox(prox_loc(c));
+                double d1 = d_from_prox(dist_loc(c));
+
+                if (d0<=d && d<=d1) {
+                    double s = d0==d1? 0: (d-d0)/(d1-d0);
+                    s = std::min(1.0, std::fma(s, c.dist_pos-c.prox_pos, c.prox_pos));
+                    L.push_back(mlocation{c.branch, s});
+                }
+            }
+
+        }
+    }
+
+    util::sort(L);
+    return L;
+}
+
+std::ostream& operator<<(std::ostream& o, const on_components_& x) {
+    return o << "(on_components " << x.relpos << " " << x.reg << ")";
 }
 
 // Uniform locset.

--- a/arbor/sampler_map.hpp
+++ b/arbor/sampler_map.hpp
@@ -1,19 +1,14 @@
 #pragma once
 
-/*
- * Helper classes for managing sampler/schedule associations in
- * cell group classes (see sampling_api doc).
- */
+// Helper classes for managing sampler/schedule associations in
+// cell group classes (see sampling_api doc).
 
-#include <functional>
-#include <mutex>
 #include <unordered_map>
+#include <vector>
 
 #include <arbor/common_types.hpp>
 #include <arbor/sampling.hpp>
 #include <arbor/schedule.hpp>
-
-#include "util/transform.hpp"
 
 namespace arb {
 
@@ -27,38 +22,6 @@ struct sampler_association {
     sampling_policy policy;
 };
 
-// Maintain a set of associations paired with handles used for deletion.
-
-class sampler_association_map {
-public:
-    void add(sampler_association_handle h, sampler_association assoc) {
-        std::lock_guard<std::mutex> lock(m_);
-        map_.insert({h, std::move(assoc)});
-    }
-
-    void remove(sampler_association_handle h) {
-        std::lock_guard<std::mutex> lock(m_);
-        map_.erase(h);
-    }
-
-    void clear() {
-        std::lock_guard<std::mutex> lock(m_);
-        map_.clear();
-    }
-
-private:
-    using assoc_map = std::unordered_map<sampler_association_handle, sampler_association>;
-    assoc_map map_;
-    std::mutex m_;
-
-    static sampler_association& second(assoc_map::value_type& p) { return p.second; }
-    auto assoc_view() { return util::transform_view(map_, &sampler_association_map::second); }
-
-public:
-    // Range-like view presents just the associations, omitting the handles.
-
-    auto begin() { return assoc_view().begin(); }
-    auto end()   { return assoc_view().end(); }
-};
+using sampler_association_map = std::unordered_map<sampler_association_handle, sampler_association>;
 
 } // namespace arb

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -65,6 +65,8 @@ public:
 
     void remove_all_samplers();
 
+    std::vector<probe_metadata> get_probe_metadata(cell_member_type) const;
+
     std::size_t num_spikes() const {
         return communicator_.num_spikes();
     }
@@ -98,7 +100,11 @@ private:
     std::unique_ptr<spike_double_buffer> local_spikes_;
 
     // Hash table for looking up the the local index of a cell with a given gid
-    std::unordered_map<cell_gid_type, cell_size_type> gid_to_local_;
+    struct gid_local_info {
+        cell_size_type cell_index;
+        cell_size_type group_index;
+    };
+    std::unordered_map<cell_gid_type, gid_local_info> gid_to_local_;
 
     communicator communicator_;
 
@@ -146,16 +152,18 @@ simulation_state::simulation_state(
     pending_events_.resize(num_local_cells);
 
     event_generators_.resize(num_local_cells);
-    cell_local_size_type lidx = 0;
+    cell_size_type lidx = 0;
+    cell_size_type grpidx = 0;
     for (const auto& group_info: decomp.groups) {
         for (auto gid: group_info.gids) {
             // Store mapping of gid to local cell index.
-            gid_to_local_[gid] = lidx;
+            gid_to_local_[gid] = gid_local_info{lidx, grpidx};
 
             // Set up the event generators for cell gid.
             event_generators_[lidx] = rec.event_generators(gid);
             ++lidx;
         }
+        ++grpidx;
     }
 
     // Generate the cell groups in parallel, with one task per cell group.
@@ -398,6 +406,15 @@ void simulation_state::remove_all_samplers() {
     sassoc_handles_.clear();
 }
 
+std::vector<probe_metadata> simulation_state::get_probe_metadata(cell_member_type probe_id) const {
+    if (auto linfo = util::value_by_key(gid_to_local_, probe_id.gid)) {
+        return cell_groups_.at(linfo->group_index)->get_probe_metadata(probe_id);
+    }
+    else {
+        return {};
+    }
+}
+
 void simulation_state::set_binning_policy(binning_kind policy, time_type bin_interval) {
     foreach_group(
         [&](cell_group_ptr& group) { group->set_binning_policy(policy, bin_interval); });
@@ -410,9 +427,9 @@ void simulation_state::inject_events(const pse_vector& events) {
         if (e.time<t_) {
             throw bad_event_time(e.time, t_);
         }
-        // gid_to_local_ maps gid to index into local set of cells.
+        // gid_to_local_ maps gid to index in local cells and of corresponding cell group.
         if (auto lidx = util::value_by_key(gid_to_local_, e.target.gid)) {
-            pending_events_[*lidx].push_back(e);
+            pending_events_[lidx->cell_index].push_back(e);
         }
     }
 }
@@ -450,6 +467,10 @@ void simulation::remove_sampler(sampler_association_handle h) {
 
 void simulation::remove_all_samplers() {
     impl_->remove_all_samplers();
+}
+
+std::vector<probe_metadata> simulation::get_probe_metadata(cell_member_type probe_id) const {
+    return impl_->get_probe_metadata(probe_id);
 }
 
 std::size_t simulation::num_spikes() const {

--- a/test/unit/test_fvm_lowered.cpp
+++ b/test/unit/test_fvm_lowered.cpp
@@ -23,7 +23,6 @@
 #include "fvm_lowered_cell.hpp"
 #include "fvm_lowered_cell_impl.hpp"
 #include "mech_private_field_access.hpp"
-#include "sampler_map.hpp"
 #include "util/meta.hpp"
 #include "util/maputil.hpp"
 #include "util/rangeutil.hpp"

--- a/test/unit/test_kinetic_linear.cpp
+++ b/test/unit/test_kinetic_linear.cpp
@@ -13,7 +13,6 @@
 #include "mech_private_field_access.hpp"
 #include "fvm_lowered_cell.hpp"
 #include "fvm_lowered_cell_impl.hpp"
-#include "sampler_map.hpp"
 #include "simple_recipes.hpp"
 #include "unit_test_catalogue.hpp"
 

--- a/test/unit/test_morph_expr.cpp
+++ b/test/unit/test_morph_expr.cpp
@@ -218,9 +218,22 @@ TEST(locset, thingify) {
         EXPECT_EQ(thingify(begb1, mp), (ll{{1,0}}));
         EXPECT_EQ(thingify(begb2, mp), (ll{{2,0}}));
         EXPECT_EQ(thingify(begb3, mp), (ll{{3,0}}));
-
-        // In the absence of a spherical root, there is no branch 4.
         EXPECT_THROW(thingify(begb4, mp), no_such_branch);
+
+        auto oc_beg_b0 = ls::on_components(0, reg::branch(0));
+        auto oc_mid_b1 = ls::on_components(0.5, reg::branch(1));
+        auto oc_mid_b123 = ls::on_components(0.5, join(reg::branch(1), reg::branch(2), reg::branch(3)));
+        auto oc_end_b123 = ls::on_components(1, join(reg::branch(1), reg::branch(2), reg::branch(3)));
+        auto oc_mid_b02 = ls::on_components(0.5, join(reg::branch(0), reg::branch(2)));
+        auto oc_end_b02 = ls::on_components(1, join(reg::branch(0), reg::branch(2)));
+
+        EXPECT_EQ(thingify(oc_beg_b0, mp),  (ll{{0, 0}}));
+        EXPECT_EQ(thingify(oc_mid_b1, mp),  (ll{{1, 0.5}}));
+        EXPECT_EQ(thingify(oc_mid_b123, mp),  (ll{{2, 0.5}, {3, 0.25}}));
+        EXPECT_EQ(thingify(oc_end_b123, mp),  (ll{{3, 1}}));
+        EXPECT_EQ(thingify(oc_mid_b02, mp),  (ll{{0, 0.5}, {2, 0.5}}));
+        EXPECT_EQ(thingify(oc_end_b02, mp),  (ll{{0, 1}, {2, 1}}));
+        EXPECT_EQ(thingify(ls::on_components(0.25, reg::cable(1, 0.5, 1)), mp),  (ll{{1, 0.625}}));
     }
     {
         auto mp = mprovider(morphology(sm));

--- a/test/unit/test_morph_expr.cpp
+++ b/test/unit/test_morph_expr.cpp
@@ -224,6 +224,7 @@ TEST(locset, thingify) {
         auto oc_mid_b1 = ls::on_components(0.5, reg::branch(1));
         auto oc_mid_b123 = ls::on_components(0.5, join(reg::branch(1), reg::branch(2), reg::branch(3)));
         auto oc_end_b123 = ls::on_components(1, join(reg::branch(1), reg::branch(2), reg::branch(3)));
+        auto oc_end_b123h = ls::on_components(1, join(reg::branch(1), reg::branch(2), reg::cable(3, 0, 0.5)));
         auto oc_mid_b02 = ls::on_components(0.5, join(reg::branch(0), reg::branch(2)));
         auto oc_end_b02 = ls::on_components(1, join(reg::branch(0), reg::branch(2)));
 
@@ -231,6 +232,7 @@ TEST(locset, thingify) {
         EXPECT_EQ(thingify(oc_mid_b1, mp),  (ll{{1, 0.5}}));
         EXPECT_EQ(thingify(oc_mid_b123, mp),  (ll{{2, 0.5}, {3, 0.25}}));
         EXPECT_EQ(thingify(oc_end_b123, mp),  (ll{{3, 1}}));
+        EXPECT_EQ(thingify(oc_end_b123h, mp),  (ll{{2, 1}, {3, 0.5}}));
         EXPECT_EQ(thingify(oc_mid_b02, mp),  (ll{{0, 0.5}, {2, 0.5}}));
         EXPECT_EQ(thingify(oc_end_b02, mp),  (ll{{0, 1}, {2, 1}}));
         EXPECT_EQ(thingify(ls::on_components(0.25, reg::cable(1, 0.5, 1)), mp),  (ll{{1, 0.625}}));


### PR DESCRIPTION
* Add `get_probe_metadata` method to `simulator` that forwards probe metadata queries to appropriate cell group, via new interface method in cell group base class.
* Replace `gid_to_local_` map in simulator implementation with a map that takes gid to local cell index _and_ local cell group index.
* Move scheduler association map mutex into the cell group where it is being used (i.e. `mc_cell_group`).
* Add generic (`visit`-able) interface to specifc fvm-probe types for accessing metadata via `any_ptr`.
* Implement (override) `get_probe_metadata` method for `mc_cell_group`.
* Use new cv policy API for LFP example discretization.
* Use new probe metadata API to simplify LFP example sampler callback.
* Add `on_components` locset expression that gives points a relative distance from the head of each component of a region.
* Simplify implementation of thingification of `ls::boundary`.

Fixes #1079 