### PR TITLE
Add python version check github action

### DIFF
--- a/.github/workflows/python_checks.yaml
+++ b/.github/workflows/python_checks.yaml
@@ -1,0 +1,23 @@
+name: python version checks
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install Python Packages
+      run: |
+        pip install --upgrade pip
+        pip install --upgrade vermin
+    - name: Minimum Version (Spack's Core)
+      run: vermin --backport argparse -v -t=3.6- python/*.py python/test/ python/tutorial/ python/example/ validation/ scripts/ doc/ example/


### PR DESCRIPTION
Not sure how useful it is, but in spack/spack they're using `vermin` to quickly check whether the python version requirements are met in the source files. This action runs in <30s, so could be useful :)