### PR TITLE
Implement 'stitch' morphology builder.

### DIFF
--- a/arbor/CMakeLists.txt
+++ b/arbor/CMakeLists.txt
@@ -31,6 +31,7 @@ set(arbor_sources
     memory/gpu_wrappers.cpp
     memory/util.cpp
     morph/embed_pwlin.cpp
+    morph/stitch.cpp
     morph/label_dict.cpp
     morph/locset.cpp
     morph/morphexcept.cpp

--- a/arbor/include/arbor/morph/embed_pwlin.hpp
+++ b/arbor/include/arbor/morph/embed_pwlin.hpp
@@ -22,14 +22,17 @@ using pw_constant_fn = util::pw_elements<double>;
 struct embed_pwlin {
     explicit embed_pwlin(const arb::morphology& m);
 
-    // Locations that mark the boundaries between segments.
-    const std::vector<mlocation>& segment_locations() const {
-        return segment_locations_;
+    // Segment queries.
+    msize_t num_segments() const {
+        return segment_cables_.size();
     }
 
-    std::pair<const mlocation*, const mlocation*> branch_segment_locations(msize_t i) const {
-        const mlocation* p = segment_locations_.data();
-        return std::make_pair(p+branch_segment_part_[i], p+branch_segment_part_[i+1]);
+    mcable segment(msize_t seg_id) const {
+        return segment_cables_.at(seg_id);
+    }
+
+    const mlocation_list& segment_ends() const {
+        return all_segment_ends_;
     }
 
     // Interpolated radius at location.
@@ -65,8 +68,8 @@ struct embed_pwlin {
     }
 
 private:
-    std::vector<mlocation> segment_locations_;
-    std::vector<msize_t> branch_segment_part_;
+    mlocation_list all_segment_ends_;
+    std::vector<mcable> segment_cables_;
     std::shared_ptr<embed_pwlin_data> data_;
 };
 

--- a/arbor/include/arbor/morph/label_dict.hpp
+++ b/arbor/include/arbor/morph/label_dict.hpp
@@ -16,6 +16,7 @@ class label_dict {
     reg_map regions_;
 
 public:
+    void import(const label_dict& other);
 
     void set(const std::string& name, locset ls);
     void set(const std::string& name, region reg);

--- a/arbor/include/arbor/morph/morphexcept.hpp
+++ b/arbor/include/arbor/morph/morphexcept.hpp
@@ -41,6 +41,27 @@ struct invalid_segment_parent: morphology_error {
     msize_t tree_size;
 };
 
+struct duplicate_stitch_id: morphology_error {
+    duplicate_stitch_id(const std::string& id);
+    std::string id;
+};
+
+struct no_such_stitch: morphology_error {
+    no_such_stitch(const std::string& id);
+    std::string id;
+};
+
+struct missing_stitch_start: morphology_error {
+    missing_stitch_start(const std::string& id);
+    std::string id;
+};
+
+struct invalid_stitch_position: morphology_error {
+    invalid_stitch_position(const std::string& id, double along);
+    std::string id;
+    double along;
+};
+
 struct label_type_mismatch: morphology_error {
     label_type_mismatch(const std::string& label);
     std::string label;

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -4,9 +4,9 @@
 #include <ostream>
 #include <vector>
 
-#include <arbor/util/lexcmp_def.hpp>
 #include <arbor/morph/primitives.hpp>
 #include <arbor/morph/segment_tree.hpp>
+#include <arbor/util/lexcmp_def.hpp>
 
 namespace arb {
 

--- a/arbor/include/arbor/morph/primitives.hpp
+++ b/arbor/include/arbor/morph/primitives.hpp
@@ -46,11 +46,11 @@ enum class comp_op {
 
 // Describe a cable segment between two adjacent samples.
 struct msegment {
+    msize_t id;
     mpoint prox;
     mpoint dist;
     int tag;
 
-    friend bool operator==(const msegment&, const msegment&);
     friend std::ostream& operator<<(std::ostream&, const msegment&);
 };
 

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -133,6 +133,9 @@ region branch(msize_t);
 // Region with all segments with segment tag id.
 region tagged(int id);
 
+// Region corresponding to a single segment.
+region segment(int id);
+
 // Region up to `distance` distal from points in `start`.
 region distal_interval(locset start, double distance);
 

--- a/arbor/include/arbor/morph/stitch.hpp
+++ b/arbor/include/arbor/morph/stitch.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arbor/morph/morphology.hpp>
+#include <arbor/morph/primitives.hpp>
+#include <arbor/morph/label_dict.hpp>
+#include <arbor/morph/region.hpp>
+#include <arbor/util/optional.hpp>
+
+namespace arb {
+
+// Stiches represent an alternative building block for morphologies.
+//
+// A stitch describes a portion of the morphology delimited by two
+// `mpoint`s. Stitches can be attached to a parent stich at any
+// point along the parent, interpolated linearly from the end points.
+// Each stitch is associated with a unique string label, and optionally
+// an integer tag value.
+//
+// The stitch builder collects stitches and produces the corresponding
+// morphology and region/location labels.
+
+struct mstitch {
+    std::string id;
+    util::optional<mpoint> prox;
+    mpoint dist;
+    int tag;
+
+    mstitch(std::string id, mpoint prox, mpoint dist, int tag = 0):
+        id(std::move(id)), prox(std::move(prox)), dist(std::move(dist)), tag(tag)
+    {}
+
+    mstitch(std::string id, mpoint dist, int tag = 0):
+        id(std::move(id)), dist(std::move(dist)), tag(tag)
+    {}
+};
+
+struct stitch_builder_impl;
+struct stitched_morphology;
+
+struct stitch_builder {
+    stitch_builder();
+
+    stitch_builder(const stitch_builder&) = delete;
+    stitch_builder(stitch_builder&&);
+
+    stitch_builder& operator=(const stitch_builder&) = delete;
+    stitch_builder& operator=(stitch_builder&&);
+
+    // Make a new stitch in the morphology, return reference to self.
+    //
+    // If the stitch does not contained a proximal point, it will be
+    // inferred from the point where it attaches to the parent stitch.
+    // If the parent is omitted, it will be taken to be the last stitch
+    // added.
+
+    stitch_builder& add(mstitch f, const std::string& parent_id, double along = 1.);
+    stitch_builder& add(mstitch f, double along = 1.);
+
+    ~stitch_builder();
+private:
+    friend stitched_morphology;
+    std::unique_ptr<stitch_builder_impl> impl_;
+};
+
+// From stitch builder construct morphology, region expressions.
+
+struct stitched_morphology_impl;
+
+struct stitched_morphology {
+    stitched_morphology() = delete;
+    stitched_morphology(const stitch_builder&); // implicit
+    stitched_morphology(stitch_builder&&); // implicit
+
+    stitched_morphology(const stitched_morphology&) = delete;
+    stitched_morphology(stitched_morphology&&);
+
+    arb::morphology morphology() const;
+    region stitch(const std::string& id) const;
+    std::vector<msize_t> segments(const std::string& id) const;
+
+    // Create labeled regions for each stitch with label equal to the stitch id, prepended by `prefix`.
+    label_dict labels(const std::string& prefix="") const;
+
+    ~stitched_morphology();
+private:
+    std::unique_ptr<stitched_morphology_impl> impl_;
+};
+
+} // namesapce arb

--- a/arbor/morph/label_dict.cpp
+++ b/arbor/morph/label_dict.cpp
@@ -25,6 +25,15 @@ void label_dict::set(const std::string& name, arb::region reg) {
     regions_[name] = std::move(reg);
 }
 
+void label_dict::import(const label_dict& other) {
+    for (const auto& entry: other.locsets()) {
+        set(entry.first, entry.second);
+    }
+    for (const auto& entry: other.regions()) {
+        set(entry.first, entry.second);
+    }
+}
+
 util::optional<const region&> label_dict::region(const std::string& name) const {
     auto it = regions_.find(name);
     if (it==regions_.end()) return {};

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -141,7 +141,7 @@ locset segment_boundaries() {
 }
 
 mlocation_list thingify_(const segments_&, const mprovider& p) {
-    return p.embedding().segment_locations();
+    return p.embedding().segment_ends();
 }
 
 std::ostream& operator<<(std::ostream& o, const segments_& x) {

--- a/arbor/morph/morphexcept.cpp
+++ b/arbor/morph/morphexcept.cpp
@@ -29,7 +29,6 @@ no_such_segment::no_such_segment(msize_t id):
     sid(id)
 {}
 
-
 invalid_mcable::invalid_mcable(mcable cable):
     morphology_error(pprintf("invalid mcable {}", cable)),
     cable(cable)
@@ -37,6 +36,33 @@ invalid_mcable::invalid_mcable(mcable cable):
 
 invalid_mcable_list::invalid_mcable_list():
     morphology_error("bad mcable_list")
+{}
+
+invalid_segment_parent::invalid_segment_parent(msize_t parent, msize_t tree_size):
+    morphology_error(pprintf("invalid segment parent {} for a segment tree of size {}", msize_string(parent), tree_size)),
+    parent(parent),
+    tree_size(tree_size)
+{}
+
+duplicate_stitch_id::duplicate_stitch_id(const std::string& id):
+    morphology_error(pprintf("duplicate stitch id {}", id)),
+    id(id)
+{}
+
+no_such_stitch::no_such_stitch(const std::string& id):
+    morphology_error(pprintf("no such stitch id {}", id)),
+    id(id)
+{}
+
+missing_stitch_start::missing_stitch_start(const std::string& id):
+    morphology_error(pprintf("require proximal point for stitch id {}", id)),
+    id(id)
+{}
+
+invalid_stitch_position::invalid_stitch_position(const std::string& id, double along):
+    morphology_error(pprintf("invalid stitch position {} on stitch {}", along, id)),
+    id(id),
+    along(along)
 {}
 
 label_type_mismatch::label_type_mismatch(const std::string& label):
@@ -59,11 +85,6 @@ circular_definition::circular_definition(const std::string& name):
     name(name)
 {}
 
-invalid_segment_parent::invalid_segment_parent(msize_t parent, msize_t tree_size):
-    morphology_error(pprintf("invalid segment parent {} for a segment tree of size {}", msize_string(parent), tree_size)),
-    parent(parent),
-    tree_size(tree_size)
-{}
 
 } // namespace arb
 

--- a/arbor/morph/primitives.cpp
+++ b/arbor/morph/primitives.cpp
@@ -132,16 +132,12 @@ bool test_invariants(const mcable_list& l) {
         && l.end()==std::find_if(l.begin(), l.end(), [](const mcable& c) {return !test_invariants(c);});
 }
 
-bool operator==(const msegment& l, const msegment& r) {
-    return l.prox==r.prox && l.dist==r.dist && l.tag==r.tag;
-}
-
 std::ostream& operator<<(std::ostream& o, const mpoint& p) {
     return o << "(point " << p.x << " " << p.y << " " << p.z << " " << p.radius << ")";
 }
 
 std::ostream& operator<<(std::ostream& o, const msegment& s) {
-    return o << "(segment " << s.prox << " " << s.dist << " " << s.tag << ")";
+    return o << "(segment " << s.id << " " << s.prox << " " << s.dist << " " << s.tag << ")";
 }
 
 std::ostream& operator<<(std::ostream& o, const mlocation& l) {

--- a/arbor/morph/segment_tree.cpp
+++ b/arbor/morph/segment_tree.cpp
@@ -24,7 +24,7 @@ msize_t segment_tree::append(msize_t p, const mpoint& prox, const mpoint& dist, 
     }
 
     auto id = size();
-    segments_.push_back(msegment{prox, dist, tag});
+    segments_.push_back(msegment{id, prox, dist, tag});
     parents_.push_back(p);
 
     // Set the point properties for the new point, and update those of the parent.

--- a/arbor/morph/stitch.cpp
+++ b/arbor/morph/stitch.cpp
@@ -1,0 +1,214 @@
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <arbor/morph/stitch.hpp>
+#include <arbor/morph/morphexcept.hpp>
+#include <arbor/morph/locset.hpp>
+#include <arbor/morph/region.hpp>
+#include <arbor/util/optional.hpp>
+
+#include "util/ordered_forest.hpp"
+#include "util/maputil.hpp"
+#include "util/meta.hpp"
+#include "util/rangeutil.hpp"
+#include "util/transform.hpp"
+
+namespace arb {
+
+struct stitch_builder_impl {
+    struct stitch_segment {
+        double along_prox;
+        double along_dist;
+
+        mpoint prox;
+        mpoint dist;
+        int tag;
+        std::string stitch_id;
+        msize_t seg_id;
+    };
+
+    using forest_type = util::ordered_forest<stitch_segment>;
+
+    forest_type forest;
+    std::unordered_map<std::string, forest_type::iterator> id_to_node;
+    std::string last_id;
+
+    stitch_builder_impl() = default;
+    stitch_builder_impl(stitch_builder_impl&&) = default;
+    stitch_builder_impl(const stitch_builder_impl& other):
+        forest(other.forest),
+        last_id(other.last_id)
+    {
+        for (auto i = forest.preorder_begin(); i!=forest.preorder_end(); ++i) {
+            id_to_node.insert({i->stitch_id, i});
+        }
+    }
+
+    stitch_builder_impl& operator=(stitch_builder_impl&&) = default;
+    stitch_builder_impl& operator=(const stitch_builder_impl& other) {
+        if (this==&other) return *this;
+        return *this = stitch_builder_impl(other);
+    }
+
+    void add(mstitch f, const std::string& parent, double along) {
+        if (id_to_node.count(f.id)) throw duplicate_stitch_id(f.id);
+
+        forest_type::iterator p;
+
+        if (!(parent.empty() && forest.empty())) {
+            p = find_stitch_along(parent, along);
+            arb_assert(p);
+
+            if (along==p->along_prox) {
+                if (!f.prox) f.prox = p->prox;
+                p = p.parent();
+            }
+            else if (along<p->along_dist) {
+                // Split parent node p at along.
+                auto split = *p;
+
+                mpoint point = lerp(p->prox, p->dist, (along-p->along_prox)/(p->along_dist-p->along_prox));
+                if (!f.prox) f.prox = point;
+
+                p->dist = point;
+                p->along_dist = along;
+                split.prox = point;
+                split.along_prox = along;
+
+                auto i = forest.push_child(p, split);
+                while (i.next()) {
+                    auto tmp = forest.prune_after(i);
+                    forest.graft_child(i, std::move(tmp));
+                }
+            }
+            else {
+                if (!f.prox) f.prox = p->dist;
+            }
+        }
+        if (!f.prox) throw missing_stitch_start(f.id);
+
+        stitch_segment n{0., 1., f.prox.value(), f.dist, f.tag, f.id, msize_t(-1)};
+        id_to_node[f.id] = p? forest.push_child(p, n): forest.push_front(n);
+        last_id = f.id;
+    }
+
+    forest_type::iterator find_stitch_along(const std::string& id, double along) {
+        if (along<0 || along>1) throw invalid_stitch_position(id, along);
+
+        auto map_it = id_to_node.find(id);
+        if (map_it==id_to_node.end()) throw no_such_stitch(id);
+
+        auto i = map_it->second;
+        arb_assert(i->along_prox==0);
+        arb_assert(i->along_dist==1 || i.child());
+
+        while (along>i->along_dist) {
+            // Continuation is last child.
+            i = i.child();
+            arb_assert(i);
+            while (i.next()) i = i.next();
+        }
+        return i;
+    }
+};
+
+stitch_builder::stitch_builder(): impl_(new stitch_builder_impl) {}
+
+stitch_builder::stitch_builder(stitch_builder&&) = default;
+stitch_builder& stitch_builder::operator=(stitch_builder&&) = default;
+
+stitch_builder& stitch_builder::add(mstitch f, const std::string& parent_id, double along) {
+    impl_->add(std::move(f), parent_id, along);
+    return *this;
+}
+
+stitch_builder& stitch_builder::add(mstitch f, double along) {
+    return add(std::move(f), impl_->last_id, along);
+}
+
+stitch_builder::~stitch_builder() = default;
+
+
+struct stitched_morphology_impl {
+    std::unordered_multimap<std::string, msize_t> id_to_segs;
+    segment_tree stree;
+
+    stitched_morphology_impl(stitch_builder_impl bimpl) {
+        auto iter = bimpl.forest.preorder_begin();
+        auto end = bimpl.forest.preorder_end();
+
+        for (; iter!=end; ++iter) {
+            msize_t seg_parent_id = iter.parent()? iter.parent()->seg_id: mnpos;
+            iter->seg_id = stree.append(seg_parent_id, iter->prox, iter->dist, iter->tag);
+        }
+
+        for (const auto& id_node: bimpl.id_to_node) {
+            const std::string& id = id_node.first;
+            auto iter = id_node.second;
+
+            while (iter && iter->stitch_id==id) {
+                id_to_segs.insert({id, iter->seg_id});
+                iter = iter.child();
+                while (iter.next()) {
+                    iter = iter.next();
+                }
+            }
+        }
+    }
+};
+
+stitched_morphology::stitched_morphology(stitch_builder&& builder):
+    impl_(new stitched_morphology_impl(std::move(*builder.impl_)))
+{}
+
+stitched_morphology::stitched_morphology(const stitch_builder& builder):
+    impl_(new stitched_morphology_impl(*builder.impl_))
+{}
+
+stitched_morphology::stitched_morphology(stitched_morphology&& other) = default;
+
+arb::morphology stitched_morphology::morphology() const {
+    return arb::morphology(impl_->stree);
+}
+
+label_dict stitched_morphology::labels(const std::string& prefix) const {
+    label_dict dict;
+
+    auto i0 = impl_->id_to_segs.begin();
+    auto end = impl_->id_to_segs.end();
+    while (i0 != end) {
+        auto i1 = i0;
+        while (i1 != end && i1->first==i0->first) ++i1;
+
+        region r  = util::foldl(
+            [&](region r, const auto& elem) { return join(std::move(r), reg::segment(elem.second)); },
+            reg::nil(),
+            util::make_range(i0, i1));
+
+        dict.set(prefix+i0->first, std::move(r));
+        i0 = i1;
+    }
+
+    return dict;
+}
+
+region stitched_morphology::stitch(const std::string& id) const {
+    auto seg_ids = util::make_range(impl_->id_to_segs.equal_range(id));
+    if (seg_ids.empty()) throw no_such_stitch(id);
+
+    return util::foldl(
+        [&](region r, const auto& elem) { return join(std::move(r), reg::segment(elem.second)); },
+        reg::nil(), seg_ids);
+}
+
+std::vector<msize_t> stitched_morphology::segments(const std::string& id) const {
+    auto seg_ids = util::transform_view(util::make_range(impl_->id_to_segs.equal_range(id)), util::second);
+    if (seg_ids.empty()) throw no_such_stitch(id);
+
+    return std::vector<msize_t>(begin(seg_ids), end(seg_ids));
+}
+
+stitched_morphology::~stitched_morphology() = default;
+
+} // namespace arb

--- a/arbor/util/ordered_forest.hpp
+++ b/arbor/util/ordered_forest.hpp
@@ -1,0 +1,668 @@
+#pragma once
+
+// The ordered forest data structure represents zero or more trees with an
+// arbitrary number of children per node, where the trees and children have a
+// well-defined ordering.
+//
+// This implementation presents a 'forward' interface, along the lines of
+// `std::forward_list`. Given an iterator pointing to a particular node in the
+// forest, one can directly obtain an iterator to its parent, its first child,
+// or its next sibling, but not its previous sibling.
+//
+// Common iterator methods:
+//
+//     `parent()`: return an iterator to the node's parent.
+//     `next()`: return an iterator to the node's next sibling.
+//     `child()`: return an iterator to the node's first child.
+//     `preorder_next()`: return an iterator to the next node in pre-order.
+//     `postorder_next()`: return an iterator to the next node in post-order.
+//
+// Note that these methods are not covariant: they return 'base' iterators
+// that can be implicitly converted to any of the derived iterators described
+// below.
+//
+// A default-constructed iterator points to no node, and plays the role of
+// an `end` iterator.
+//
+// The derived iterators differ only in the semantics of `operator++`:
+//
+//     `sibling_iterator`: proceed to next sibling.
+//     `preorder_iterator`: proceed to next node in pre-order.
+//     `postorder_iterator`: proceed to next node in post-order.
+//
+// Any of the iterators can be converted implicitly to any const iterator, and
+// any of the non-const iterators can be converted implicitly to any non-const
+// iterator.
+//
+// The iterators provided by `begin()` and `end()` are pre-order iterators.
+// The other ordered forest iterator methods are:
+//
+//     `child_begin`: return a sibling iterator starting at the child of the given node.
+//     `root_begin`: return a sibling iterator to the first tree.
+//     `postorder_begin`: return a post-order iterator to the first node in post-order.
+//     `preorder_begin`: return a post-order iterator to the first node in pre-order.
+//
+// Note that all ordered forest iterators are forward iterators.
+//
+// Ordered forests can be constructed from an intializer list with the aid of
+// the `ordered_forest_builder` helper class. Each item in the initalizer list
+// is either a value (corresponding to a node without children), or a pair
+// { value, IL } where value denotes the value at the node, and IL is an
+// initializer list with the same semantics, defining the node's children.
+//
+// Mutation operations are of the following types:
+//
+// * Insertions: add a new node as next sibling, first child, or first tree.
+// * Grafts: splice a forest between a node and its next sibling, or before its first child.
+// * Erasures: remove a node, replacing it with its children.
+// * Cuts: remove a sub-tree, presenting it as a new forest.
+//
+// These methods are described in more detail within the class definition below.
+//
+// The ordered forest implementation is allocator aware.
+
+#include <type_traits>
+#include <iterator>
+#include <memory>
+#include <utility>
+
+namespace arb {
+namespace util {
+
+template <typename V, typename Allocator>
+struct ordered_forest_builder;
+
+template <typename V, typename Allocator = std::allocator<V>>
+struct ordered_forest {
+private:
+    struct node {
+        V* item_ = nullptr;
+        node* parent_ = nullptr;
+        node* child_ = nullptr;
+        node* next_ = nullptr;
+    };
+
+    using node_alloc_t = typename std::allocator_traits<Allocator>::template rebind_alloc<node>;
+    using item_alloc_traits = std::allocator_traits<Allocator>;
+    using node_alloc_traits = std::allocator_traits<node_alloc_t>;
+
+public:
+    using value_type = V;
+    using allocator_type = Allocator;
+    using size_type = std::size_t;
+
+    struct iterator_base {
+        node* n_ = nullptr;
+
+        iterator_base() = default;
+        explicit iterator_base(node* n): n_(n) {}
+        explicit operator bool() const { return n_; }
+    };
+
+    // Constructor overloads for iterators permit construction of any const
+    // iterator from any other iterator, or of any mutable iterator from any
+    // other mutable iterator.
+
+    template <bool const_flag>
+    struct iterator_mc: iterator_base {
+        using pointer = std::conditional_t<const_flag, const V*, V*>;
+        using reference = std::conditional_t<const_flag, const V&, V&>;
+        using value_type = V;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+
+        iterator_mc() = default;
+
+        template <bool flag = const_flag, typename std::enable_if_t<flag, int> = 0>
+        iterator_mc(const iterator_mc<false>& i): iterator_base(i.n_) {}
+
+        iterator_mc parent() const { return iterator_mc{n_? n_->parent_: nullptr}; }
+        iterator_mc next() const { return iterator_mc{n_? n_->next_: nullptr}; }
+        iterator_mc child() const { return iterator_mc{n_? n_->child_: nullptr}; }
+
+        bool operator==(const iterator_base& a) const { return n_ == a.n_; }
+        bool operator!=(const iterator_base& a) const { return n_ != a.n_; }
+
+        iterator_mc preorder_next() const {
+            if (!n_) return {};
+            if (n_->child_) return iterator_mc{n_->child_};
+
+            node* x = n_;
+            while (x && !x->next_) x = x->parent_;
+            return iterator_mc{x? x->next_: nullptr};
+        }
+
+        iterator_mc postorder_next() const {
+            if (!n_) return {};
+            if (n_->next_) {
+                node* x = n_->next_;
+                while (node* c = x->child_) x = c;
+                return iterator_mc{x};
+            }
+            else return parent();
+        }
+
+        reference operator*() const { return *n_->item_; }
+        pointer operator->() const { return n_->item_; }
+
+    protected:
+        friend ordered_forest;
+
+        explicit iterator_mc(node* n): iterator_base(n) {}
+        using iterator_base::n_;
+    };
+
+    template <bool const_flag>
+    struct sibling_iterator_mc: iterator_mc<const_flag> {
+        sibling_iterator_mc() = default;
+        sibling_iterator_mc(const iterator_mc<const_flag>& i): iterator_mc<const_flag>(i) {}
+
+        sibling_iterator_mc& operator++() { return *this = this->next(); }
+        sibling_iterator_mc operator++(int) { auto p = *this; return ++*this, p; }
+    };
+
+    using sibling_iterator = sibling_iterator_mc<false>;
+    using const_sibling_iterator = sibling_iterator_mc<true>;
+
+    template <bool const_flag>
+    struct preorder_iterator_mc: iterator_mc<const_flag> {
+        preorder_iterator_mc() = default;
+        preorder_iterator_mc(const iterator_mc<const_flag>& i): iterator_mc<const_flag>(i) {}
+
+        preorder_iterator_mc& operator++() { return *this = this->preorder_next(); }
+        preorder_iterator_mc operator++(int) { auto p = *this; return ++*this, p; }
+    };
+
+    using preorder_iterator = preorder_iterator_mc<false>;
+    using const_preorder_iterator = preorder_iterator_mc<true>;
+
+    template <bool const_flag>
+    struct postorder_iterator_mc: iterator_mc<const_flag> {
+        postorder_iterator_mc() = default;
+        postorder_iterator_mc(const iterator_mc<const_flag>& i): iterator_mc<const_flag>(i) {}
+
+        postorder_iterator_mc& operator++() { return *this = this->postorder_next(); }
+        postorder_iterator_mc operator++(int) { auto p = *this; return ++*this, p; }
+    };
+
+    using postorder_iterator = postorder_iterator_mc<false>;
+    using const_postorder_iterator = postorder_iterator_mc<true>;
+
+    bool empty() const { return !first_; }
+
+    // Note: size is O(n) in the number of elements n.
+    std::size_t size() const {
+        std::size_t n = 0;
+        for (const auto& _: *this) (void)_, ++n;
+        return n;
+    }
+
+    sibling_iterator child_begin(const iterator_mc<false>& i) { return sibling_iterator{i.child()}; }
+    const_sibling_iterator child_begin(const iterator_mc<true>& i) const { return const_sibling_iterator{i.child()}; }
+
+    sibling_iterator child_end(const iterator_base&) { return {}; }
+    const_sibling_iterator child_end(const iterator_base&) const { return {}; }
+
+    sibling_iterator root_begin() { return sibling_iterator{first_else_end()}; }
+    const_sibling_iterator root_begin() const { return const_sibling_iterator{first_else_end()}; }
+
+    sibling_iterator root_end() { return sibling_iterator{}; }
+    const_sibling_iterator root_end() const { return const_sibling_iterator{}; }
+
+    postorder_iterator postorder_begin() { return postorder_iterator{first_leaf()}; }
+    const_postorder_iterator postorder_begin() const { return const_postorder_iterator{first_leaf()}; }
+
+    postorder_iterator postorder_end() { return {}; }
+    const_postorder_iterator postorder_end() const { return {}; }
+
+    preorder_iterator preorder_begin() { return preorder_iterator{first_else_end()}; }
+    const_preorder_iterator preorder_begin() const { return const_preorder_iterator{first_else_end()}; }
+
+    preorder_iterator preorder_end() { return {}; }
+    const_preorder_iterator preorder_end() const { return {}; }
+
+    // Default iteration is preorder.
+
+    using iterator = preorder_iterator;
+    using const_iterator = const_preorder_iterator;
+
+    iterator begin() { return preorder_begin(); }
+    iterator end() { return {}; }
+
+    const_iterator begin() const { return preorder_begin(); }
+    const_iterator end() const { return {}; }
+
+    const_iterator cbegin() const { return preorder_begin(); }
+    const_iterator cend() const { return {}; }
+
+    // Insertion and emplace operations:
+    //
+    // * All return an iterator to the last inserted node, or an iterator to the referenced
+    //   node (or first tree, for push_front) if the collection of inserted items is empty.
+    //
+    // * The iterator argument may not be an end iterator.
+    //
+    // Insertion member functions are templated on iterator class in order to return covariantly.
+
+    // Insert/emplace item as next sibling.
+
+    template <typename Iter, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter insert_after(const Iter& i, const V& item) {
+        return assert_valid(i), splice_impl(i.n_->parent_, i.n_->next_, make_node(item));
+    }
+
+    template <typename Iter, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter insert_after(const Iter& i, V&& item) {
+        return assert_valid(i), splice_impl(i.n_->parent_, i.n_->next_, make_node(std::move(item)));
+    }
+
+    template <typename Iter, typename... Args, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter emplace_after(const Iter& i, Args&&... args) {
+        return assert_valid(i), splice_impl(i.n_->parent_, i.n_->next_, make_node(std::forward<Args>(args)...));
+    }
+
+    // Insert trees in forest as next siblings.
+
+    template <typename Iter, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter graft_after(const Iter& i, ordered_forest of) {
+        assert_valid(i);
+        if (of.empty()) return i;
+
+        // Underlying move or copy depends upon allocator equality.
+        ordered_forest f(std::move(of), get_allocator());
+        node* sp_first = f.first_;
+        f.first_ = nullptr;
+        return splice_impl(i.n_->parent_, i.n_->next_, sp_first);
+    }
+
+    // Insert item as first child.
+
+    template <typename Iter, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter push_child(const Iter& i, const V& item) {
+        return assert_valid(i), splice_impl(i.n_, i.n_->child_, make_node(item));
+    }
+
+    template <typename Iter, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter push_child(const Iter& i, V&& item) {
+        return assert_valid(i), splice_impl(i.n_, i.n_->child_, make_node(std::move(item)));
+    }
+
+    template <typename Iter, typename... Args, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter emplace_child(const Iter& i, Args&&... args) {
+        return assert_valid(i), splice_impl(i.n_, i.n_->child_, make_node(std::forward<Args>(args)...));
+    }
+
+    // Insert trees in forest as first children.
+
+    template <typename Iter, typename = std::enable_if_t<std::is_base_of<iterator_mc<false>, Iter>::value>>
+    Iter graft_child(const Iter& i, ordered_forest of) {
+        assert_valid(i);
+        if (of.empty()) return i;
+
+        // Underlying move or copy depends upon allocator equality.
+        ordered_forest f(std::move(of), get_allocator());
+        node* sp_first = f.first_;
+        f.first_ = nullptr;
+        return splice_impl(i.n_, i.n_->child_, sp_first);
+    }
+
+    // Insert item as first top-level tree.
+
+    iterator push_front(const V& item) {
+        return splice_impl(nullptr, first_, make_node(item));
+    }
+
+    iterator push_front(V&& item) {
+        return splice_impl(nullptr, first_, make_node(std::move(item)));
+    }
+
+    template <typename... Args>
+    iterator emplace_front(Args&&... args) {
+        return splice_impl(nullptr, first_, make_node(std::forward<Args>(args)...));
+    }
+
+    // Insert trees in forest as first top-level children.
+
+    iterator graft_front(ordered_forest of) {
+        if (of.empty()) return {};
+
+        // Underlying move or copy depends upon allocator equality.
+        ordered_forest f(std::move(of), get_allocator());
+        node* sp_first = f.first_;
+        f.first_ = nullptr;
+        return splice_impl(nullptr, first_, sp_first);
+    }
+
+    // Erase and cut operations:
+    //
+    // * Erase/pop operations replace a node with all of that node's children.
+    // * Prune operations remove a whole subtree, and return it as a new ordered forest.
+
+    // Erase/cut next sibling.
+
+    void erase_after(const iterator_mc<false>& i) {
+        assert_valid(i.next()), erase_impl(i.n_->next_);
+    }
+
+    ordered_forest prune_after(const iterator_mc<false>& i) {
+        return assert_valid(i.next()), prune_impl(i.n_->next_);
+    }
+
+    // Erase/cut first child.
+
+    void erase_child(const iterator_mc<false>& i) {
+        assert_valid(i.child()), erase_impl(i.n_->child_);
+    }
+
+    ordered_forest prune_child(const iterator_mc<false>& i) {
+        return assert_valid(i.child()), prune_impl(i.n_->child_);
+    }
+
+    // Erase/cut root of first tree. Precondition: forest is non-empty.
+
+    void erase_front() {
+        assert_nonempty(), erase_impl(first_);
+    }
+
+    ordered_forest prune_front() {
+        return assert_nonempty(), prune_impl(first_);
+    }
+
+    // Access by reference to root of first tree.
+
+    V& front() { return *begin(); }
+    const V& front() const { return *begin(); }
+
+    // Comparison:
+
+    bool operator==(const ordered_forest& other) const {
+        const_iterator a = begin();
+        const_iterator b = other.begin();
+
+        while (a && b) {
+            if (!a.child() != !b.child() || !a.next() != !b.next() || !(*a==*b)) return false;
+            ++a, ++b;
+        }
+        return !a && !b;
+    }
+
+    bool operator!=(const ordered_forest& other) const {
+        return !(*this==other);
+    }
+
+    // Constructors, assignment, destructors:
+
+    ordered_forest(const Allocator& alloc = Allocator()) noexcept:
+        item_alloc_(alloc),
+        node_alloc_(alloc)
+    {}
+
+    ordered_forest(ordered_forest&& other) noexcept:
+        ordered_forest(std::move(other.item_alloc_))
+    {
+        first_ = other.first_;
+        other.first_ = nullptr;
+    }
+
+    ordered_forest(ordered_forest&& other, const Allocator& alloc):
+        ordered_forest(alloc)
+    {
+        if (allocators_equal(other)) {
+            first_ = other.first_;
+            other.first_ = nullptr;
+        }
+        else {
+            copy_impl(other);
+        }
+    }
+
+    ordered_forest(std::initializer_list<ordered_forest_builder<V, Allocator>> blist, const Allocator& alloc = Allocator{}):
+        ordered_forest(alloc)
+    {
+        sibling_iterator j;
+        for (auto& b: blist) {
+            ordered_forest f(std::move(b.f_), item_alloc_);
+            j = j? graft_after(j, std::move(f)): sibling_iterator(graft_front(std::move(f)));
+        }
+    }
+
+    ordered_forest(const ordered_forest& other):
+        ordered_forest(item_alloc_traits::select_on_container_copy_construction(other.item_alloc_))
+    {
+        copy_impl(other);
+    }
+
+    ordered_forest(const ordered_forest& other, const Allocator& alloc):
+        ordered_forest(alloc)
+    {
+        copy_impl(other);
+    }
+
+    ordered_forest& operator=(const ordered_forest& other) {
+        if (this==&other) return *this;
+        delete_node(first_);
+
+        if (item_alloc_traits::propagate_on_container_copy_assignment::value) {
+            item_alloc_ = other.item_alloc_;
+        }
+        if (node_alloc_traits::propagate_on_container_copy_assignment::value) {
+            node_alloc_ = other.node_alloc_;
+        }
+
+        copy_impl(other);
+        return *this;
+    }
+
+    ordered_forest& operator=(ordered_forest&& other) {
+        if (this==&other) return *this;
+        delete_node(first_);
+
+        if (item_alloc_traits::propagate_on_container_move_assignment::value) {
+            item_alloc_ = other.item_alloc_;
+        }
+        if (node_alloc_traits::propagate_on_container_move_assignment::value) {
+            node_alloc_ = other.node_alloc_;
+        }
+
+        if (allocators_equal(other)) {
+            first_ = other.first_;
+            other.first_ = nullptr;
+        }
+        else {
+            copy_impl(other);
+        }
+        return *this;
+    }
+
+    ~ordered_forest() { delete_node(first_); }
+
+    // Swap
+
+    void swap(ordered_forest& other)
+        noexcept(
+            (item_alloc_traits::propagate_on_container_swap::value && node_alloc_traits::propagate_on_container_swap::value) ||
+            (item_alloc_traits::is_always_equal::value && node_alloc_traits::is_always_equal::value)
+        )
+    {
+        using std::swap;
+        if (item_alloc_traits::propagate_on_container_swap::value) {
+            swap(item_alloc_, other.item_alloc_);
+        }
+        if (node_alloc_traits::propagate_on_container_swap::value) {
+            swap(node_alloc_, other.node_alloc_);
+        }
+
+        swap(first_, other.first_);
+    }
+
+    friend void swap(ordered_forest& a, ordered_forest& b) {
+        a.swap(b);
+    }
+
+    // Allocator access
+
+    allocator_type get_allocator() const noexcept { return item_alloc_; }
+
+private:
+    Allocator item_alloc_;
+    node_alloc_t node_alloc_;
+    node* first_ = nullptr;
+
+    bool allocators_equal(const ordered_forest& other) const {
+        return item_alloc_==other.item_alloc_ && node_alloc_==other.node_alloc_;
+    }
+
+    iterator_mc<false> first_else_end() { return iterator_mc<false>{first_}; }
+    iterator_mc<true> first_else_end() const { return iterator_mc<true>{first_}; }
+
+    iterator_mc<false> first_leaf() { return iterator_mc<false>{first_leaf_node()}; }
+    iterator_mc<true> first_leaf() const { return iterator_mc<true>{first_leaf_node()}; }
+
+    node* first_leaf_node() const {
+        node* n = first_;
+        while (n && n->child_) n = n->child_;
+        return n;
+    }
+
+    // Throw on invalid iterator.
+    void assert_valid(iterator_base i) {
+        if (!i.n_) throw std::invalid_argument("bad iterator");
+    }
+
+    void assert_nonempty() {
+        if (!first_) throw std::invalid_argument("empty forest");
+    }
+
+    ordered_forest prune_impl(node*& next_write) {
+        node* r = next_write;
+        next_write = next_write->next_;
+        r->next_ = nullptr;
+        r->parent_ = nullptr;
+
+        ordered_forest f(get_allocator());
+        f.first_ = r;
+
+        return f;
+    }
+
+    void erase_impl(node*& next_write) {
+        ordered_forest cut = prune_impl(next_write);
+
+        node* cut_root = cut.first_;
+        if (cut_root->child_) {
+            splice_impl(next_write->parent_, next_write, cut_root->child_);
+        }
+
+        cut_root->child_ = nullptr;
+    }
+
+    iterator_mc<false> splice_impl(node* parent, node*& next_write, node* sp_first) {
+        node* sp_last = nullptr;
+
+        for (node* j = sp_first; j; j = j->next_) {
+            j->parent_ = parent;
+            sp_last = j;
+        }
+        sp_last->next_ = next_write;
+        next_write = sp_first;
+
+        return iterator_mc<false>{sp_last};
+    }
+
+    template <typename U, typename OtherAllocator>
+    void copy_impl(const ordered_forest<U, OtherAllocator>& other) {
+        auto copy_children = [&](auto& self, const auto& from, auto& to) -> void {
+            sibling_iterator j;
+            for (auto i = other.child_begin(from); i!=other.child_end(from); ++i) {
+                // TODO: explicit `this` required for g++6; remove when g++6 deprecated.
+                j = j? this->insert_after(j, *i): sibling_iterator(this->push_child(to, *i));
+                self(self, i, j);
+            }
+        };
+
+        sibling_iterator j;
+        for (auto i = other.root_begin(); i!=other.root_end(); ++i) {
+            j = j? insert_after(j, *i): sibling_iterator(push_front(*i));
+            copy_children(copy_children, i, j);
+        }
+    }
+
+    // Node creation, destruction:
+
+    template <typename... Args>
+    node* make_node(Args&&... args) {
+        node* x = node_alloc_traits::allocate(node_alloc_, 1);
+        try {
+            node_alloc_traits::construct(node_alloc_, x);
+        }
+        catch (...) {
+            node_alloc_traits::deallocate(node_alloc_, x, 1);
+            throw;
+        }
+
+        x->item_ = item_alloc_traits::allocate(item_alloc_, 1);
+        try {
+            item_alloc_traits::construct(item_alloc_, x->item_, std::forward<Args>(args)...);
+        }
+        catch (...) {
+            item_alloc_traits::deallocate(item_alloc_, x->item_, 1);
+            throw;
+        }
+        return x;
+    }
+
+    void delete_node(node* n) {
+        if (!n) return;
+
+        delete_item(n->item_);
+        delete_node(n->child_);
+        delete_node(n->next_);
+
+        node_alloc_traits::destroy(node_alloc_, n);
+        node_alloc_traits::deallocate(node_alloc_, n, 1);
+    }
+
+    void delete_item(V* item) {
+        if (!item) return;
+
+        item_alloc_traits::destroy(item_alloc_, item);
+        item_alloc_traits::deallocate(item_alloc_, item, 1);
+    }
+};
+
+// Helper class for building trees from initializer_lists. Ordered forest can be
+// constructed from an initializer list of builder objects; each builder object
+// represents a tree, constructed from a single value, or a pair: root value
+// and a sequence of builder objects represeting the children.
+//
+// While the builder takes the same allocator type as its associated forest, it
+// will build the temporary trees with a default-constructed allocator.
+
+template <typename V, typename Allocator>
+struct ordered_forest_builder {
+    template <typename X, typename std::enable_if_t<std::is_constructible<V, X&&>::value, int> = 0>
+    ordered_forest_builder(X&& x) {
+        f_.emplace_front(x);
+    }
+
+    template <typename X, typename std::enable_if_t<std::is_constructible<V, X&&>::value, int> = 0>
+    ordered_forest_builder(X&& x, std::initializer_list<ordered_forest_builder<V, Allocator>> children) {
+        using sibling_iterator = typename ordered_forest<V, Allocator>::sibling_iterator;
+
+        auto top = f_.emplace_front(x);
+        sibling_iterator j;
+
+        for (auto& g: children) {
+            ordered_forest<V, Allocator> c(std::move(g.f_));
+            j = j? f_.graft_after(j, std::move(c)): sibling_iterator(f_.graft_child(top, std::move(c)));
+        }
+    }
+
+    friend class ordered_forest<V, Allocator>;
+
+private:
+    ordered_forest<V, Allocator> f_;
+};
+
+} // namespace util
+} // namespace arb

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -126,8 +126,10 @@ set(unit_sources
     test_morph_expr.cpp
     test_morph_place.cpp
     test_morph_primitives.cpp
+    test_morph_stitch.cpp
     test_multi_event_stream.cpp
     test_optional.cpp
+    test_ordered_forest.cpp
     test_padded.cpp
     test_partition.cpp
     test_partition_by_constraint.cpp

--- a/test/unit/test_morph_expr.cpp
+++ b/test/unit/test_morph_expr.cpp
@@ -353,6 +353,8 @@ TEST(region, thingify_simple_morphologies) {
         auto q2  = reg::cable(0, 0.25, 0.5);
         auto q3  = reg::cable(0, 0.5,  0.75);
         auto q4  = reg::cable(0, 0.75, 1);
+        auto s0  = reg::segment(0);
+        auto s2  = reg::segment(2);
 
         // Concrete cable lists
         cl h1_{{0, 0.0, 0.5}};
@@ -360,8 +362,9 @@ TEST(region, thingify_simple_morphologies) {
         cl t1_{{0, 0.0, 0.1}, {0, 0.3, 0.7}};
         cl t2_{{0, 0.1, 0.3}, {0, 0.7, 1.0}};
         cl all_{{0, 0, 1}};
-        cl empty_{};
 
+        EXPECT_TRUE(region_eq(mp, s0, cl{{0, 0, 0.1}}));
+        EXPECT_TRUE(region_eq(mp, s2, cl{{0, 0.3, 0.7}}));
         EXPECT_TRUE(region_eq(mp, join(h1, h2), all_));
         EXPECT_TRUE(region_eq(mp, intersect(h1, h2), cl{{0, 0.5, 0.5}}));
         EXPECT_TRUE(region_eq(mp, t1, t1_));
@@ -389,7 +392,7 @@ TEST(region, thingify_simple_morphologies) {
     }
 
 
-    // Test handling of spherical soma on multi-branch morphologies
+    // A simple Y-shaped morphology.
     //
     //  sample ids:
     //              0           |
@@ -417,6 +420,7 @@ TEST(region, thingify_simple_morphologies) {
         auto mp = mprovider(morphology(sm));
 
         using ls::location;
+        using reg::segment;
         using reg::tagged;
         using reg::distal_interval;
         using reg::proximal_interval;
@@ -436,6 +440,8 @@ TEST(region, thingify_simple_morphologies) {
         auto reg5_ = distal_interval(start1_, 0);
         auto reg6_ = proximal_interval(start1_, 0);
 
+        EXPECT_TRUE(region_eq(mp, segment(3), mcable_list{{2,0,0}}));
+        EXPECT_TRUE(region_eq(mp, segment(4), mcable_list{{2,0,1}}));
         EXPECT_TRUE(region_eq(mp, tagged(1), mcable_list{{0,0,1}}));
         EXPECT_TRUE(region_eq(mp, tagged(2), mcable_list{{2,0,1}}));
         EXPECT_TRUE(region_eq(mp, tagged(3), mcable_list{{1,0,1}}));
@@ -459,20 +465,27 @@ TEST(region, thingify_moderate_morphologies) {
 
     // Test multi-level morphologies.
     //
-    // Eight samples
-    //
-    //  sample ids:
+    // Eight points:
     //            0
     //           1 3
     //          2   4
     //             5 6
     //                7
-    //  tags:
-    //            1
-    //           3 2
-    //          3   2
-    //             4 3
-    //                3
+    //
+    // Segments [with tag]:
+    //             +
+    //           ./ \.
+    //         0[3]  2[2]
+    //         ./     \.
+    //       1[3]     3[2]
+    //       ./         \.
+    //       +           +
+    //                 ./ \.
+    //               4[4]  5[3]
+    //               ./     \.
+    //               +      6[3]
+    //                        \.
+    //                         +
     {
         pvec parents = {mnpos, 0, 1, 0, 3, 4, 4, 6};
         svec points = {
@@ -492,6 +505,7 @@ TEST(region, thingify_moderate_morphologies) {
         auto mp = mprovider(morphology(sm));
 
         using ls::location;
+        using reg::segment;
         using reg::tagged;
         using reg::distal_interval;
         using reg::proximal_interval;
@@ -504,16 +518,12 @@ TEST(region, thingify_moderate_morphologies) {
         using reg::cable;
         using reg::complete;
 
-        auto soma = tagged(1);
         auto axon = tagged(2);
         auto dend = tagged(3);
         auto apic = tagged(4);
         auto b1  = branch(1);
         auto b3  = branch(3);
         auto b13 = join(b1, b3);
-
-        cl empty_{};
-        cl soma_ = empty_;
 
         // Whole branches:
         mcable b0_{0,0,1};
@@ -528,6 +538,10 @@ TEST(region, thingify_moderate_morphologies) {
         EXPECT_TRUE(region_eq(mp, apic, cl{b2_}));
         EXPECT_TRUE(region_eq(mp, join(dend, apic), cl{b0_,b2_,b3_}));
         EXPECT_TRUE(region_eq(mp, join(axon, join(dend, apic)), all_));
+
+        EXPECT_TRUE(region_eq(mp, tagged(2), join(segment(2), segment(3))));
+        EXPECT_TRUE(region_eq(mp, tagged(3), join(segment(0), segment(1), segment(5), segment(6))));
+        EXPECT_TRUE(region_eq(mp, tagged(4), segment(4)));
 
         // Test that intersection correctly generates zero-length cables at
         // parent-child interfaces.

--- a/test/unit/test_morph_stitch.cpp
+++ b/test/unit/test_morph_stitch.cpp
@@ -1,0 +1,236 @@
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+#include <arbor/morph/morphexcept.hpp>
+#include <arbor/morph/morphology.hpp>
+#include <arbor/morph/mprovider.hpp>
+#include <arbor/morph/place_pwlin.hpp>
+#include <arbor/morph/primitives.hpp>
+#include <arbor/morph/stitch.hpp>
+
+#include "../test/gtest.h"
+#include "morph_pred.hpp"
+
+using namespace arb;
+using testing::region_eq;
+
+TEST(morph, stitch_none_or_one) {
+    stitch_builder B;
+
+    stitched_morphology sm0(B);
+    EXPECT_TRUE(sm0.morphology().empty());
+
+    mpoint p1{1, 2, 3, 0.5}, p2{2, 4, 5, 1.};
+    B.add({"first", p1, p2, 3});
+
+    stitched_morphology sm1(std::move(B));
+    morphology m1 = sm1.morphology();
+
+    msegment seg0 = m1.branch_segments(0).front();
+    EXPECT_EQ(3, seg0.tag);
+    EXPECT_EQ(p1, seg0.prox);
+    EXPECT_EQ(p2, seg0.dist);
+
+    mprovider p(m1, sm1.labels("stitch:"));
+    EXPECT_TRUE(region_eq(p, "stitch:first", reg::segment(0)));
+}
+
+TEST(morph, stitch_two) {
+    {
+        // p1 ===== p2 ===== p3
+
+        mpoint p1{1, 2, 3, 0.5}, p2{2, 4, 5, 1.}, p3{3, 6, 7, 1.5};
+        stitch_builder B;
+
+        B.add({"0", p1, p2, 0})
+         .add({"1", p3, 1}, "0");
+
+        stitched_morphology sm(std::move(B));
+        morphology m = sm.morphology();
+
+        ASSERT_EQ(1u, m.num_branches());
+        ASSERT_EQ(2u, m.branch_segments(0).size());
+
+        msegment seg0 = m.branch_segments(0)[0];
+        msegment seg1 = m.branch_segments(0)[1];
+
+        EXPECT_EQ(p1, seg0.prox);
+        EXPECT_EQ(p2, seg0.dist);
+        EXPECT_EQ(p2, seg1.prox);
+        EXPECT_EQ(p3, seg1.dist);
+
+        mprovider p(m, sm.labels("stitch:"));
+        EXPECT_TRUE(region_eq(p, "stitch:0", reg::segment(0)));
+        EXPECT_TRUE(region_eq(p, "stitch:1", reg::segment(1)));
+    }
+    {
+        // p1 ===== p2
+        //  \.
+        //   \.
+        //    p3
+
+        mpoint p1{1, 2, 3, 0.5}, p2{2, 4, 5, 1.}, p3{3, 6, 7, 1.5};
+        stitch_builder B;
+
+        B.add({"0", p1, p2, 0})
+         .add({"1", p3, 1}, "0", 0);
+
+        stitched_morphology sm(std::move(B));
+        morphology m = sm.morphology();
+
+        ASSERT_EQ(2u, m.num_branches());
+        ASSERT_EQ(1u, m.branch_segments(0).size());
+        ASSERT_EQ(1u, m.branch_segments(1).size());
+
+        EXPECT_EQ(mnpos, m.branch_parent(0));
+        EXPECT_EQ(mnpos, m.branch_parent(1));
+
+        msegment seg0 = m.branch_segments(0)[0];
+        msegment seg1 = m.branch_segments(1)[0];
+
+        EXPECT_EQ(p1, seg0.prox);
+        EXPECT_EQ(p1, seg1.prox);
+
+        mprovider p(m, sm.labels("stitch:"));
+        // Branch ordering is arbitrary, so check both possibilities:
+        if (seg0.dist == p2) {
+            EXPECT_TRUE(region_eq(p, "stitch:0", reg::segment(0)));
+            EXPECT_TRUE(region_eq(p, "stitch:1", reg::segment(1)));
+        }
+        else {
+            ASSERT_EQ(p2, seg1.dist);
+            EXPECT_TRUE(region_eq(p, "stitch:0", reg::segment(1)));
+            EXPECT_TRUE(region_eq(p, "stitch:1", reg::segment(0)));
+        }
+    }
+    {
+        // p1 ==x== p2
+        //      \.
+        //       \.
+        //        p3
+
+        mpoint p1{1, 2, 3, 0.5}, p2{2, 4, 5, 1.}, p3{3, 6, 7, 1.5};
+        stitch_builder B;
+
+        B.add({"0", p1, p2, 0})
+         .add({"1", p3, 1}, "0", 0.5);
+
+        stitched_morphology sm(std::move(B));
+        morphology m = sm.morphology();
+
+        ASSERT_EQ(3u, m.num_branches());
+        ASSERT_EQ(1u, m.branch_segments(0).size());
+        ASSERT_EQ(1u, m.branch_segments(1).size());
+        ASSERT_EQ(1u, m.branch_segments(2).size());
+
+        msegment seg0 = m.branch_segments(0)[0];
+        msegment seg1 = m.branch_segments(1)[0];
+        msegment seg2 = m.branch_segments(2)[0];
+
+        EXPECT_EQ(p1, seg0.prox);
+        mpoint x = lerp(p1, p2, 0.5);
+        EXPECT_EQ(x, seg0.dist);
+
+        EXPECT_EQ(x, seg1.prox);
+        EXPECT_EQ(x, seg2.prox);
+
+        mprovider p(m, sm.labels("stitch:"));
+        // Branch ordering is arbitrary, so check both possibilities:
+        if (seg2.dist == p2) {
+            EXPECT_TRUE(region_eq(p, "stitch:0", join(reg::segment(0), reg::segment(2))));
+            EXPECT_TRUE(region_eq(p, "stitch:1", reg::segment(1)));
+        }
+        else {
+            ASSERT_EQ(p2, seg1.dist);
+            EXPECT_TRUE(region_eq(p, "stitch:0", join(reg::segment(0), reg::segment(1))));
+            EXPECT_TRUE(region_eq(p, "stitch:1", reg::segment(2)));
+        }
+    }
+}
+
+TEST(morph, stitch_errors) {
+    mpoint p1{1, 2, 3, 0.5}, p2{2, 4, 5, 1.}, p3{3, 6, 7, 1.5};
+    stitch_builder B;
+
+    B.add({"0", p1, p2, 0});
+    ASSERT_THROW(B.add({"0", p3, 0}, "0", 0.5), duplicate_stitch_id);
+    ASSERT_THROW(B.add({"1", p3, 0}, "x", 0.5), no_such_stitch);
+    ASSERT_THROW(B.add({"1", p3, 0}, "0", 1.5), invalid_stitch_position);
+
+    stitch_builder C;
+    ASSERT_THROW(C.add({"0", p1, 0}), missing_stitch_start);
+}
+
+TEST(morph, stitch_complex) {
+    //                p[8]
+    //                  |
+    // p[0]---x----x----x---p[1]---x---p[2]
+    //        |    |    |          |
+    //      p[3] p[4] p[5]--p[7]   p[6]
+
+    mpoint p[] = {
+        {0, 1, 0, 1.},
+        {4, 1, 0, 1.},
+        {6, 1, 0, 1.},
+        {1, 0, 0, 1.},
+        {2, 0, 0, 1.},
+        {3, 0, 0, 1.},
+        {5, 0, 0, 1.},
+        {4, 0, 0, 1.},
+        {3, 2, 0, 1.}
+    };
+
+    stitch_builder B;
+
+    // (labels chosen to reflect distal point)
+    B.add({"1", p[0], p[1]})
+     .add({"2", p[2]}, "1")
+     .add({"3", p[3]}, "1", 0.25)
+     .add({"4", p[4]}, "1", 0.50)
+     .add({"5", p[5]}, "1", 0.75)
+     .add({"6", p[6]}, "2", 0.50)
+     .add({"7", p[7]}, "5")
+     .add({"8", p[8]}, "1", 0.75);
+
+    stitched_morphology sm(std::move(B));
+    morphology m = sm.morphology();
+    mprovider P(m, sm.labels());
+
+    EXPECT_EQ(10u, m.num_branches());
+
+    EXPECT_EQ(4u, sm.segments("1").size());
+    EXPECT_EQ(2u, sm.segments("2").size());
+    EXPECT_EQ(1u, sm.segments("3").size());
+    EXPECT_EQ(1u, sm.segments("4").size());
+    EXPECT_EQ(1u, sm.segments("5").size());
+    EXPECT_EQ(1u, sm.segments("6").size());
+    EXPECT_EQ(1u, sm.segments("7").size());
+    EXPECT_EQ(1u, sm.segments("8").size());
+
+    auto region_prox_eq = [&P, place = place_pwlin(m)](region r, mpoint p) {
+        mlocation_list ls = thingify(ls::most_proximal(r), P);
+        if (ls.empty()) {
+            return ::testing::AssertionFailure() << "region " << r << " is empty";
+        }
+        else if (ls.size()>1u) {
+            return ::testing::AssertionFailure() << "region " << r << " has multiple proximal points";
+        }
+
+        mpoint prox = place.at(ls.front());
+        if (prox!=p) {
+            return ::testing::AssertionFailure() << "region " << r << " proximal point " << prox << " is not equal to " << p;
+        }
+
+        return ::testing::AssertionSuccess();
+    };
+
+    EXPECT_TRUE(region_prox_eq(sm.stitch("2"), p[1]));
+    EXPECT_TRUE(region_prox_eq(sm.stitch("3"), mpoint{1, 1, 0, 1.}));
+    EXPECT_TRUE(region_prox_eq(sm.stitch("4"), mpoint{2, 1, 0, 1.}));
+    EXPECT_TRUE(region_prox_eq(sm.stitch("5"), mpoint{3, 1, 0, 1.}));
+    EXPECT_TRUE(region_prox_eq(sm.stitch("6"), mpoint{5, 1, 0, 1.}));
+    EXPECT_TRUE(region_prox_eq(sm.stitch("7"), p[5]));
+    EXPECT_TRUE(region_prox_eq(sm.stitch("8"), mpoint{3, 1, 0, 1.}));
+}
+

--- a/test/unit/test_ordered_forest.cpp
+++ b/test/unit/test_ordered_forest.cpp
@@ -1,0 +1,513 @@
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+#include "../gtest.h"
+#include "util/ordered_forest.hpp"
+
+using arb::util::ordered_forest;
+
+namespace {
+template <typename T>
+struct simple_allocator {
+    using value_type = T;
+
+    simple_allocator():
+        n_alloc_(new std::size_t()),
+        n_dealloc_(new std::size_t())
+    {}
+
+    simple_allocator(const simple_allocator&) noexcept = default;
+
+    template <typename U>
+    simple_allocator(const simple_allocator<U>& other) noexcept {
+        n_alloc_ = other.n_alloc_;
+        n_dealloc_ = other.n_dealloc_;
+    }
+
+    T* allocate(std::size_t n) {
+        auto p = new T[n];
+        ++*n_alloc_;
+        return p;
+    }
+
+    void deallocate(T* p, std::size_t) {
+        delete [] p;
+        ++*n_dealloc_;
+    }
+
+    bool operator==(const simple_allocator& other) const {
+        return other.n_alloc_ == n_alloc_ && other.n_dealloc_ == n_dealloc_;
+    }
+
+    bool operator!=(const simple_allocator& other) const {
+        return !(*this==other);
+    }
+
+    using propagate_on_container_copy_assignment = std::false_type;
+    using propagate_on_container_move_assignment = std::false_type;
+    using propagate_on_container_swap = std::true_type;
+
+    void reset_counts() {
+        *n_alloc_ = 0;
+        *n_dealloc_ = 0;
+    }
+
+    std::size_t n_alloc() const { return *n_alloc_; }
+    std::size_t n_dealloc() const { return *n_dealloc_; }
+
+    std::shared_ptr<std::size_t> n_alloc_, n_dealloc_;
+};
+
+template <typename T, typename A>
+::testing::AssertionResult forest_invariant(const ordered_forest<T, A>& f) {
+    // check parent-child confluence:
+
+    for (auto i = f.root_begin(); i!=f.root_end(); ++i) {
+        if (i.parent()) {
+            return ::testing::AssertionFailure() << "root node " << *i << " has parent " << *i.parent();
+        }
+    }
+
+    for (auto i = f.begin(); i!=f.end(); ++i) {
+        auto cb = f.child_begin(i);
+        auto ce = f.child_end(i);
+
+        for (auto j = cb; j!=ce; ++j) {
+            if (j.parent() != i) {
+                auto failure = ::testing::AssertionFailure() << "child node " << *j << " of " << *i << " has parent ";
+                return j.parent()? (failure << *j.parent()): (failure << "(null)");
+            }
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
+
+} // anonymous namespace
+
+TEST(ordered_forest, empty) {
+    ordered_forest<int> f1;
+    EXPECT_EQ(0u, f1.size());
+    EXPECT_TRUE(f1.begin() == f1.end());
+
+    simple_allocator<int> alloc;
+    ASSERT_EQ(0u, alloc.n_alloc());
+    ASSERT_EQ(0u, alloc.n_dealloc());
+
+    ordered_forest<int, simple_allocator<int>> f2(alloc);
+    EXPECT_EQ(0u, alloc.n_alloc());
+    EXPECT_EQ(0u, alloc.n_dealloc());
+}
+
+TEST(ordered_forest, push) {
+    simple_allocator<int> alloc;
+
+    {
+        ordered_forest<int, simple_allocator<int>> f(alloc);
+
+        f.push_front(3);
+        auto i2 = f.push_front(2);
+        f.push_child(i2, 5);
+        f.push_child(i2, 4);
+        f.push_front(1);
+
+        ASSERT_TRUE(forest_invariant(f));
+
+        ASSERT_EQ(5u, f.size());
+        EXPECT_EQ(10u, alloc.n_alloc()); // five nodes, five items.
+
+        auto i = f.begin();
+        ASSERT_TRUE(i);
+        EXPECT_EQ(1, *i);
+        EXPECT_FALSE(i.child());
+
+        i = i.next();
+        ASSERT_TRUE(i);
+        auto j = i.child();
+        ASSERT_TRUE(j);
+        EXPECT_EQ(4, *j);
+        j = j.next();
+        ASSERT_TRUE(j);
+        EXPECT_EQ(5, *j);
+        EXPECT_FALSE(j.next());
+
+        i = i.next();
+        ASSERT_TRUE(i);
+        EXPECT_EQ(3, *i);
+        EXPECT_FALSE(i.child());
+        EXPECT_FALSE(i.next());
+    }
+
+    EXPECT_EQ(alloc.n_dealloc(), alloc.n_alloc());
+}
+
+TEST(ordered_forest, insert) {
+    simple_allocator<int> alloc;
+
+    {
+        ordered_forest<int, simple_allocator<int>> f(alloc);
+
+        auto r = f.push_front(1);
+        f.insert_after(r, 3);
+        r = f.insert_after(r, 2);
+        auto c = f.push_child(r, 4);
+        f.insert_after(c, 6);
+        f.insert_after(c, 5);
+
+        ASSERT_TRUE(forest_invariant(f));
+
+        ASSERT_EQ(6u, f.size());
+        EXPECT_EQ(12u, alloc.n_alloc()); // six nodes, six items.
+
+        auto i = f.begin();
+        ASSERT_TRUE(i);
+        EXPECT_EQ(1, *i);
+        EXPECT_FALSE(i.child());
+
+        i = i.next();
+        ASSERT_TRUE(i);
+        auto j = i.child();
+        ASSERT_TRUE(j);
+        EXPECT_EQ(4, *j);
+        j = j.next();
+        ASSERT_TRUE(j);
+        EXPECT_EQ(5, *j);
+        j = j.next();
+        ASSERT_TRUE(j);
+        EXPECT_EQ(6, *j);
+        EXPECT_FALSE(j.next());
+
+        i = i.next();
+        ASSERT_TRUE(i);
+        EXPECT_EQ(3, *i);
+        EXPECT_FALSE(i.child());
+        EXPECT_FALSE(i.next());
+    }
+
+    EXPECT_EQ(alloc.n_dealloc(), alloc.n_alloc());
+}
+
+TEST(ordered_forest, initializer_list) {
+    ordered_forest<int> f = {1, {2, {4, 5, 6}}, 3};
+    EXPECT_EQ(6u, f.size());
+
+    ASSERT_TRUE(forest_invariant(f));
+
+    auto i = f.begin();
+    ASSERT_TRUE(i);
+    EXPECT_EQ(1, *i);
+    EXPECT_FALSE(i.child());
+
+    i = i.next();
+    ASSERT_TRUE(i);
+    auto j = i.child();
+    ASSERT_TRUE(j);
+    EXPECT_EQ(4, *j);
+    j = j.next();
+    ASSERT_TRUE(j);
+    EXPECT_EQ(5, *j);
+    j = j.next();
+    ASSERT_TRUE(j);
+    EXPECT_EQ(6, *j);
+    EXPECT_FALSE(j.next());
+
+    i = i.next();
+    ASSERT_TRUE(i);
+    EXPECT_EQ(3, *i);
+    EXPECT_FALSE(i.child());
+    EXPECT_FALSE(i.next());
+}
+
+TEST(ordered_forest, equality) {
+    using of = ordered_forest<int>;
+
+    EXPECT_EQ(of{}, of{});
+    EXPECT_NE(of{1},  of{});
+    EXPECT_NE(of{},  of{1});
+
+    EXPECT_EQ((of{1, 2, 3}), (of{1, 2, 3}));
+    EXPECT_NE((of{1, 2, 3}),  (of{1, {2, {3}}}));
+    EXPECT_NE((of{{1, {2, 3}}}),  (of{1, 2, 3}));
+
+    struct always_eq {
+        int n_;
+        always_eq(int n): n_(n) {}
+        bool operator==(const always_eq&) const { return true; }
+        bool operator!=(const always_eq&) const { return false; }
+    };
+
+    ordered_forest<always_eq> f1 = {{1, {2, 3}}, {4, {5, {6, {7}}, 8}}, 9};
+    ordered_forest<always_eq> f2 = {{3, {1, 0}}, {2, {8, {6, {4}}, 7}}, 5};
+    EXPECT_EQ(f2, f1);
+
+    ordered_forest<always_eq> f3 = {{3, {{1, {0}}}}, {2, {8, {6, {4}}, 7}}, 5};
+    EXPECT_NE(f1, f3);
+}
+
+TEST(ordered_forest, iteration) {
+    using ivector = std::vector<int>;
+
+    ordered_forest<int> f = {{1, {2, 3}}, {4, {5, {6, {7}}, 8}}, 9};
+    const ordered_forest<int>& cf = f;
+
+    ivector pre{f.preorder_begin(), f.preorder_end()};
+    EXPECT_EQ((ivector{1, 2, 3, 4, 5, 6, 7, 8, 9}), pre);
+
+    ivector cpre{cf.preorder_begin(), cf.preorder_end()};
+    EXPECT_EQ((ivector{1, 2, 3, 4, 5, 6, 7, 8, 9}), cpre);
+
+    ivector pre_default{f.begin(), f.end()};
+    EXPECT_EQ((ivector{1, 2, 3, 4, 5, 6, 7, 8, 9}), pre_default);
+
+    ivector cpre_default{cf.begin(), cf.end()};
+    EXPECT_EQ((ivector{1, 2, 3, 4, 5, 6, 7, 8, 9}), cpre_default);
+
+    ivector pre_cdefault{f.cbegin(), f.cend()};
+    EXPECT_EQ((ivector{1, 2, 3, 4, 5, 6, 7, 8, 9}), pre_cdefault);
+
+    ivector root{f.root_begin(), f.root_end()};
+    EXPECT_EQ((ivector{1, 4, 9}), root);
+
+    ivector croot{cf.root_begin(), cf.root_end()};
+    EXPECT_EQ((ivector{1, 4, 9}), croot);
+
+    ivector post{f.postorder_begin(), f.postorder_end()};
+    EXPECT_EQ((ivector{2, 3, 1, 5, 7, 6, 8, 4, 9}), post);
+
+    ivector cpost{cf.postorder_begin(), cf.postorder_end()};
+    EXPECT_EQ((ivector{2, 3, 1, 5, 7, 6, 8, 4, 9}), cpost);
+
+    auto four = std::find(f.begin(), f.end(), 4);
+    ivector child_four{f.child_begin(four), f.child_end(four)};
+    EXPECT_EQ((ivector{5, 6, 8}), child_four);
+
+    ivector cchild_four{cf.child_begin(four), cf.child_end(four)};
+    EXPECT_EQ((ivector{5, 6, 8}), cchild_four);
+
+    using preorder_iterator = ordered_forest<int>::preorder_iterator;
+    using postorder_iterator = ordered_forest<int>::postorder_iterator;
+
+    ivector pre_four{preorder_iterator(four), preorder_iterator(four.next())};
+    EXPECT_EQ((ivector{4, 5, 6, 7, 8}), pre_four);
+
+    auto seven = std::find(f.begin(), f.end(), 7);
+    auto nine = std::find(f.begin(), f.end(), 9);
+    ivector post_seven_nine{postorder_iterator(seven), postorder_iterator(nine)};
+    EXPECT_EQ((ivector{7, 6, 8, 4}), post_seven_nine);
+}
+
+TEST(ordered_forest, copy_move) {
+    simple_allocator<int> alloc;
+
+    using ivector = std::vector<int>;
+    using of = ordered_forest<int, simple_allocator<int>>;
+
+    of f1(alloc);
+    {
+        of f({{1, {2, 3}}, {4, {5, {6, {7}}, 8}}, 9}, alloc);
+        EXPECT_EQ(18u, alloc.n_alloc());
+        ASSERT_TRUE(forest_invariant(f));
+
+        f1 = f;
+        ASSERT_TRUE(forest_invariant(f1));
+        EXPECT_EQ(36u, alloc.n_alloc());
+        EXPECT_FALSE(f.empty());
+
+        of f2 = std::move(f);
+        ASSERT_TRUE(forest_invariant(f2));
+        EXPECT_EQ(36u, alloc.n_alloc());
+        EXPECT_TRUE(f.empty());
+
+        ivector elems2{f2.begin(), f2.end()};
+        EXPECT_EQ((ivector{1, 2, 3, 4, 5, 6, 7, 8, 9}), elems2);
+    }
+
+    EXPECT_EQ(36u, alloc.n_alloc());
+    EXPECT_EQ(18u, alloc.n_dealloc());
+
+    ivector elems1{f1.begin(), f1.end()};
+    EXPECT_EQ((ivector{1, 2, 3, 4, 5, 6, 7, 8, 9}), elems1);
+
+    // With a different != allocator object, require move assignment
+    // to perform copy.
+
+    simple_allocator<int> other_alloc;
+    ASSERT_NE(alloc, other_alloc);
+    ASSERT_FALSE(std::allocator_traits<simple_allocator<int>>::propagate_on_container_move_assignment::value);
+
+    of f3(other_alloc);
+
+    f3 = std::move(f1);
+    ASSERT_TRUE(forest_invariant(f3));
+    EXPECT_FALSE(f1.empty());
+
+    EXPECT_EQ(36u, alloc.n_alloc());
+    EXPECT_EQ(18u, alloc.n_dealloc());
+    EXPECT_EQ(18u, other_alloc.n_alloc());
+    EXPECT_EQ(0u, other_alloc.n_dealloc());
+}
+
+TEST(ordered_forest, erase) {
+    simple_allocator<int> alloc;
+    using of = ordered_forest<int, simple_allocator<int>>;
+
+    of f({1, 2, {3, {4, {5, {6, 7}}, 8}}, 9}, alloc);
+    ASSERT_TRUE(forest_invariant(f));
+    EXPECT_EQ(18u, alloc.n_alloc());
+
+    auto two = std::find(f.begin(), f.end(), 2);
+    f.erase_after(two);
+
+    ASSERT_TRUE(forest_invariant(f));
+    EXPECT_EQ((of{1, 2, 4, {5, {6, 7}}, 8, 9}), f);
+    EXPECT_EQ(2u, alloc.n_dealloc());
+
+    auto five = std::find(f.begin(), f.end(), 5);
+    f.erase_child(five);
+
+    ASSERT_TRUE(forest_invariant(f));
+    EXPECT_EQ((of{1, 2, 4, {5, {7}}, 8, 9}), f);
+    EXPECT_EQ(4u, alloc.n_dealloc());
+
+    auto eight = std::find(f.begin(), f.end(), 8);
+    ASSERT_THROW(f.erase_child(eight), std::invalid_argument);
+
+    auto seven = std::find(f.begin(), f.end(), 7);
+    ASSERT_THROW(f.erase_after(seven), std::invalid_argument);
+
+    f.erase_front();
+    ASSERT_TRUE(forest_invariant(f));
+    EXPECT_EQ((of{2, 4, {5, {7}}, 8, 9}), f);
+    EXPECT_EQ(6u, alloc.n_dealloc());
+
+    of empty;
+    ASSERT_THROW(empty.erase_front(), std::invalid_argument);
+}
+
+TEST(ordered_forest, prune) {
+    simple_allocator<int> alloc;
+    using of = ordered_forest<int, simple_allocator<int>>;
+
+    of f({1, 2, {3, {4, {5, {6, 7}}, 8}}, 9}, alloc);
+    ASSERT_TRUE(forest_invariant(f));
+    EXPECT_EQ(18u, alloc.n_alloc());
+    EXPECT_EQ(0u, alloc.n_dealloc());
+
+    of p1 = f.prune_front();
+    ASSERT_TRUE(forest_invariant(f));
+    ASSERT_TRUE(forest_invariant(p1));
+    EXPECT_EQ((of{2, {3, {4, {5, {6, 7}}, 8}}, 9}), f);
+    EXPECT_EQ((of{1}), p1);
+
+    of p2 = f.prune_after(std::find(f.begin(), f.end(), 4));
+    ASSERT_TRUE(forest_invariant(f));
+    ASSERT_TRUE(forest_invariant(p2));
+    EXPECT_EQ((of{2, {3, {4, 8}}, 9}), f);
+    EXPECT_EQ((of{{5, {6, 7}}}), p2);
+
+    of p3 = f.prune_child(std::find(f.begin(), f.end(), 3));
+    ASSERT_TRUE(forest_invariant(f));
+    ASSERT_TRUE(forest_invariant(p3));
+    EXPECT_EQ((of{2, {3, {8}}, 9}), f);
+    EXPECT_EQ((of{4}), p3);
+
+    EXPECT_EQ(0u, alloc.n_dealloc());
+    EXPECT_EQ(f.get_allocator(), p1.get_allocator());
+    EXPECT_EQ(f.get_allocator(), p2.get_allocator());
+    EXPECT_EQ(f.get_allocator(), p3.get_allocator());
+
+    of empty;
+    ASSERT_THROW(empty.erase_child(empty.begin()), std::invalid_argument);
+    ASSERT_THROW(empty.erase_after(empty.begin()), std::invalid_argument);
+    ASSERT_THROW(empty.erase_front(), std::invalid_argument);
+
+    of unit{1};
+    ASSERT_THROW(unit.erase_child(unit.begin()), std::invalid_argument);
+    ASSERT_THROW(unit.erase_after(unit.begin()), std::invalid_argument);
+}
+
+TEST(ordered_forest, graft) {
+    using of = ordered_forest<int, simple_allocator<int>>;
+
+    of f1{1, {2, {3, 4}}, 5};
+    auto j = f1.graft_after(f1.begin(), of{6, {7, {8}}});
+
+    ASSERT_TRUE(j);
+    ASSERT_TRUE(forest_invariant(f1));
+    EXPECT_EQ(7, *j);
+    EXPECT_EQ((of{1, 6, {7, {8}}, {2, {3, 4}}, 5}), f1);
+
+    j = f1.graft_child(std::find(f1.begin(), f1.end(), 2), of{9, 10});
+
+    ASSERT_TRUE(j);
+    ASSERT_TRUE(forest_invariant(f1));
+    EXPECT_EQ(10, *j);
+    EXPECT_EQ((of{1, 6, {7, {8}}, {2, {9, 10, 3, 4}}, 5}), f1);
+
+    j = f1.graft_front(of{{11, {12, 13}}});
+
+    ASSERT_TRUE(j);
+    ASSERT_TRUE(forest_invariant(f1));
+    EXPECT_EQ(11, *j);
+    EXPECT_EQ((of{{11, {12, 13}}, 1, 6, {7, {8}}, {2, {9, 10, 3, 4}}, 5}), f1);
+
+    simple_allocator<int> alloc1, alloc2;
+    of f2({1, 2}, alloc1);
+    of f3({3, 4}, alloc1);
+    of f4({5, 6}, alloc2);
+
+    ASSERT_TRUE(forest_invariant(f2));
+    ASSERT_TRUE(forest_invariant(f3));
+    ASSERT_TRUE(forest_invariant(f4));
+
+    EXPECT_EQ(8u, alloc1.n_alloc());
+    EXPECT_EQ(0u, alloc1.n_dealloc());
+    EXPECT_EQ(4u, alloc2.n_alloc());
+
+    f2.graft_front(std::move(f3));
+    ASSERT_TRUE(forest_invariant(f2));
+    ASSERT_TRUE(forest_invariant(f3));
+    EXPECT_EQ(8u, alloc1.n_alloc());
+    EXPECT_EQ(0u, alloc1.n_dealloc());
+
+    f2.graft_front(std::move(f4));
+    ASSERT_TRUE(forest_invariant(f2));
+    ASSERT_TRUE(forest_invariant(f4));
+    EXPECT_EQ(12u, alloc1.n_alloc());
+    EXPECT_EQ(0u, alloc1.n_dealloc());
+    EXPECT_EQ(4u, alloc2.n_dealloc());
+
+    EXPECT_EQ((of{5, 6, 3, 4, 1, 2}), f2);
+}
+
+TEST(ordered_forest, swap) {
+    simple_allocator<int> alloc1, alloc2;
+    using of = ordered_forest<int, simple_allocator<int>>;
+
+    of a({1, {2, {3, 4}}, 5}, alloc1);
+    of b({6, 7, 8, 9}, alloc2);
+
+    of a_copy(a), b_copy(b);
+
+    ASSERT_TRUE(forest_invariant(a));
+    ASSERT_TRUE(forest_invariant(b));
+    ASSERT_TRUE(forest_invariant(a_copy));
+    ASSERT_TRUE(forest_invariant(b_copy));
+
+    ASSERT_EQ(alloc1, a.get_allocator());
+    ASSERT_EQ(alloc2, b.get_allocator());
+    ASSERT_EQ(alloc1, a_copy.get_allocator());
+    ASSERT_EQ(alloc2, b_copy.get_allocator());
+    ASSERT_EQ(a_copy, a);
+    ASSERT_EQ(b_copy, b);
+
+    swap(a, b);
+
+    ASSERT_TRUE(forest_invariant(a));
+    ASSERT_TRUE(forest_invariant(b));
+    EXPECT_EQ(alloc2, a.get_allocator());
+    EXPECT_EQ(alloc1, b.get_allocator());
+    EXPECT_EQ(b_copy, a);
+    EXPECT_EQ(a_copy, b);
+}


### PR DESCRIPTION
New PR post master rollback; squashed and rebased, but reprises #1111.

* Add (forward) ordered forest implementation, tests.
* Add `segment` region expression; to ease implementation, `msegment` now also knows its own id.
* Add `stitch_builder` and `stitched_morphology`. A stitch corresponds to a labelled, linearly-interpolated segment which can be attached at any point along a parent stitch. A `stitched_morphology` takes a `stitch_builder` object and constructs a segment tree and morphology, and provides a dictionary of stitch labels to segment indices and region expressions.
* Add `import` method for `label_dict`, so that the label dictionary returned by `stitched_morphology` can be merged with an existing dictionary.
* Add section on stitch builder etc. to cable cell docs.
* Update cable cell docs to remove out of date info and to provide some context.
* Describe ordered forest datastructure and interface in a long comment at the beginning of the header file.