### PR TITLE
remove arb::util::either from Python interface

### DIFF
--- a/python/s_expr.cpp
+++ b/python/s_expr.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include <cctype>
 #include <cstring>
 #include <string>
@@ -298,32 +296,26 @@ bool test_identifier(const char* in) {
 //
 
 bool s_expr::is_atom() const {
-    std::cout << "testing atom\n";
     return state.index()==0;
 }
 
 const token& s_expr::atom() const {
-    std::cout << "testing atom\n";
     return state.get<0>();
 }
 
 const s_expr& s_expr::head() const {
-    std::cout << "getting head\n";
     return state.get<1>().head.get();
 }
 
 const s_expr& s_expr::tail() const {
-    std::cout << "getting tail\n";
     return state.get<1>().tail.get();
 }
 
 s_expr& s_expr::head() {
-    std::cout << "getting head\n";
     return state.get<1>().head.get();
 }
 
 s_expr& s_expr::tail() {
-    std::cout << "getting tail\n";
     return state.get<1>().tail.get();
 }
 
@@ -367,9 +359,7 @@ s_expr parse(lexer& L) {
     using namespace std::string_literals;
 
     s_expr node;
-    std::cout << "STARTING: " << node << std::endl;
     auto t = L.current();
-    std::cout << "da lexah is priiiiiiimed" << std::endl;
 
     if (t.kind==tok::lparen) {
         t = L.next();
@@ -403,7 +393,6 @@ s_expr parse(lexer& L) {
         return token{t.column, tok::error, "Missing opening parenthesis'('."};;
     }
 
-    std::cout << "FINISHED: " << node << std::endl;
     return node;
 }
 

--- a/python/s_expr.cpp
+++ b/python/s_expr.cpp
@@ -7,8 +7,8 @@
 #include <ostream>
 #include <vector>
 
-#include <arbor/util/either.hpp>
 #include <arbor/arbexcept.hpp>
+#include <arbor/util/variant.hpp>
 
 #include "s_expr.hpp"
 #include "strprintf.hpp"
@@ -298,26 +298,32 @@ bool test_identifier(const char* in) {
 //
 
 bool s_expr::is_atom() const {
-    return (bool)state;
+    std::cout << "testing atom\n";
+    return state.index()==0;
 }
 
 const token& s_expr::atom() const {
+    std::cout << "testing atom\n";
     return state.get<0>();
 }
 
 const s_expr& s_expr::head() const {
+    std::cout << "getting head\n";
     return state.get<1>().head.get();
 }
 
 const s_expr& s_expr::tail() const {
+    std::cout << "getting tail\n";
     return state.get<1>().tail.get();
 }
 
 s_expr& s_expr::head() {
+    std::cout << "getting head\n";
     return state.get<1>().head.get();
 }
 
 s_expr& s_expr::tail() {
+    std::cout << "getting tail\n";
     return state.get<1>().tail.get();
 }
 
@@ -361,7 +367,9 @@ s_expr parse(lexer& L) {
     using namespace std::string_literals;
 
     s_expr node;
+    std::cout << "STARTING: " << node << std::endl;
     auto t = L.current();
+    std::cout << "da lexah is priiiiiiimed" << std::endl;
 
     if (t.kind==tok::lparen) {
         t = L.next();
@@ -395,6 +403,7 @@ s_expr parse(lexer& L) {
         return token{t.column, tok::error, "Missing opening parenthesis'('."};;
     }
 
+    std::cout << "FINISHED: " << node << std::endl;
     return node;
 }
 

--- a/python/s_expr.hpp
+++ b/python/s_expr.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include <arbor/util/either.hpp>
-#include <arbor/util/optional.hpp>
+#include <arbor/util/variant.hpp>
 
 namespace pyarb {
 
@@ -85,12 +85,12 @@ struct s_expr {
     // An s_expr can be one of
     //      1. an atom
     //      2. a pair of s_expr (head and tail)
-    // The s_expr uses a util::either to represent these two possible states,
-    // which requires using an incomplete definition of s_expr, requiring
-    // with a std::shared_ptr.
+    // The s_expr uses a util::variant to represent these two possible states,
+    // which requires using an incomplete definition of s_expr, which is stored
+    // using a std::unique_ptr.
 
     using pair_type = s_pair<value_wrapper<s_expr>>;
-    arb::util::either<token, pair_type> state = token{-1, tok::nil, "nil"};
+    arb::util::variant<token, pair_type> state = token{-1, tok::nil, "nil"};
 
     s_expr(const s_expr& s): state(s.state) {}
     s_expr() = default;

--- a/python/strprintf.hpp
+++ b/python/strprintf.hpp
@@ -13,8 +13,6 @@
 
 #include <arbor/util/optional.hpp>
 
-#include "s_expr.hpp"
-
 namespace pyarb {
 namespace util {
 


### PR DESCRIPTION
Switch `arb::util::either` to `arb::util::variant` in the Python wrapper.

Fixes #1133 