### PR TITLE
Sanitize recipe

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -58,10 +58,10 @@ gj_unsupported_domain_decomposition::gj_unsupported_domain_decomposition(cell_gi
 {}
 
 gj_connection_mismatch::gj_connection_mismatch(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1):
-        arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites must be on the cell with gid = {})", gid, site_0, site_1, gid)),
-        gid(gid),
-        site_0(site_0),
-        site_1(site_1)
+    arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites must be on the cell with gid = {})", gid, site_0.gid, site_0.index, site_1.gid, site_1.index, gid)),
+    gid(gid),
+    site_0(site_0),
+    site_1(site_1)
 {}
 
 bad_gj_connection::bad_gj_connection(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1):

--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -15,30 +15,34 @@ bad_cell_description::bad_cell_description(cell_kind kind, cell_gid_type gid):
     gid(gid),
     kind(kind)
 {}
-
 bad_target_description::bad_target_description(cell_gid_type gid, cell_size_type rec_val, cell_size_type cell_val):
-    arbor_exception(pprintf("recipe::num_targets(gid={}) -> {} does not match the number of synapses on the cell -> {})", gid, rec_val, cell_val)),
+    arbor_exception(pprintf("Model building error on cell {}: recipe::num_targets(gid={}) = {} is greater than the number of synapses on the cell = {}", gid, gid, rec_val, cell_val)),
     gid(gid), rec_val(rec_val), cell_val(cell_val)
 {}
 
 bad_source_description::bad_source_description(cell_gid_type gid, cell_size_type rec_val, cell_size_type cell_val):
-    arbor_exception(pprintf("recipe::num_sources(gid={}) -> {} does not match the number of threshold detectors on the cell -> {})", gid, rec_val, cell_val)),
+    arbor_exception(pprintf("Model building error on cell {}: recipe::num_sources(gid={}) = {} is greater than the number of detectors on the cell = {}", gid, gid, rec_val, cell_val)),
     gid(gid), rec_val(rec_val), cell_val(cell_val)
 {}
 
-bad_connection_source::bad_connection_source(cell_gid_type gid, cell_member_type source):
-    arbor_exception(pprintf("recipe::connections_on(gid={}): source ({}, {}) does not exist)", gid, source.gid, source.index)),
-    gid(gid), source(source)
+bad_connection_source_gid::bad_connection_source_gid(cell_gid_type gid, cell_gid_type src_gid, cell_size_type num_cells):
+    arbor_exception(pprintf("Model building error on cell {}: connection source gid {} is out of range: there are only {} cells in the model, in the range [{}:{}].", gid, src_gid, num_cells, 0, num_cells-1)),
+    gid(gid), src_gid(src_gid), num_cells(num_cells)
 {}
 
-bad_connection_target::bad_connection_target(cell_gid_type gid, cell_member_type target):
-    arbor_exception(pprintf("recipe::connections_on(gid={}): target ({}, {}) does not exist)", gid, target.gid, target.index)),
-    gid(gid), target(target)
+bad_connection_source_lid::bad_connection_source_lid(cell_gid_type gid, cell_lid_type src_lid, cell_size_type num_sources):
+    arbor_exception(pprintf("Model building error on cell {}: connection source index {} is out of range. Cell {} has {} sources, in the range [{}:{}].", gid, src_lid, gid, num_sources, 0, num_sources-1)),
+    gid(gid), src_lid(src_lid), num_sources(num_sources)
 {}
 
-connection_target_mismatch::connection_target_mismatch(cell_gid_type gid, cell_member_type target):
-arbor_exception(pprintf("recipe::connections_on(gid={}): target ({}, {}) must be on the cell with gid = {})", gid, target.gid, target.index, gid)),
-gid(gid), target(target)
+bad_connection_target_gid::bad_connection_target_gid(cell_gid_type gid, cell_gid_type tgt_gid):
+    arbor_exception(pprintf("Model building error on cell {}: connection target gid {} has to match cell gid {}].", gid, tgt_gid, gid)),
+    gid(gid), tgt_gid(tgt_gid)
+{}
+
+bad_connection_target_lid::bad_connection_target_lid(cell_gid_type gid, cell_lid_type tgt_lid, cell_size_type num_targets):
+    arbor_exception(pprintf("Model building error on cell {}: connection target index {} is out of range. Cell {} has {} targets, in the range [{}:{}].", gid, tgt_lid, gid, num_targets, 0, num_targets-1)),
+    gid(gid), tgt_lid(tgt_lid), num_targets(num_targets)
 {}
 
 bad_global_property::bad_global_property(cell_kind kind):
@@ -57,18 +61,17 @@ gj_unsupported_domain_decomposition::gj_unsupported_domain_decomposition(cell_gi
     gid_1(gid_1)
 {}
 
-gj_connection_mismatch::gj_connection_mismatch(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1):
-    arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites must be on the cell with gid = {})", gid, site_0.gid, site_0.index, site_1.gid, site_1.index, gid)),
+bad_gj_connection_gid::bad_gj_connection_gid(cell_gid_type gid, cell_gid_type site_0, cell_gid_type site_1):
+    arbor_exception(pprintf("Model building error on cell {}: recipe::gap_junctions_on(gid={}) -> cell {} <-> cell{}: one of the sites must be on the cell with gid = {})", gid, gid, site_0, site_1, gid)),
     gid(gid),
     site_0(site_0),
     site_1(site_1)
 {}
 
-bad_gj_connection::bad_gj_connection(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1):
-    arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites does not exist)", gid, site_0.gid, site_0.index, site_1.gid, site_1.index)),
+bad_gj_connection_lid::bad_gj_connection_lid(cell_gid_type gid, cell_member_type site):
+    arbor_exception(pprintf("Model building error on cell {}: gap junction index {} on cell {} does not exist)", gid, site.gid, site.index)),
     gid(gid),
-    site_0(site_0),
-    site_1(site_1)
+    site(site)
 {}
 
 gj_kind_mismatch::gj_kind_mismatch(cell_gid_type gid_0, cell_gid_type gid_1):

--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -16,6 +16,31 @@ bad_cell_description::bad_cell_description(cell_kind kind, cell_gid_type gid):
     kind(kind)
 {}
 
+bad_target_description::bad_target_description(cell_gid_type gid, cell_size_type rec_val, cell_size_type cell_val):
+    arbor_exception(pprintf("recipe::num_targets(gid={}) -> {} does not match the number of synapses on the cell -> {})", gid, rec_val, cell_val)),
+    gid(gid), rec_val(rec_val), cell_val(cell_val)
+{}
+
+bad_source_description::bad_source_description(cell_gid_type gid, cell_size_type rec_val, cell_size_type cell_val):
+    arbor_exception(pprintf("recipe::num_source(gid={}) -> {} does not match the number of threshold detectors on the cell -> {})", gid, rec_val, cell_val)),
+    gid(gid), rec_val(rec_val), cell_val(cell_val)
+{}
+
+bad_connection_source::bad_connection_source(cell_gid_type gid, cell_member_type source):
+    arbor_exception(pprintf("recipe::connections_on(gid={}): source ({}, {}) does not exist)", gid, source.gid, source.index)),
+    gid(gid), source(source)
+{}
+
+bad_connection_target::bad_connection_target(cell_gid_type gid, cell_member_type target):
+    arbor_exception(pprintf("recipe::connections_on(gid={}): target ({}, {}) does not exist)", gid, target.gid, target.index)),
+    gid(gid), target(target)
+{}
+
+connection_target_mismatch::connection_target_mismatch(cell_gid_type gid, cell_member_type target):
+arbor_exception(pprintf("recipe::connections_on(gid={}): target ({}, {}) must be on the cell with gid = {})", gid, target.gid, target.index, gid)),
+gid(gid), target(target)
+{}
+
 bad_global_property::bad_global_property(cell_kind kind):
     arbor_exception(pprintf("bad global property for cell kind {}", kind)),
     kind(kind)
@@ -30,6 +55,20 @@ gj_unsupported_domain_decomposition::gj_unsupported_domain_decomposition(cell_gi
     arbor_exception(pprintf("No support for gap junctions across domain decomposition groups for gid {} and {}", gid_0, gid_1)),
     gid_0(gid_0),
     gid_1(gid_1)
+{}
+
+gj_connection_mismatch::gj_connection_mismatch(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1):
+        arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites must be on the cell with gid = {})", gid, site_0, site_1, gid)),
+        gid(gid),
+        site_0(site_0),
+        site_1(site_1)
+{}
+
+bad_gj_connection::bad_gj_connection(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1):
+    arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites' does not exist)", gid, site_0.gid, site_0.index, site_1.gid, site_1.index)),
+    gid(gid),
+    site_0(site_0),
+    site_1(site_1)
 {}
 
 gj_kind_mismatch::gj_kind_mismatch(cell_gid_type gid_0, cell_gid_type gid_1):

--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -22,7 +22,7 @@ bad_target_description::bad_target_description(cell_gid_type gid, cell_size_type
 {}
 
 bad_source_description::bad_source_description(cell_gid_type gid, cell_size_type rec_val, cell_size_type cell_val):
-    arbor_exception(pprintf("recipe::num_source(gid={}) -> {} does not match the number of threshold detectors on the cell -> {})", gid, rec_val, cell_val)),
+    arbor_exception(pprintf("recipe::num_sources(gid={}) -> {} does not match the number of threshold detectors on the cell -> {})", gid, rec_val, cell_val)),
     gid(gid), rec_val(rec_val), cell_val(cell_val)
 {}
 
@@ -65,7 +65,7 @@ gj_connection_mismatch::gj_connection_mismatch(cell_gid_type gid, cell_member_ty
 {}
 
 bad_gj_connection::bad_gj_connection(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1):
-    arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites' does not exist)", gid, site_0.gid, site_0.index, site_1.gid, site_1.index)),
+    arbor_exception(pprintf("recipe::gap_junctions_on(gid={}) -> ({}, {}) <-> ({}, {}): one of the sites does not exist)", gid, site_0.gid, site_0.index, site_1.gid, site_1.index)),
     gid(gid),
     site_0(site_0),
     site_1(site_1)

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -33,7 +33,12 @@ communicator::communicator(const recipe& rec,
     num_domains_ = distributed_->size();
     num_local_groups_ = dom_dec.groups.size();
     num_local_cells_ = dom_dec.num_local_cells;
+
+    std::vector<cell_size_type> cell_num_sources;
     auto num_total_cells = rec.num_cells();
+    for (auto gid: util::make_span(num_total_cells)) {
+        cell_num_sources.push_back(rec.num_sources(gid));
+    }
 
     // For caching information about each cell
     struct gid_info {
@@ -95,7 +100,7 @@ communicator::communicator(const recipe& rec,
     for (const auto& cell: gid_infos) {
         auto num_targets = rec.num_targets(cell.gid);
         for (auto c: cell.conns) {
-            auto num_sources = rec.num_sources(c.source.index);
+            auto num_sources = cell_num_sources[c.source.gid];
             if (c.source.gid >= num_total_cells || c.source.index >= num_sources) {
                 throw arb::bad_connection_source(cell.gid, c.source);
             }

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -538,19 +538,13 @@ void fvm_lowered_cell_impl<Backend>::initialize(
         cell_gid_type gid = gids[cell_idx];
 
         // Sanity check recipe
-        auto rec_sources = rec.num_sources(gid);
-        auto rec_targets = rec.num_targets(gid);
-        auto cell_sources = cells[cell_idx].detectors().size();
-        unsigned cell_targets = 0;
-        for (auto syn : cells[cell_idx].synapses()) {
-            cell_targets += syn.second.size();
+        auto& cell = cells[cell_idx];
+        if (rec.num_sources(gid) > cell.detectors().size()) {
+            throw arb::bad_source_description(gid, rec.num_sources(gid), cell.detectors().size());;
         }
-
-        if (rec_sources != cell_sources) {
-            throw arb::bad_source_description(gid, rec_sources, cell_sources);
-        }
-        if (rec_targets != cell_targets) {
-            throw arb::bad_target_description(gid, rec_targets, cell_targets);
+        auto cell_targets = util::sum_by(cell.synapses(), [](auto& syn) {return syn.second.size();});
+        if (cell_targets > rec.num_targets(gid)) {
+            throw arb::bad_target_description(gid, rec.num_targets(gid), cell_targets);
         }
 
         // Collect detectors, probe handles.
@@ -607,16 +601,16 @@ std::vector<fvm_gap_junction> fvm_lowered_cell_impl<Backend>::fvm_gap_junctions(
         auto gj_list = rec.gap_junctions_on(gid);
         for (auto g: gj_list) {
             if (gid != g.local.gid && gid != g.peer.gid) {
-                throw arb::gj_connection_mismatch(gid, g.local, g.peer);
+                throw arb::bad_gj_connection_gid(gid, g.local.gid, g.peer.gid);
             }
-            cell_gid_type cv0, cv1;
-            try {
-                cv0 = gid_to_cvs[g.local.gid].at(g.local.index);
-                cv1 = gid_to_cvs[g.peer.gid].at(g.peer.index);
+            if (g.local.index >= gid_to_cvs[g.local.gid].size()) {
+                throw arb::bad_gj_connection_lid(gid, g.local);
             }
-            catch (std::out_of_range&) {
-                throw arb::bad_gj_connection(gid, g.local, g.peer);
+            if (g.peer.index >= gid_to_cvs[g.peer.gid].size()) {
+                throw arb::bad_gj_connection_lid(gid, g.peer);
             }
+            auto cv0 = gid_to_cvs[g.local.gid][g.local.index];
+            auto cv1 = gid_to_cvs[g.peer.gid][g.peer.index];
             if (gid != g.local.gid) {
                 std::swap(cv0, cv1);
             }

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -47,22 +47,29 @@ struct bad_source_description: arbor_exception {
     cell_size_type rec_val, cell_val;
 };
 
-struct bad_connection_source: arbor_exception {
-    bad_connection_source(cell_gid_type gid, cell_member_type source);
-    cell_gid_type gid;
-    cell_member_type source;
+struct bad_connection_source_gid: arbor_exception {
+    bad_connection_source_gid(cell_gid_type gid, cell_gid_type src_gid, cell_size_type num_cells);
+    cell_gid_type gid, src_gid;
+    cell_size_type num_cells;
 };
 
-struct bad_connection_target: arbor_exception {
-    bad_connection_target(cell_gid_type gid, cell_member_type target);
+struct bad_connection_source_lid: arbor_exception {
+    bad_connection_source_lid(cell_gid_type gid, cell_lid_type src_lid, cell_size_type num_sources);
     cell_gid_type gid;
-    cell_member_type target;
+    cell_lid_type src_lid;
+    cell_size_type num_sources;
 };
 
-struct connection_target_mismatch: arbor_exception {
-    connection_target_mismatch(cell_gid_type gid, cell_member_type target);
+struct bad_connection_target_gid: arbor_exception {
+    bad_connection_target_gid(cell_gid_type gid, cell_gid_type tgt_gid);
+    cell_gid_type gid, tgt_gid;
+};
+
+struct bad_connection_target_lid: arbor_exception {
+    bad_connection_target_lid(cell_gid_type gid, cell_lid_type tgt_lid, cell_size_type num_targets);
     cell_gid_type gid;
-    cell_member_type target;
+    cell_lid_type tgt_lid;
+    cell_size_type num_targets;
 };
 
 struct bad_global_property: arbor_exception {
@@ -80,16 +87,15 @@ struct gj_kind_mismatch: arbor_exception {
     cell_gid_type gid_0, gid_1;
 };
 
-struct gj_connection_mismatch: arbor_exception {
-    gj_connection_mismatch(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1);
-    cell_gid_type gid;
-    cell_member_type site_0, site_1;
+struct bad_gj_connection_gid: arbor_exception {
+    bad_gj_connection_gid(cell_gid_type gid, cell_gid_type site_0, cell_gid_type site_1);
+    cell_gid_type gid, site_0, site_1;
 };
 
-struct bad_gj_connection: arbor_exception {
-    bad_gj_connection(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1);
+struct bad_gj_connection_lid: arbor_exception {
+    bad_gj_connection_lid(cell_gid_type gid, cell_member_type site);
     cell_gid_type gid;
-    cell_member_type site_0, site_1;
+    cell_member_type site;
 };
 
 // Domain decomposition errors:

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -35,6 +35,36 @@ struct bad_cell_description: arbor_exception {
     cell_kind kind;
 };
 
+struct bad_target_description: arbor_exception {
+    bad_target_description(cell_gid_type gid, cell_size_type rec_val, cell_size_type cell_val);
+    cell_gid_type gid;
+    cell_size_type rec_val, cell_val;
+};
+
+struct bad_source_description: arbor_exception {
+    bad_source_description(cell_gid_type gid, cell_size_type rec_val, cell_size_type cell_val);
+    cell_gid_type gid;
+    cell_size_type rec_val, cell_val;
+};
+
+struct bad_connection_source: arbor_exception {
+    bad_connection_source(cell_gid_type gid, cell_member_type source);
+    cell_gid_type gid;
+    cell_member_type source;
+};
+
+struct bad_connection_target: arbor_exception {
+    bad_connection_target(cell_gid_type gid, cell_member_type target);
+    cell_gid_type gid;
+    cell_member_type target;
+};
+
+struct connection_target_mismatch: arbor_exception {
+    connection_target_mismatch(cell_gid_type gid, cell_member_type target);
+    cell_gid_type gid;
+    cell_member_type target;
+};
+
 struct bad_global_property: arbor_exception {
     explicit bad_global_property(cell_kind kind);
     cell_kind kind;
@@ -48,6 +78,18 @@ struct bad_probe_id: arbor_exception {
 struct gj_kind_mismatch: arbor_exception {
     gj_kind_mismatch(cell_gid_type gid_0, cell_gid_type gid_1);
     cell_gid_type gid_0, gid_1;
+};
+
+struct gj_connection_mismatch: arbor_exception {
+    gj_connection_mismatch(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1);
+    cell_gid_type gid;
+    cell_member_type site_0, site_1;
+};
+
+struct bad_gj_connection: arbor_exception {
+    bad_gj_connection(cell_gid_type gid, cell_member_type site_0, cell_member_type site_1);
+    cell_gid_type gid;
+    cell_member_type site_0, site_1;
 };
 
 // Domain decomposition errors:

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -93,7 +93,7 @@ domain_decomposition partition_load_balance(
                     auto conns = rec.gap_junctions_on(element);
                     for (auto c: conns) {
                         if (element != c.local.gid && element != c.peer.gid) {
-                            throw bad_cell_description(cell_kind::cable, element);
+                            throw gj_connection_mismatch(element, c.local, c.peer);
                         }
                         cell_member_type other = c.local.gid == element ? c.peer : c.local;
 

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -93,7 +93,7 @@ domain_decomposition partition_load_balance(
                     auto conns = rec.gap_junctions_on(element);
                     for (auto c: conns) {
                         if (element != c.local.gid && element != c.peer.gid) {
-                            throw gj_connection_mismatch(element, c.local, c.peer);
+                            throw bad_gj_connection_gid(element, c.local.gid, c.peer.gid);
                         }
                         cell_member_type other = c.local.gid == element ? c.peer : c.local;
 

--- a/test/simple_recipes.hpp
+++ b/test/simple_recipes.hpp
@@ -10,6 +10,8 @@
 #include <arbor/cable_cell_param.hpp>
 #include <arbor/recipe.hpp>
 
+#include "util/rangeutil.hpp"
+
 namespace arb {
 
 // Common functionality: maintain an unordered map of probe data
@@ -117,11 +119,7 @@ public:
     }
 
     cell_size_type num_targets(cell_gid_type i) const override {
-        cell_size_type total_synapses = 0;
-        for (auto syn_type: cells_.at(i).synapses()) {
-            total_synapses+= syn_type.second.size();
-        }
-        return total_synapses;
+        return util::sum_by(cells_.at(i).synapses(), [](auto& syn) {return syn.second.size();});
     }
 
     util::unique_any get_cell_description(cell_gid_type i) const override {

--- a/test/simple_recipes.hpp
+++ b/test/simple_recipes.hpp
@@ -117,7 +117,11 @@ public:
     }
 
     cell_size_type num_targets(cell_gid_type i) const override {
-        return cells_.at(i).synapses().size();
+        cell_size_type total_synapses = 0;
+        for (auto syn_type: cells_.at(i).synapses()) {
+            total_synapses+= syn_type.second.size();
+        }
+        return total_synapses;
     }
 
     util::unique_any get_cell_description(cell_gid_type i) const override {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -139,6 +139,7 @@ set(unit_sources
     test_pp_util.cpp
     test_probe.cpp
     test_range.cpp
+    test_recipe.cpp
     test_ratelem.cpp
     test_schedule.cpp
     test_scope_exit.cpp

--- a/test/unit/test_recipe.cpp
+++ b/test/unit/test_recipe.cpp
@@ -117,13 +117,6 @@ TEST(recipe, num_sources)
 
         EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_source_description);
     }
-    {
-        auto recipe_2 = custom_recipe({cell}, {0}, {0}, {{}}, {{}});
-        auto decomp_2 = partition_load_balance(recipe_2, context);
-
-        EXPECT_THROW(simulation(recipe_2, decomp_2, context), arb::bad_source_description);
-
-    }
 }
 
 TEST(recipe, num_targets)
@@ -149,12 +142,6 @@ TEST(recipe, num_targets)
         auto decomp_1 = partition_load_balance(recipe_1, context);
 
         EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_target_description);
-    }
-    {
-        auto recipe_2 = custom_recipe({cell}, {0}, {3}, {{}}, {{}});
-        auto decomp_2 = partition_load_balance(recipe_2, context);
-
-        EXPECT_THROW(simulation(recipe_2, decomp_2, context), arb::bad_target_description);
     }
 }
 
@@ -190,7 +177,7 @@ TEST(recipe, gap_junctions)
         auto recipe_1 = custom_recipe({cell_0, cell_1}, {0, 0}, {0, 0}, {{}, {}}, {gjs_1, gjs_1});
         auto decomp_1 = partition_load_balance(recipe_1, context);
 
-        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_gj_connection);
+        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_gj_connection_lid);
 
     }
     {
@@ -201,7 +188,7 @@ TEST(recipe, gap_junctions)
         auto recipe_2 = custom_recipe({cell_0, cell_1}, {0, 0}, {0, 0}, {{}, {}}, {gjs_2, gjs_2});
         auto context = make_context(resources);
 
-        EXPECT_THROW(partition_load_balance(recipe_2, context), arb::gj_connection_mismatch);
+        EXPECT_THROW(partition_load_balance(recipe_2, context), arb::bad_gj_connection_gid);
     }
 }
 
@@ -224,7 +211,6 @@ TEST(recipe, connections)
                    {{1, 1}, {0, 0}, 0.1, 0.1},
                    {{1, 0}, {0, 1}, 0.2, 0.4}};
 
-
         conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
                    {{0, 0}, {1, 0}, 0.3, 0.1},
                    {{0, 0}, {1, 0}, 0.1, 0.8}};
@@ -246,7 +232,7 @@ TEST(recipe, connections)
         auto recipe_1 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
         auto decomp_1 = partition_load_balance(recipe_1, context);
 
-        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_connection_source);
+        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_connection_source_gid);
     }
     {
         conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
@@ -260,7 +246,7 @@ TEST(recipe, connections)
         auto recipe_2 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
         auto decomp_2 = partition_load_balance(recipe_2, context);
 
-        EXPECT_THROW(simulation(recipe_2, decomp_2, context), arb::bad_connection_source);
+        EXPECT_THROW(simulation(recipe_2, decomp_2, context), arb::bad_connection_source_lid);
     }
     {
         conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
@@ -274,21 +260,7 @@ TEST(recipe, connections)
         auto recipe_3 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
         auto decomp_3 = partition_load_balance(recipe_3, context);
 
-        EXPECT_THROW(simulation(recipe_3, decomp_3, context), arb::bad_connection_target);
-    }
-    {
-        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
-                   {{1, 1}, {0, 0}, 0.1, 0.1},
-                   {{1, 0}, {0, 1}, 0.2, 0.4}};
-
-        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
-                   {{0, 0}, {1, 9}, 0.3, 0.1},
-                   {{0, 0}, {1, 0}, 0.1, 0.8}};
-
-        auto recipe_4 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
-        auto decomp_4 = partition_load_balance(recipe_4, context);
-
-        EXPECT_THROW(simulation(recipe_4, decomp_4, context), arb::bad_connection_target);
+        EXPECT_THROW(simulation(recipe_3, decomp_3, context), arb::bad_connection_target_gid);
     }
     {
         conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
@@ -302,6 +274,20 @@ TEST(recipe, connections)
         auto recipe_5 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
         auto decomp_5 = partition_load_balance(recipe_5, context);
 
-        EXPECT_THROW(simulation(recipe_5, decomp_5, context), arb::connection_target_mismatch);
+        EXPECT_THROW(simulation(recipe_5, decomp_5, context), arb::bad_connection_target_gid);
+    }
+    {
+        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
+                   {{1, 1}, {0, 0}, 0.1, 0.1},
+                   {{1, 0}, {0, 1}, 0.2, 0.4}};
+
+        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
+                   {{0, 0}, {1, 9}, 0.3, 0.1},
+                   {{0, 0}, {1, 0}, 0.1, 0.8}};
+
+        auto recipe_4 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
+        auto decomp_4 = partition_load_balance(recipe_4, context);
+
+        EXPECT_THROW(simulation(recipe_4, decomp_4, context), arb::bad_connection_target_lid);
     }
 }

--- a/test/unit/test_recipe.cpp
+++ b/test/unit/test_recipe.cpp
@@ -1,0 +1,307 @@
+#include "../gtest.h"
+
+#include <arbor/common_types.hpp>
+#include <arbor/domain_decomposition.hpp>
+#include <arbor/load_balance.hpp>
+#include <arbor/cable_cell.hpp>
+#include <arbor/recipe.hpp>
+#include <arbor/simulation.hpp>
+
+#include <arborenv/concurrency.hpp>
+
+#include "util/span.hpp"
+
+#include "../common_cells.hpp"
+
+using namespace arb;
+using arb::util::make_span;
+
+namespace {
+    class custom_recipe: public recipe {
+    public:
+        custom_recipe(std::vector<cable_cell> cells,
+                      std::vector<cell_size_type> num_sources,
+                      std::vector<cell_size_type> num_targets,
+                      std::vector<std::vector<cell_connection>> conns,
+                      std::vector<std::vector<gap_junction_connection>> gjs):
+            num_cells_(cells.size()),
+            num_sources_(num_sources),
+            num_targets_(num_targets),
+            connections_(conns),
+            gap_junctions_(gjs),
+            cells_(cells) {}
+
+        cell_size_type num_cells() const override {
+            return num_cells_;
+        }
+        arb::util::unique_any get_cell_description(cell_gid_type gid) const override {
+            return cells_[gid];
+        }
+        cell_kind get_cell_kind(cell_gid_type gid) const override {
+            return cell_kind::cable;
+        }
+        std::vector<gap_junction_connection> gap_junctions_on(cell_gid_type gid) const override {
+            return gap_junctions_[gid];
+        }
+        std::vector<cell_connection> connections_on(cell_gid_type gid) const override {
+            return connections_[gid];
+        }
+        cell_size_type num_sources(cell_gid_type gid) const override {
+            return num_sources_[gid];
+        }
+        cell_size_type num_targets(cell_gid_type gid) const override {
+            return num_targets_[gid];
+        }
+        arb::util::any get_global_properties(cell_kind) const override {
+            arb::cable_cell_global_properties a;
+            a.default_parameters = arb::neuron_parameter_defaults;
+            return a;
+        }
+
+    private:
+        cell_size_type num_cells_;
+        std::vector<cell_size_type> num_sources_, num_targets_;
+        std::vector<std::vector<cell_connection>> connections_;
+        std::vector<std::vector<gap_junction_connection>> gap_junctions_;
+        std::vector<cable_cell> cells_;
+    };
+
+    cable_cell custom_cell(cell_size_type num_detectors, cell_size_type num_synapses, cell_size_type num_gj) {
+        arb::segment_tree tree;
+        tree.append(arb::mnpos, {0,0,0,10}, {0,0,20,10}, 1); // soma
+        tree.append(0, {0,0, 20, 2}, {0,0, 320, 2}, 3);  // dendrite
+
+        arb::cable_cell cell(tree, {});
+
+        // Add a num_detectors detectors to the cell.
+        for (auto i: util::make_span(num_detectors)) {
+            cell.place(arb::mlocation{0,(double)i/num_detectors}, arb::threshold_detector{10});
+        }
+
+        // Add a num_synapses synapses to the cell.
+        for (auto i: util::make_span(num_synapses)) {
+            cell.place(arb::mlocation{0,(double)i/num_synapses}, "expsyn");
+        }
+
+        // Add a num_gj gap_junctions to the cell.
+        for (auto i: util::make_span(num_gj)) {
+            cell.place(arb::mlocation{0,(double)i/num_gj}, arb::gap_junction_site{});
+        }
+
+        return cell;
+    }
+}
+
+// test assumes one domain
+TEST(recipe, num_sources)
+{
+    arb::proc_allocation resources;
+    if (auto nt = arbenv::get_env_num_threads()) {
+        resources.num_threads = nt;
+    }
+    else {
+        resources.num_threads = arbenv::thread_concurrency();
+    }
+    auto context = make_context(resources);
+    auto cell = custom_cell(1, 0, 0);
+
+    {
+        auto recipe_0 = custom_recipe({cell}, {1}, {0}, {{}}, {{}});
+        auto decomp_0 = partition_load_balance(recipe_0, context);
+
+        EXPECT_NO_THROW(simulation(recipe_0, decomp_0, context));
+    }
+    {
+        auto recipe_1 = custom_recipe({cell}, {2}, {0}, {{}}, {{}});
+        auto decomp_1 = partition_load_balance(recipe_1, context);
+
+        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_source_description);
+    }
+    {
+        auto recipe_2 = custom_recipe({cell}, {0}, {0}, {{}}, {{}});
+        auto decomp_2 = partition_load_balance(recipe_2, context);
+
+        EXPECT_THROW(simulation(recipe_2, decomp_2, context), arb::bad_source_description);
+
+    }
+}
+
+TEST(recipe, num_targets)
+{
+    arb::proc_allocation resources;
+    if (auto nt = arbenv::get_env_num_threads()) {
+        resources.num_threads = nt;
+    }
+    else {
+        resources.num_threads = arbenv::thread_concurrency();
+    }
+    auto context = make_context(resources);
+    auto cell = custom_cell(0, 2, 0);
+
+    {
+        auto recipe_0 = custom_recipe({cell}, {0}, {2}, {{}}, {{}});
+        auto decomp_0 = partition_load_balance(recipe_0, context);
+
+        EXPECT_NO_THROW(simulation(recipe_0, decomp_0, context));
+    }
+    {
+        auto recipe_1 = custom_recipe({cell}, {0}, {1}, {{}}, {{}});
+        auto decomp_1 = partition_load_balance(recipe_1, context);
+
+        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_target_description);
+    }
+    {
+        auto recipe_2 = custom_recipe({cell}, {0}, {3}, {{}}, {{}});
+        auto decomp_2 = partition_load_balance(recipe_2, context);
+
+        EXPECT_THROW(simulation(recipe_2, decomp_2, context), arb::bad_target_description);
+    }
+}
+
+TEST(recipe, gap_junctions)
+{
+    arb::proc_allocation resources;
+    if (auto nt = arbenv::get_env_num_threads()) {
+        resources.num_threads = nt;
+    }
+    else {
+        resources.num_threads = arbenv::thread_concurrency();
+    }
+    auto context = make_context(resources);
+
+    auto cell_0 = custom_cell(0, 0, 3);
+    auto cell_1 = custom_cell(0, 0, 3);
+
+    {
+        std::vector<arb::gap_junction_connection> gjs_0 = {{{0, 0}, {1, 1}, 0.1},
+                                                           {{0, 1}, {1, 2}, 0.1},
+                                                           {{0, 2}, {1, 0}, 0.1}};
+
+        auto recipe_0 = custom_recipe({cell_0, cell_1}, {0, 0}, {0, 0}, {{}, {}}, {gjs_0, gjs_0});
+        auto decomp_0 = partition_load_balance(recipe_0, context);
+
+        EXPECT_NO_THROW(simulation(recipe_0, decomp_0, context));
+    }
+    {
+        std::vector<arb::gap_junction_connection> gjs_1 = {{{0, 0}, {1, 1}, 0.1},
+                                                           {{0, 1}, {1, 2}, 0.1},
+                                                           {{0, 2}, {1, 5}, 0.1}};
+
+        auto recipe_1 = custom_recipe({cell_0, cell_1}, {0, 0}, {0, 0}, {{}, {}}, {gjs_1, gjs_1});
+        auto decomp_1 = partition_load_balance(recipe_1, context);
+
+        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_gj_connection);
+
+    }
+    {
+        std::vector<arb::gap_junction_connection> gjs_2 = {{{0, 0}, {1, 1}, 0.1},
+                                                           {{0, 1}, {1, 2}, 0.1},
+                                                           {{0, 2}, {3, 0}, 0.1}};
+
+        auto recipe_2 = custom_recipe({cell_0, cell_1}, {0, 0}, {0, 0}, {{}, {}}, {gjs_2, gjs_2});
+        auto context = make_context(resources);
+
+        EXPECT_THROW(partition_load_balance(recipe_2, context), arb::gj_connection_mismatch);
+    }
+}
+
+TEST(recipe, connections)
+{
+    arb::proc_allocation resources;
+    if (auto nt = arbenv::get_env_num_threads()) {
+        resources.num_threads = nt;
+    }
+    else {
+        resources.num_threads = arbenv::thread_concurrency();
+    }
+    auto context = make_context(resources);
+
+    auto cell_0 = custom_cell(1, 2, 0);
+    auto cell_1 = custom_cell(2, 1, 0);
+    std::vector<arb::cell_connection> conns_0, conns_1;
+    {
+        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
+                   {{1, 1}, {0, 0}, 0.1, 0.1},
+                   {{1, 0}, {0, 1}, 0.2, 0.4}};
+
+
+        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
+                   {{0, 0}, {1, 0}, 0.3, 0.1},
+                   {{0, 0}, {1, 0}, 0.1, 0.8}};
+
+        auto recipe_0 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
+        auto decomp_0 = partition_load_balance(recipe_0, context);
+
+        EXPECT_NO_THROW(simulation(recipe_0, decomp_0, context));
+    }
+    {
+        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
+                   {{2, 1}, {0, 0}, 0.1, 0.1},
+                   {{1, 0}, {0, 1}, 0.2, 0.4}};
+
+        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
+                   {{0, 0}, {1, 0}, 0.3, 0.1},
+                   {{0, 0}, {1, 0}, 0.1, 0.8}};
+
+        auto recipe_1 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
+        auto decomp_1 = partition_load_balance(recipe_1, context);
+
+        EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_connection_source);
+    }
+    {
+        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
+                   {{1, 1}, {0, 0}, 0.1, 0.1},
+                   {{1, 3}, {0, 1}, 0.2, 0.4}};
+
+        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
+                   {{0, 0}, {1, 0}, 0.3, 0.1},
+                   {{0, 0}, {1, 0}, 0.1, 0.8}};
+
+        auto recipe_2 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
+        auto decomp_2 = partition_load_balance(recipe_2, context);
+
+        EXPECT_THROW(simulation(recipe_2, decomp_2, context), arb::bad_connection_source);
+    }
+    {
+        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
+                   {{1, 1}, {0, 0}, 0.1, 0.1},
+                   {{1, 0}, {0, 1}, 0.2, 0.4}};
+
+        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
+                   {{0, 0}, {7, 0}, 0.3, 0.1},
+                   {{0, 0}, {1, 0}, 0.1, 0.8}};
+
+        auto recipe_3 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
+        auto decomp_3 = partition_load_balance(recipe_3, context);
+
+        EXPECT_THROW(simulation(recipe_3, decomp_3, context), arb::bad_connection_target);
+    }
+    {
+        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
+                   {{1, 1}, {0, 0}, 0.1, 0.1},
+                   {{1, 0}, {0, 1}, 0.2, 0.4}};
+
+        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
+                   {{0, 0}, {1, 9}, 0.3, 0.1},
+                   {{0, 0}, {1, 0}, 0.1, 0.8}};
+
+        auto recipe_4 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
+        auto decomp_4 = partition_load_balance(recipe_4, context);
+
+        EXPECT_THROW(simulation(recipe_4, decomp_4, context), arb::bad_connection_target);
+    }
+    {
+        conns_0 = {{{1, 0}, {0, 0}, 0.1, 0.1},
+                   {{1, 1}, {0, 0}, 0.1, 0.1},
+                   {{1, 0}, {0, 1}, 0.2, 0.4}};
+
+        conns_1 = {{{0, 0}, {1, 0}, 0.1, 0.2},
+                   {{0, 0}, {0, 0}, 0.3, 0.1},
+                   {{0, 0}, {1, 0}, 0.1, 0.8}};
+
+        auto recipe_5 = custom_recipe({cell_0, cell_1}, {1, 2}, {2, 1}, {conns_0, conns_1}, {{}, {}});
+        auto decomp_5 = partition_load_balance(recipe_5, context);
+
+        EXPECT_THROW(simulation(recipe_5, decomp_5, context), arb::connection_target_mismatch);
+    }
+}


### PR DESCRIPTION
* Raise an exception if:
1. `recipe.num_souces(gid)` != number of detectors placed on the cell.
2. `recipe.num_targets(gid)`  != number of synapses placed on the cell.
3. `recipe.connections_on(gid)` has connections with non-existent source or target gids or lids
* Raise better exception for gap junctions
* Fix unit test 

Addresses #681 