### PR TITLE
Fix clang warning

### DIFF
--- a/arbor/include/arbor/util/expected.hpp
+++ b/arbor/include/arbor/util/expected.hpp
@@ -69,7 +69,7 @@ private:
 template <typename E>
 struct unexpected {
     template <typename F>
-    friend class unexpected;
+    friend struct unexpected;
 
     unexpected() = default;
     unexpected(const unexpected&) = default;


### PR DESCRIPTION
Our clang build is currently generating a lot of warnings: https://travis-ci.org/github/arbor-sim/arbor/jobs/727445121