### PR TITLE
Remove const_cast

### DIFF
--- a/arbor/backends/gpu/shared_state.cpp
+++ b/arbor/backends/gpu/shared_state.cpp
@@ -192,7 +192,7 @@ std::ostream& operator<<(std::ostream& o, shared_state& s) {
     o << " conductivity " << s.conductivity << "\n";
     for (auto& ki: s.ion_data) {
         auto& kn = ki.first;
-        auto& i = const_cast<ion_state&>(ki.second);
+        auto& i = ki.second;
         o << " " << kn << "/current_density        " << i.iX_ << "\n";
         o << " " << kn << "/reversal_potential     " << i.eX_ << "\n";
         o << " " << kn << "/internal_concentration " << i.Xi_ << "\n";

--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -258,7 +258,7 @@ std::ostream& operator<<(std::ostream& out, const shared_state& s) {
     out << "conductivity " << csv(s.conductivity) << "\n";
     for (const auto& ki: s.ion_data) {
         auto& kn = ki.first;
-        auto& i = const_cast<ion_state&>(ki.second);
+        auto& i = ki.second;
         out << kn << "/current_density        " << csv(i.iX_) << "\n";
         out << kn << "/reversal_potential     " << csv(i.eX_) << "\n";
         out << kn << "/internal_concentration " << csv(i.Xi_) << "\n";


### PR DESCRIPTION
Remove the only cases of `const_cast` in the library (except for those required for calls to external C APIs).

I don't know how or when these snuck into the code, but they do not appear to be necessary.