### PR TITLE
New SWC parser broke `load_swc_allen`.

### DIFF
--- a/arbor/swcio.cpp
+++ b/arbor/swcio.cpp
@@ -52,7 +52,7 @@ std::ostream& operator<<(std::ostream& out, const swc_record& record) {
 
     out.precision(std::numeric_limits<double>::digits10+2);
     return out << record.id << ' ' << record.tag << ' '
-               << record.x  << ' ' << record.y   << ' ' << record.z << ' ' << record.r
+               << record.x  << ' ' << record.y   << ' ' << record.z << ' ' << record.r << ' '
                << record.parent_id << '\n';
 }
 


### PR DESCRIPTION
* Minor output formatting fix for `swc_record`.
* Modify the Python `load_swc_allen` implementation to cope with SWC record ids not necessarily being contiguous, and with SWC record parent ids corresponding to record ids, not 0-based indices.