### PR TITLE
Fixes the curious case of the missing quotes in the Python single cell model example, both code and docs.

### DIFF
--- a/doc/gs_single_cell.rst
+++ b/doc/gs_single_cell.rst
@@ -48,9 +48,9 @@ create the ``cable_cell`` that represents it are as follows:
     # (3) Create cell and set properties
     cell = arbor.cable_cell(tree, labels)
     cell.set_properties(Vm=-40)
-    cell.paint('soma', 'hh')
-    cell.place('center', arbor.iclamp( 10, 2, 0.8))
-    cell.place('center', arbor.spike_detector(-10))
+    cell.paint('"soma"', 'hh')
+    cell.place('"center"', arbor.iclamp( 10, 2, 0.8))
+    cell.place('"center"', arbor.spike_detector(-10))
 
     # Discretization: the default discretization in Arbor is 1 compartment per branch.
     # Let's be a bit more precise and make that every 2 μm:
@@ -112,7 +112,7 @@ and provides an interface for recording potentials and running the simulation.
     m = arbor.single_cell_model(cell)
 
     # (5) Attach voltage probe sampling at 10 kHz (every 0.1 ms).
-    m.probe('voltage', 'center', frequency=10000)
+    m.probe('voltage', '"center"', frequency=10000)
 
     # (6) Run simulation for 100 ms of simulated activity.
     m.run(tfinal=100)

--- a/doc/gs_single_cell.rst
+++ b/doc/gs_single_cell.rst
@@ -52,10 +52,6 @@ create the ``cable_cell`` that represents it are as follows:
     cell.place('"center"', arbor.iclamp( 10, 2, 0.8))
     cell.place('"center"', arbor.spike_detector(-10))
 
-    # Discretization: the default discretization in Arbor is 1 compartment per branch.
-    # Let's be a bit more precise and make that every 2 μm:
-    cell.compartments_length(2)
-
 
 Let's unpack that.
 

--- a/doc/gs_single_cell.rst
+++ b/doc/gs_single_cell.rst
@@ -89,8 +89,6 @@ with the named regions and locations.
   an :class:`arbor.iclamp<arbor._arbor.iclamp>` with a duration of 2 ms and a current of
   0.8 nA, starting at 10 ms. Then, add an :class:`arbor.spike_detector<arbor._arbor.spike_detector>`
   with a threshold of -10 mV to the location we've labelled 'center'.
-* Finally, we adjust the :ref:`discretisation <cable-discretisation>` of the simulation
-  by setting the compartment length to 2 μm. By default there is one compartment per branch.
 
 Single cell network
 ----------------------------------------------------

--- a/python/example/single_cell_model.py
+++ b/python/example/single_cell_model.py
@@ -11,15 +11,19 @@ labels = arbor.label_dict({'soma':   '(tag 1)',
 # (3) Create cell and set properties
 cell = arbor.cable_cell(tree, labels)
 cell.set_properties(Vm=-40)
-cell.paint('soma', 'hh')
-cell.place('center', arbor.iclamp( 10, 2, 0.8))
-cell.place('center', arbor.spike_detector(-10))
+cell.paint('"soma"', 'hh')
+cell.place('"center"', arbor.iclamp( 10, 2, 0.8))
+cell.place('"center"', arbor.spike_detector(-10))
+
+# Discretization: the default discretization in Arbor is 1 compartment per branch.
+# Let's be a bit more precise and make that every 2 μm:
+cell.compartments_length(2)
 
 # (4) Make single cell model.
 m = arbor.single_cell_model(cell)
 
 # (5) Attach voltage probe sampling at 10 kHz (every 0.1 ms).
-m.probe('voltage', 'center', frequency=10000)
+m.probe('voltage', '"center"', frequency=10000)
 
 # (6) Run simulation for 100 ms of simulated activity.
 m.run(tfinal=100)

--- a/python/example/single_cell_model.py
+++ b/python/example/single_cell_model.py
@@ -15,10 +15,6 @@ cell.paint('"soma"', 'hh')
 cell.place('"center"', arbor.iclamp( 10, 2, 0.8))
 cell.place('"center"', arbor.spike_detector(-10))
 
-# Discretization: the default discretization in Arbor is 1 compartment per branch.
-# Let's be a bit more precise and make that every 2 μm:
-cell.compartments_length(2)
-
 # (4) Make single cell model.
 m = arbor.single_cell_model(cell)
 


### PR DESCRIPTION
Tested all Python examples on current master successfully.