### PR TITLE
Add optimised HH.

### DIFF
--- a/mechanisms/default/hh.mod
+++ b/mechanisms/default/hh.mod
@@ -53,7 +53,7 @@ INITIAL {
 }
 
 DERIVATIVE states {
-    LOCAL alpha, beta
+    LOCAL alpha, beta, sum
 
     : sodium activation system
     alpha = m_alpha(v)

--- a/mechanisms/default/hh.mod
+++ b/mechanisms/default/hh.mod
@@ -25,9 +25,14 @@ ASSIGNED { q10 }
 
 BREAKPOINT {
     SOLVE states METHOD cnexp
-          
-    ina = gnabar*m*m*m*h*(v - ena)
-    ik  = gkbar*n*n*n*n*(v - ek)
+    LOCAL gk, m_, n_, n2
+
+    n_ = n
+    m_ = m
+    n2 = n_*n_
+    gk = gkbar*n2*n2
+    ina = gnabar*m_*m_*m_*h*(v - ena)
+    ik  = gk*(v - ek)
     il  = gl*(v - el)
 }
 


### PR DESCRIPTION
Provide a cleaned-up and optimised version of the HH-mechanism. Locally I see a ~5% improvement on the busyring benchmark with HH on dend and soma.

These optimisations are in-line with those done on the BBP and Allen catalogues.
