### PR TITLE
Correct sense of target vs synapse count test.

### DIFF
--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -540,7 +540,7 @@ void fvm_lowered_cell_impl<Backend>::initialize(
             throw arb::bad_source_description(gid, rec.num_sources(gid), cell.detectors().size());;
         }
         auto cell_targets = util::sum_by(cell.synapses(), [](auto& syn) {return syn.second.size();});
-        if (cell_targets > rec.num_targets(gid)) {
+        if (rec.num_targets(gid) > cell_targets) {
             throw arb::bad_target_description(gid, rec.num_targets(gid), cell_targets);
         }
 

--- a/test/unit/test_recipe.cpp
+++ b/test/unit/test_recipe.cpp
@@ -141,7 +141,7 @@ TEST(recipe, num_targets)
         EXPECT_NO_THROW(simulation(recipe_0, decomp_0, context));
     }
     {
-        auto recipe_1 = custom_recipe({cell}, {0}, {1}, {{}}, {{}});
+        auto recipe_1 = custom_recipe({cell}, {0}, {3}, {{}}, {{}});
         auto decomp_1 = partition_load_balance(recipe_1, context);
 
         EXPECT_THROW(simulation(recipe_1, decomp_1, context), arb::bad_target_description);


### PR DESCRIPTION
* Swap arguments in target count check in `fvm_lowered_cell_impl.hpp`.
* Update unit test to suit.

Fixes #1202.