### PR TITLE
Modify SWC loaders

### DIFF
--- a/arborio/include/arborio/swcio.hpp
+++ b/arborio/include/arborio/swcio.hpp
@@ -168,9 +168,7 @@ swc_data parse_swc(std::vector<swc_record>);
 
 // Convert a valid, ordered sequence of SWC records to a morphological segment tree.
 //
-// Note that 'one-point soma' SWC files are explicitly not supported; the swc_data
-// is expected to abide by the restrictions of `strict` mode parsing as described
-// above.
+// Note that 'one-point soma' SWC files are explicitly not supported.
 //
 // The generated segment tree will be contiguous. There will be one segment for
 // each SWC record after the first: this record defines the tag and distal point
@@ -181,8 +179,7 @@ arb::segment_tree load_swc_arbor(const swc_data& data);
 // As above, will convert a valid, ordered sequence of SWC records to a morphological
 // segment tree.
 //
-// Note that 'one-point soma' SWC files are supported here; the swc_data is expected
-// to abide by the restrictions of `relaxed` mode parsing as described above.
+// Note that 'one-point soma' SWC files are supported here
 //
 // These functions comply with inferred SWC rules from the Allen institute and Neuron.
 // These rules are explicitly listed in the docs.

--- a/arborio/include/arborio/swcio.hpp
+++ b/arborio/include/arborio/swcio.hpp
@@ -124,9 +124,22 @@ struct swc_record {
     friend std::istream& operator>>(std::istream&, swc_record&);
 };
 
+enum class swc_mode { relaxed, strict };
+
 struct swc_data {
-    std::string metadata;
-    std::vector<swc_record> records;
+private:
+    std::string metadata_;
+    std::vector<swc_record> records_;
+    swc_mode mode_;
+
+public:
+    swc_data() = delete;
+    swc_data(std::vector<arborio::swc_record>, swc_mode = swc_mode::relaxed);
+    swc_data(std::string, std::vector<arborio::swc_record>, swc_mode = swc_mode::relaxed);
+
+    const std::vector<swc_record>& records() const {return records_;};
+    std::string metadata() const {return metadata_;};
+    swc_mode mode() const {return mode_;};
 };
 
 // Read SWC records from stream, collecting any initial metadata represented
@@ -150,14 +163,12 @@ struct swc_data {
 //
 // SWC records are returned in id order.
 
-enum class swc_mode { relaxed, strict };
-
-swc_data parse_swc(std::istream&, swc_mode = swc_mode::strict);
-swc_data parse_swc(const std::string& text, swc_mode mode = swc_mode::strict);
+swc_data parse_swc(std::istream&, swc_mode = swc_mode::relaxed);
+swc_data parse_swc(const std::string&, swc_mode mode = swc_mode::relaxed);
 
 // Parse a series of existing SWC records.
 
-swc_data parse_swc(std::vector<swc_record>, swc_mode = swc_mode::strict);
+swc_data parse_swc(std::vector<swc_record>, swc_mode = swc_mode::relaxed);
 
 // Convert a valid, ordered sequence of SWC records to a morphological segment tree.
 //
@@ -169,11 +180,7 @@ swc_data parse_swc(std::vector<swc_record>, swc_mode = swc_mode::strict);
 // each SWC record after the first: this record defines the tag and distal point
 // of the segment, while the proximal point is taken from the parent record.
 
-arb::segment_tree as_segment_tree(const std::vector<swc_record>&);
-
-inline arb::segment_tree as_segment_tree(const swc_data& data) {
-    return as_segment_tree(data.records);
-}
+arb::segment_tree load_swc_arbor(const swc_data& data);
 
 // As above, will convert a valid, ordered sequence of SWC records to a morphological
 // segment tree.
@@ -184,16 +191,7 @@ inline arb::segment_tree as_segment_tree(const swc_data& data) {
 // These functions comply with inferred SWC rules from the Allen institute and Neuron.
 // These rules are explicitly listed in the docs.
 
-arb::segment_tree load_swc_neuron(const std::vector<swc_record>& records);
-
-inline arb::segment_tree load_swc_neuron(const swc_data& data) {
-    return load_swc_neuron(data.records);
-}
-
-arb::segment_tree load_swc_allen(std::vector<swc_record>& records, bool no_gaps=false);
-
-inline arb::segment_tree load_swc_allen(swc_data& data) {
-    return load_swc_allen(data.records);
-}
+arb::segment_tree load_swc_neuron(const swc_data& data);
+arb::segment_tree load_swc_allen(const swc_data& data, bool no_gaps=false);
 
 } // namespace arborio

--- a/arborio/include/arborio/swcio.hpp
+++ b/arborio/include/arborio/swcio.hpp
@@ -162,10 +162,6 @@ public:
 swc_data parse_swc(std::istream&);
 swc_data parse_swc(const std::string&);
 
-// Parse a series of existing SWC records.
-
-swc_data parse_swc(std::vector<swc_record>);
-
 // Convert a valid, ordered sequence of SWC records to a morphological segment tree.
 //
 // Note that 'one-point soma' SWC files are explicitly not supported.

--- a/arborio/include/arborio/swcio.hpp
+++ b/arborio/include/arborio/swcio.hpp
@@ -124,22 +124,18 @@ struct swc_record {
     friend std::istream& operator>>(std::istream&, swc_record&);
 };
 
-enum class swc_mode { relaxed, strict };
-
 struct swc_data {
 private:
     std::string metadata_;
     std::vector<swc_record> records_;
-    swc_mode mode_;
 
 public:
     swc_data() = delete;
-    swc_data(std::vector<arborio::swc_record>, swc_mode = swc_mode::relaxed);
-    swc_data(std::string, std::vector<arborio::swc_record>, swc_mode = swc_mode::relaxed);
+    swc_data(std::vector<arborio::swc_record>);
+    swc_data(std::string, std::vector<arborio::swc_record>);
 
     const std::vector<swc_record>& records() const {return records_;};
     std::string metadata() const {return metadata_;};
-    swc_mode mode() const {return mode_;};
 };
 
 // Read SWC records from stream, collecting any initial metadata represented
@@ -163,12 +159,12 @@ public:
 //
 // SWC records are returned in id order.
 
-swc_data parse_swc(std::istream&, swc_mode = swc_mode::relaxed);
-swc_data parse_swc(const std::string&, swc_mode mode = swc_mode::relaxed);
+swc_data parse_swc(std::istream&);
+swc_data parse_swc(const std::string&);
 
 // Parse a series of existing SWC records.
 
-swc_data parse_swc(std::vector<swc_record>, swc_mode = swc_mode::relaxed);
+swc_data parse_swc(std::vector<swc_record>);
 
 // Convert a valid, ordered sequence of SWC records to a morphological segment tree.
 //

--- a/arborio/swcio.cpp
+++ b/arborio/swcio.cpp
@@ -195,10 +195,6 @@ swc_data parse_swc(const std::string& text) {
     return parse_swc(is);
 }
 
-swc_data parse_swc(std::vector<swc_record> records) {
-    return swc_data(std::move(records));
-}
-
 arb::segment_tree load_swc_arbor(const swc_data& data) {
     const auto& records = data.records();
 

--- a/doc/concepts/morphology.rst
+++ b/doc/concepts/morphology.rst
@@ -501,11 +501,11 @@ interpretations.
 
 The SWC file format specifications are not very detailed, which has lead different simulators to interpret
 SWC files in different ways, especially when it comes to the soma. Arbor has its own an interpretation that
-is powerful, and simple to understand at the same time. However, we have also developed functions that will
+is powerful and simple to understand at the same time. However, we have also developed functions that will
 interpret SWC files similarly to how the NEURON simulator would, and how the Allen Institute would.
 
 Despite the differences between the interpretations, there is a common set of checks that are always performed
-to check the validity of SWC files:
+to validate an SWC file:
    * Check that there are no duplicate ids.
    * Check that the parent id of a sample is less than the id of the sample.
    * Check that the parent id of a sample refers to an existing sample.
@@ -562,25 +562,25 @@ and all samples are translated in space towards the origin.
 
 NEURON interpretation:
 """"""""""""""""""""""
-The NEURON interpretation was obtained by experimenting with the `Import3d_SWC_read` function. We came up with the
+The NEURON interpretation was obtained by experimenting with the ``Import3d_SWC_read`` function. We came up with the
 following set of rules that govern NEURON's SWC behavior and enforced them in arbor's NEURON-complaint SWC
 interpreter:
    * SWC files must contain a soma sample and it must to be the first sample.
    * A soma is represented by a series of n≥1 unbranched, serially listed samples.
    * A soma is constructed as a single cylinder with diameter equal to the piecewise average diameter of all the
-   segments forming the soma.
+     segments forming the soma.
    * A single-sample soma at is constructed as a cylinder with length=diameter.
    * If a non-soma sample is to have a soma sample as its parent, it must have the most distal sample of the soma
-   as the parent.
+     as the parent.
    * Every non-soma sample that has a soma sample as its parent, attaches to the created soma cylinder at its midpoint.
    * If a non-soma sample has a soma sample as its parent, no segment is created between the sample and its parent,
-   instead that sample is the proximal point of a new segment, and there is a gap in the morphology (represented
-   electrically as a zero-resistance wire)
+     instead that sample is the proximal point of a new segment, and there is a gap in the morphology (represented
+     electrically as a zero-resistance wire)
    * To create a segment with a certain tag, that is to be attached to the soma, we need at least 2 samples with that
-   tag.
+     tag.
 
 API
 ---
 
 * :ref:`Python <py_morphology>`
-* :ref:`C++ <cpp_morphology>`
+* :ref:`C++ <morphology-construction>`

--- a/doc/cpp/cable_cell.rst
+++ b/doc/cpp/cable_cell.rst
@@ -145,8 +145,8 @@ by two stitches:
    cell.paint("\"soma\"", "hh");
 
 
-Supported morphology formats:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Supported morphology formats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Arbor supports morphologies described using the SWC file format and the NeuroML file format.
 

--- a/doc/cpp/cable_cell.rst
+++ b/doc/cpp/cable_cell.rst
@@ -209,19 +209,19 @@ basic checks performed on them. The :cpp:type:`swc_data` object can then be used
 
 .. cpp:function:: swc_data parse_swc(std::istream&)
 
-   Returns an `swc_data` object given an std::istream object.
+   Returns an :cpp:type:`swc_data` object given an std::istream object.
 
 .. cpp:function:: segment_tree load_swc_arbor(const swc_data& data)
 
    Returns a segment tree constructed according to Arbor's SWC specifications.
 
-.. cpp:function:: segment_tree load_swc_allen(swc_data& data, bool no_gaps=false)
+.. cpp:function:: segment_tree load_swc_allen(const swc_data& data, bool no_gaps=false)
 
    Returns a segment tree constructed according to the Allen Institute's SWC specifications.
-   By default gaps in the segment tree are allowed, this can be toggled using the ``no_gaps``
+   By default, gaps in the segment tree are allowed, this can be toggled using the ``no_gaps``
    argument.
 
-.. cpp:function:: segment_tree load_swc_neuron(swc_data& data)
+.. cpp:function:: segment_tree load_swc_neuron(const swc_data& data)
 
    Returns a segment tree constructed according to NEURON's SWC specifications.
 

--- a/doc/cpp/cable_cell.rst
+++ b/doc/cpp/cable_cell.rst
@@ -163,7 +163,7 @@ basic checks performed on them. The :cpp:type:`swc_data` object can then be used
 :cpp:type:`segment_tree` object using one of the following functions: (See the morphology concepts
 :ref:`page <morph-formats>` for more details).
 
-  * :cpp:func:`as_segment_tree`
+  * :cpp:func:`load_swc_arbor`
   * :cpp:func:`load_swc_allen`
   * :cpp:func:`load_swc_neuron`
 
@@ -211,13 +211,15 @@ basic checks performed on them. The :cpp:type:`swc_data` object can then be used
 
    Returns an `swc_data` object given an std::istream object.
 
-.. cpp:function:: segment_tree as_segment_tree(const swc_data& data)
+.. cpp:function:: segment_tree load_swc_arbor(const swc_data& data)
 
    Returns a segment tree constructed according to Arbor's SWC specifications.
 
-.. cpp:function:: segment_tree load_swc_allen(swc_data& data)
+.. cpp:function:: segment_tree load_swc_allen(swc_data& data, bool no_gaps=false)
 
    Returns a segment tree constructed according to the Allen Institute's SWC specifications.
+   By default gaps in the segment tree are allowed, this can be toggled using the ``no_gaps``
+   argument.
 
 .. cpp:function:: segment_tree load_swc_neuron(swc_data& data)
 

--- a/doc/python/morphology.rst
+++ b/doc/python/morphology.rst
@@ -285,7 +285,7 @@ Cell morphology
         the use of cylinders or fustrums to describe morphologies, and it is not possible to
         infer how branches attached to the soma should be connected.
 
-        The :func:`load_swc_allen` function provides support for interpreting
+        The :func:`load_swc_allen` and :func:`load_swc_neuron `functions provide support for interpreting
         such SWC files.
 
 

--- a/doc/python/morphology.rst
+++ b/doc/python/morphology.rst
@@ -285,7 +285,7 @@ Cell morphology
         the use of cylinders or fustrums to describe morphologies, and it is not possible to
         infer how branches attached to the soma should be connected.
 
-        The :func:`load_swc_allen` and :func:`load_swc_neuron `functions provide support for interpreting
+        The :func:`load_swc_allen` and :func:`load_swc_neuron` functions provide support for interpreting
         such SWC files.
 
 

--- a/doc/scripts/inputs.py
+++ b/doc/scripts/inputs.py
@@ -85,7 +85,7 @@ tmp = [
 ysoma_morph3 = representation.make_morph(tmp)
 
 tmp = [
-    [[Segment((-3.0, 0.0, 0.7), (0.0, 0.0, 1.0), 2)], [Segment((0.0, 0.0, 1.0), (2.0, 0.0,  1.0), 1)], [Segment((2.0, 0.0, 1.0), (20.0, 0.0, 1.0), 3)]],
+    [[Segment((0.0, 0.0, 1.0), (2.0, 0.0,  1.0), 1)], [Segment((-3.0, 0.0, 0.7), (0.0, 0.0, 1.0), 2)], [Segment((2.0, 0.0, 1.0), (20.0, 0.0, 1.0), 3)]],
 ]
 swc_morph = representation.make_morph(tmp)
 

--- a/example/single/single.cpp
+++ b/example/single/single.cpp
@@ -158,5 +158,5 @@ arb::morphology read_swc(const std::string& path) {
     std::ifstream f(path);
     if (!f) throw std::runtime_error("unable to open SWC file: "+path);
 
-    return arb::morphology(arborio::as_segment_tree(arborio::parse_swc(f)));
+    return arb::morphology(arborio::load_swc_arbor(arborio::parse_swc(f, arborio::swc_mode::strict)));
 }

--- a/example/single/single.cpp
+++ b/example/single/single.cpp
@@ -158,5 +158,5 @@ arb::morphology read_swc(const std::string& path) {
     std::ifstream f(path);
     if (!f) throw std::runtime_error("unable to open SWC file: "+path);
 
-    return arb::morphology(arborio::load_swc_arbor(arborio::parse_swc(f, arborio::swc_mode::strict)));
+    return arb::morphology(arborio::load_swc_arbor(arborio::parse_swc(f)));
 }

--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -142,7 +142,7 @@ void register_morphology(pybind11::module& m) {
                 throw pyarb_error(util::pprintf("can't open file '{}'", fname));
             }
             try {
-                return arborio::load_swc_arbor(arborio::parse_swc(fid, arborio::swc_mode::strict));
+                return arborio::load_swc_arbor(arborio::parse_swc(fid));
             }
             catch (arborio::swc_error& e) {
                 // Try to produce helpful error messages for SWC parsing errors.
@@ -166,7 +166,7 @@ void register_morphology(pybind11::module& m) {
                 throw pyarb_error(util::pprintf("can't open file '{}'", fname));
             }
             try {
-                return arborio::load_swc_allen(arborio::parse_swc(fid, arborio::swc_mode::relaxed), no_gaps);
+                return arborio::load_swc_allen(arborio::parse_swc(fid), no_gaps);
             }
             catch (arborio::swc_error& e) {
                 // Try to produce helpful error messages for SWC parsing errors.
@@ -199,7 +199,7 @@ void register_morphology(pybind11::module& m) {
                 throw pyarb_error(util::pprintf("can't open file '{}'", fname));
             }
             try {
-                return arborio::load_swc_neuron(arborio::parse_swc(fid, arborio::swc_mode::relaxed));
+                return arborio::load_swc_neuron(arborio::parse_swc(fid));
             }
             catch (arborio::swc_error& e) {
                 // Try to produce helpful error messages for SWC parsing errors.

--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -14,39 +14,6 @@
 
 namespace pyarb {
 
-arb::segment_tree load_swc_neuron(const std::string& fname) {
-    std::ifstream fid{fname};
-    if (!fid.good()) {
-        throw pyarb_error(util::pprintf("can't open file '{}'", fname));
-    }
-    try {
-        auto records = arborio::parse_swc(fid, arborio::swc_mode::relaxed).records;
-        return arborio::load_swc_neuron(records);
-    }
-    catch (arborio::swc_error& e) {
-        // Try to produce helpful error messages for SWC parsing errors.
-        throw pyarb_error(
-                util::pprintf("NEURON SWC: error parsing {}: {}", fname, e.what()));
-    }
-}
-
-arb::segment_tree load_swc_allen(const std::string& fname, bool no_gaps=false) {
-        std::ifstream fid{fname};
-        if (!fid.good()) {
-            throw pyarb_error(util::pprintf("can't open file '{}'", fname));
-        }
-        try {
-            using namespace arb;
-            auto records = arborio::parse_swc(fid, arborio::swc_mode::relaxed).records;
-            return arborio::load_swc_allen(records, no_gaps);
-        }
-        catch (arborio::swc_error& e) {
-            // Try to produce helpful error messages for SWC parsing errors.
-            throw pyarb_error(
-                util::pprintf("Allen SWC: error parsing {}: {}", fname, e.what()));
-        }
-}
-
 void register_morphology(pybind11::module& m) {
     using namespace pybind11::literals;
 
@@ -167,7 +134,7 @@ void register_morphology(pybind11::module& m) {
                 return util::pprintf("<arbor.segment_tree:\n{}>", s);});
 
     // Function that creates a segment_tree from an swc file.
-    // Wraps calls to C++ functions arb::parse_swc_file() and arb::swc_as_segment_tree().
+    // Wraps calls to C++ functions arborio::parse_swc() and arborio::load_swc_arbor().
     m.def("load_swc",
         [](std::string fname) {
             std::ifstream fid{fname};
@@ -175,35 +142,90 @@ void register_morphology(pybind11::module& m) {
                 throw pyarb_error(util::pprintf("can't open file '{}'", fname));
             }
             try {
-                auto records = arborio::parse_swc(fid).records;
-                return arborio::as_segment_tree(records);
+                return arborio::load_swc_arbor(arborio::parse_swc(fid, arborio::swc_mode::strict));
+            }
+            catch (arborio::swc_error& e) {
+                // Try to produce helpful error messages for SWC parsing errors.
+                throw pyarb_error(util::pprintf("error parsing {}: {}", fname, e.what()));
+            }
+        },
+        "filename"_a,
+        "Generate a segment tree from an SWC file following the rules prescribed by\n"
+        "Arbor. Specifically:\n"
+        "* Single-segment somas are disallowed. These are usually interpreted as spherical somas\n"
+        "  and are a special case. This behavior is not allowed using this SWC loader.\n"
+        "* There are no special rules related to somata. They can be one or multiple branches\n"
+        "  and other segments can connect anywhere along them.\n"
+        "* A segment is always created between a sample and its parent, meaning there\n"
+        "  are no gaps in the resulting segment tree.");
+
+    m.def("load_swc_allen",
+        [](std::string fname, bool no_gaps=false) {
+            std::ifstream fid{fname};
+            if (!fid.good()) {
+                throw pyarb_error(util::pprintf("can't open file '{}'", fname));
+            }
+            try {
+                return arborio::load_swc_allen(arborio::parse_swc(fid, arborio::swc_mode::relaxed), no_gaps);
             }
             catch (arborio::swc_error& e) {
                 // Try to produce helpful error messages for SWC parsing errors.
                 throw pyarb_error(
-                    util::pprintf("error parsing {}: {}", fname, e.what()));
+                        util::pprintf("Allen SWC: error parsing {}: {}", fname, e.what()));
             }
         },
-        "Load an swc file and as a segment_tree.");
+        "filename"_a, "no_gaps"_a=false,
+        "Generate a segment tree from an SWC file following the rules prescribed by\n"
+        "AllenDB and Sonata. Specifically:\n"
+        "* The first sample (the root) is treated as the center of the soma.\n"
+        "* The first morphology is translated such that the soma is centered at (0,0,0).\n"
+        "* The first sample has tag 1 (soma).\n"
+        "* All other samples have tags 2, 3 or 4 (axon, apic and dend respectively)\n"
+        "SONATA prescribes that there should be no gaps, however the models in AllenDB\n"
+        "have gaps between the start of sections and the soma. The flag no_gaps can be\n"
+        "used to enforce this requirement.\n"
+        "\n"
+        "Arbor does not support modelling the soma as a sphere, so a cylinder with length\n"
+        "equal to the soma diameter is used. The cylinder is centered on the origin, and\n"
+        "aligned along the z axis.\n"
+        "Axons and apical dendrites are attached to the proximal end of the cylinder, and\n"
+        "dendrites to the distal end, with a gap between the start of each branch and the\n"
+        "end of the soma cylinder to which it is attached.");
 
-    m.def("load_swc_allen", &load_swc_allen,
-            "filename"_a, "no_gaps"_a=false,
-            "Generate a segment tree from an SWC file following the rules prescribed by\n"
-            "AllenDB and Sonata. Specifically:\n"
-            "* The first sample (the root) is treated as the center of the soma.\n"
-            "* The first morphology is translated such that the soma is centered at (0,0,0).\n"
-            "* The first sample has tag 1 (soma).\n"
-            "* All other samples have tags 2, 3 or 4 (axon, apic and dend respectively)\n"
-            "SONATA prescribes that there should be no gaps, however the models in AllenDB\n"
-            "have gaps between the start of sections and the soma. The flag no_gaps can be\n"
-            "used to enforce this requirement.\n"
-            "\n"
-            "Arbor does not support modelling the soma as a sphere, so a cylinder with length\n"
-            "equal to the soma diameter is used. The cylinder is centered on the origin, and\n"
-            "aligned along the z axis.\n"
-            "Axons and apical dendrites are attached to the proximal end of the cylinder, and\n"
-            "dendrites to the distal end, with a gap between the start of each branch and the\n"
-            "end of the soma cylinder to which it is attached.");
+    m.def("load_swc_neuron",
+        [](std::string fname) {
+            std::ifstream fid{fname};
+            if (!fid.good()) {
+                throw pyarb_error(util::pprintf("can't open file '{}'", fname));
+            }
+            try {
+                return arborio::load_swc_neuron(arborio::parse_swc(fid, arborio::swc_mode::relaxed));
+            }
+            catch (arborio::swc_error& e) {
+                // Try to produce helpful error messages for SWC parsing errors.
+                throw pyarb_error(
+                    util::pprintf("NEURON SWC: error parsing {}: {}", fname, e.what()));
+            }
+        },
+        "filename"_a,
+        "Generate a segment tree from an SWC file following the rules prescribed by\n"
+        "NEURON. Specifically:\n"
+        "* The first sample must be a soma sample.\n"
+        "* The soma is represented by a series of n≥1 unbranched, serially listed samples.\n"
+        "* The soma is constructed as a single cylinder with diameter equal to the piecewise\n"
+        "  average diameter of all the segments forming the soma.\n"
+        "* A single-sample soma at is constructed as a cylinder with length=diameter.\n"
+        "* If a non-soma sample is to have a soma sample as its parent, it must have the\n"
+        "  most distal sample of the soma as the parent.\n"
+        "* Every non-soma sample that has a soma sample as its parent, attaches to the\n"
+        "  created soma cylinder at its midpoint.\n"
+        "* If a non-soma sample has a soma sample as its parent, no segment is created\n"
+        "  between the sample and its parent, instead that sample is the proximal point of\n"
+        "  a new segment, and there is a gap in the morphology (represented electrically as a\n"
+        "  zero-resistance wire)\n"
+        "* To create a segment with a certain tag, that is to be attached to the soma,\n"
+        "  we need at least 2 samples with that tag."
+        );
 
     // arb::morphology
 

--- a/test/ubench/fvm_discretize.cpp
+++ b/test/ubench/fvm_discretize.cpp
@@ -5,7 +5,9 @@
 
 #include <arbor/cable_cell.hpp>
 #include <arbor/morph/morphology.hpp>
-#include <arbor/swcio.hpp>
+
+#include <arborio/swcio.hpp>
+
 #include <benchmark/benchmark.h>
 
 #include "event_queue.hpp"
@@ -26,7 +28,7 @@ arb::morphology from_swc(const std::string& path) {
     std::ifstream in(path);
     if (!in) throw std::runtime_error("could not open "+path);
 
-    return morphology(arb::as_segment_tree(parse_swc(in)));
+    return morphology(arborio::load_swc_arbor(arborio::parse_swc(in, arborio::swc_mode::strict)));
 }
 
 void run_cv_geom(benchmark::State& state) {

--- a/test/ubench/fvm_discretize.cpp
+++ b/test/ubench/fvm_discretize.cpp
@@ -28,7 +28,7 @@ arb::morphology from_swc(const std::string& path) {
     std::ifstream in(path);
     if (!in) throw std::runtime_error("could not open "+path);
 
-    return morphology(arborio::load_swc_arbor(arborio::parse_swc(in, arborio::swc_mode::strict)));
+    return morphology(arborio::load_swc_arbor(arborio::parse_swc(in)));
 }
 
 void run_cv_geom(benchmark::State& state) {

--- a/test/unit/test_morphology.cpp
+++ b/test/unit/test_morphology.cpp
@@ -319,7 +319,7 @@ TEST(morphology, swc) {
     }
 
     // Load swc samples from file.
-    auto swc = arborio::parse_swc(fid, arborio::swc_mode::strict);
+    auto swc = arborio::parse_swc(fid);
 
     // Build a segmewnt_tree from swc samples.
     auto sm = arborio::load_swc_arbor(swc);

--- a/test/unit/test_morphology.cpp
+++ b/test/unit/test_morphology.cpp
@@ -322,7 +322,7 @@ TEST(morphology, swc) {
     auto swc = arborio::parse_swc(fid, arborio::swc_mode::strict);
 
     // Build a segmewnt_tree from swc samples.
-    auto sm = arborio::as_segment_tree(swc);
+    auto sm = arborio::load_swc_arbor(swc);
     EXPECT_EQ(5798u, sm.size()); // SWC data contains 5799 samples.
 
     // Test that the morphology contains the expected number of branches.

--- a/test/unit/test_swcio.cpp
+++ b/test/unit/test_swcio.cpp
@@ -66,7 +66,7 @@ TEST(swc_record, invalid_input) {
     }
 }
 
-TEST(swc_parser, bad_relaxed) {
+TEST(swc_parser, bad_parse) {
     {
         std::string bad1 =
             "1 1 0.1 0.2 0.3 0.4 -1\n"
@@ -74,7 +74,7 @@ TEST(swc_parser, bad_relaxed) {
             "3 1 0.1 0.2 0.3 0.4 2\n"
             "5 1 0.1 0.2 0.3 0.4 4\n";
 
-        EXPECT_THROW(parse_swc(bad1, swc_mode::relaxed), swc_no_such_parent);
+        EXPECT_THROW(parse_swc(bad1), swc_no_such_parent);
     }
 
     {
@@ -84,7 +84,7 @@ TEST(swc_parser, bad_relaxed) {
             "3 1 0.1 0.2 0.3 0.4 2\n"
             "4 1 0.1 0.2 0.3 0.4 -1\n";
 
-        EXPECT_THROW(parse_swc(bad2, swc_mode::relaxed), swc_no_such_parent);
+        EXPECT_THROW(parse_swc(bad2), swc_no_such_parent);
     }
 
     {
@@ -94,7 +94,7 @@ TEST(swc_parser, bad_relaxed) {
             "3 1 0.1 0.2 0.3 0.4 1\n"
             "4 1 0.1 0.2 0.3 0.4 3\n";
 
-        EXPECT_THROW(parse_swc(bad3, swc_mode::relaxed), swc_record_precedes_parent);
+        EXPECT_THROW(parse_swc(bad3), swc_record_precedes_parent);
     }
 
     {
@@ -104,7 +104,7 @@ TEST(swc_parser, bad_relaxed) {
             "3 1 0.1 0.2 0.3 0.4 1\n"
             "4 1 0.1 0.2 0.3 0.4 3\n";
 
-        EXPECT_THROW(parse_swc(bad4, swc_mode::relaxed), swc_duplicate_record_id);
+        EXPECT_THROW(parse_swc(bad4), swc_duplicate_record_id);
     }
 
     {
@@ -114,68 +114,47 @@ TEST(swc_parser, bad_relaxed) {
             "3 1 0.1 0.2 0.3 0.4 2\n"
             "4 1 0.1 0.2 0.3 0.4 -1\n";
 
-        EXPECT_THROW(parse_swc(bad5, swc_mode::relaxed), swc_no_such_parent);
+        EXPECT_THROW(parse_swc(bad5), swc_no_such_parent);
     }
 }
 
-TEST(swc_parser, bad_strict) {
-    {
-        std::string bad6 =
-            "1 7 0.1 0.2 0.3 0.4 -1\n"; // just one record
-
-        EXPECT_THROW(parse_swc(bad6, swc_mode::strict), swc_spherical_soma);
-    }
-    {
-        std::string bad3 =
-            "1 4 0.1 0.2 0.3 0.4 -1\n" // solitary tag
-            "2 6 0.1 0.2 0.3 0.4 1\n"
-            "3 6 0.1 0.2 0.3 0.4 2\n"
-            "4 6 0.1 0.2 0.3 0.4 1\n";
-
-        EXPECT_THROW(parse_swc(bad3, swc_mode::strict), swc_spherical_soma);
-        EXPECT_NO_THROW(parse_swc(bad3, swc_mode::relaxed));
-    }
-}
-
-TEST(swc_parser, valid_relaxed) {
+TEST(swc_parser, valid_parse) {
     // Non-contiguous is okay.
     {
-        std::string bad1 =
+        std::string valid1 =
             "1 1 0.1 0.2 0.3 0.4 -1\n"
             "2 1 0.1 0.2 0.3 0.4 1\n"
             "3 1 0.1 0.2 0.3 0.4 2\n"
             "5 1 0.1 0.2 0.3 0.4 3\n"; // non-contiguous
 
-        EXPECT_NO_THROW(parse_swc(bad1, swc_mode::relaxed));
+        EXPECT_NO_THROW(parse_swc(valid1));
     }
 
     // As is out of order.
     {
-        std::string bad2 =
+        std::string valid2 =
             "1 1 0.1 0.2 0.3 0.4 -1\n"
             "3 1 0.1 0.2 0.3 0.4 2\n" // out of order
             "2 1 0.1 0.2 0.3 0.4 1\n"
             "4 1 0.1 0.2 0.3 0.4 3\n";
 
-        EXPECT_NO_THROW(parse_swc(bad2, swc_mode::relaxed));
+        EXPECT_NO_THROW(parse_swc(valid2));
     }
 
-}
-
-TEST(swc_parser, valid_strict) {
+    //  With comments
     {
-        std::string valid1 =
+        std::string valid3 =
             "# Hello\n"
             "# world.\n";
 
-        swc_data data = parse_swc(valid1, swc_mode::strict);
+        swc_data data = parse_swc(valid3);
         EXPECT_EQ("Hello\nworld.\n", data.metadata());
         EXPECT_TRUE(data.records().empty());
     }
 
+    // Non-contiguous, out of order records with comments.
     {
-        // Non-contiguous, out of order records are fine.
-        std::string valid2 =
+        std::string valid4 =
             "# Some people put\n"
             "# <xml /> in here!\n"
             "1 1 0.1 0.2 0.3 0.4 -1\n"
@@ -183,7 +162,7 @@ TEST(swc_parser, valid_strict) {
             "5 2 0.2 0.6 0.8 0.2 2\n"
             "4 0 0.2 0.8 0.6 0.3 2";
 
-        swc_data data = parse_swc(valid2, swc_mode::strict);
+        swc_data data = parse_swc(valid4);
         EXPECT_EQ("Some people put\n<xml /> in here!\n", data.metadata());
         ASSERT_EQ(4u, data.records().size());
         EXPECT_EQ(swc_record(1, 1, 0.1, 0.2, 0.3, 0.4, -1), data.records()[0]);
@@ -200,27 +179,13 @@ TEST(swc_parser, valid_strict) {
             "3 2 0.2 0.6 0.8 0.2 2 # it is a cow!\n"
             "4 0 0.2 0.8 0.6 0.3 2";
 
-        swc_data data2 = parse_swc(valid2, swc_mode::strict);
+        swc_data data2 = parse_swc(valid4);
         EXPECT_EQ(data.records(), data2.records());
     }
+
 }
 
-TEST(swc_parser, segment_tree) {
-    {
-        // Missing parent record will throw.
-        std::vector<swc_record> swc{
-            {1, 1, 0., 0., 0., 1., -1},
-            {5, 3, 1., 1., 1., 1., 2}
-        };
-        EXPECT_THROW(load_swc_arbor(swc), swc_no_such_parent);
-    }
-    {
-        // A single SWC record will throw.
-        std::vector<swc_record> swc{
-            {1, 1, 0., 0., 0., 1., -1}
-        };
-        EXPECT_THROW(load_swc_arbor(swc), swc_spherical_soma);
-    }
+TEST(swc_parser, arbor_complaint) {
     {
         // Otherwise, ensure segment ends and tags correspond.
         mpoint p0{0.1, 0.2, 0.3, 0.4};
@@ -260,7 +225,67 @@ TEST(swc_parser, segment_tree) {
         EXPECT_EQ(p2, tree.segments()[3].prox);
         EXPECT_EQ(p4, tree.segments()[3].dist);
     }
+    {
+        // Otherwise, ensure segment ends and tags correspond.
+        mpoint p0{0.1, 0.2, 0.3, 0.4};
+        mpoint p1{0.3, 0.4, 0.5, 0.3};
+        mpoint p2{0.2, 0.8, 0.6, 0.3};
+        mpoint p3{0.2, 0.6, 0.8, 0.2};
+
+        std::vector<swc_record> swc{
+            {1, 1, p0.x, p0.y, p0.z, p0.radius, -1},
+            {2, 1, p1.x, p1.y, p1.z, p1.radius, 1},
+            {3, 2, p2.x, p2.y, p2.z, p2.radius, 1},
+            {4, 3, p3.x, p3.y, p3.z, p3.radius, 2},
+        };
+
+        segment_tree tree = load_swc_arbor(swc);
+        ASSERT_EQ(3u, tree.segments().size());
+
+        EXPECT_EQ(mnpos, tree.parents()[0]);
+        EXPECT_EQ(1,  tree.segments()[0].tag);
+        EXPECT_EQ(p0, tree.segments()[0].prox);
+        EXPECT_EQ(p1, tree.segments()[0].dist);
+
+        EXPECT_EQ(mnpos, tree.parents()[1]);
+        EXPECT_EQ(2,  tree.segments()[1].tag);
+        EXPECT_EQ(p0, tree.segments()[1].prox);
+        EXPECT_EQ(p2, tree.segments()[1].dist);
+
+        EXPECT_EQ(0u, tree.parents()[2]);
+        EXPECT_EQ(3,  tree.segments()[2].tag);
+        EXPECT_EQ(p1, tree.segments()[2].prox);
+        EXPECT_EQ(p3, tree.segments()[2].dist);
+    }
 }
+
+TEST(swc_parser, not_arbor_complaint) {
+    {
+        // Missing parent record will throw.
+        std::vector<swc_record> swc{
+            {1, 1, 0., 0., 0., 1., -1},
+            {5, 3, 1., 1., 1., 1., 2}
+        };
+        EXPECT_THROW(load_swc_arbor(swc), swc_no_such_parent);
+    }
+    {
+        // A single SWC record will throw.
+        std::vector<swc_record> swc{
+            {1, 1, 0., 0., 0., 1., -1}
+        };
+        EXPECT_THROW(load_swc_arbor(swc), swc_spherical_soma);
+    }
+    {
+        std::vector<swc_record> swc{
+            {1, 4, 0.1, 0.2, 0.3, 0.4, -1},
+            {2, 6, 0.1, 0.2, 0.3, 0.4,  1},
+            {3, 6, 0.1, 0.2, 0.3, 0.4,  2},
+            {4, 6, 0.1, 0.2, 0.3, 0.4,  1}
+        };
+        EXPECT_THROW(load_swc_arbor(swc), swc_spherical_soma);
+    }
+}
+
 TEST(swc_parser, allen_compliant) {
     using namespace arborio;
     {
@@ -934,7 +959,7 @@ TEST(swc_parser, from_neuromorpho)
         return;
     }
 
-    auto data = parse_swc(fid, swc_mode::strict);
+    auto data = parse_swc(fid);
     EXPECT_EQ(5799u, data.records().size());
 }
 #endif


### PR DESCRIPTION
* Rename `as_segment_tree` to `load_swc_arbor`.
* Remove `swc_mode`: `sort_and_validate_swc` now performs the `relaxed` checks by default, `load_swc_arbor` performs the `strict` checks. 
* `load_swc_xxx` only accept `swc_data` as an argument
* `swc_data` can not be default constructed; it runs `sort_and_validate_swc` at construction.
* doc/unit test fixes

Addresses #1213 