### PR TITLE
Split `no_such_parameter` exception

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -101,14 +101,14 @@ fingerprint_mismatch::fingerprint_mismatch(const std::string& mech_name):
     mech_name(mech_name)
 {}
 
-no_such_global_parameter::no_such_global_parameter(const std::string& mech_name, const std::string& param_name):
-    arbor_exception(pprintf("mechanism {} has no GLOBAL parameter {}", mech_name, param_name)),
+no_such_global::no_such_global(const std::string& mech_name, const std::string& param_name):
+    arbor_exception(pprintf("mechanism {} has no global {} that can be derived", mech_name, param_name)),
     mech_name(mech_name),
     param_name(param_name)
 {}
 
-no_such_range_parameter::no_such_range_parameter(const std::string& mech_name, const std::string& param_name):
-    arbor_exception(pprintf("mechanism {} has no RANGE parameter {}", mech_name, param_name)),
+no_such_parameter::no_such_parameter(const std::string& mech_name, const std::string& param_name):
+    arbor_exception(pprintf("mechanism {} has no parameter {} that can be set", mech_name, param_name)),
     mech_name(mech_name),
     param_name(param_name)
 {}

--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -101,8 +101,14 @@ fingerprint_mismatch::fingerprint_mismatch(const std::string& mech_name):
     mech_name(mech_name)
 {}
 
-no_such_parameter::no_such_parameter(const std::string& mech_name, const std::string& param_name):
-    arbor_exception(pprintf("mechanism {} has no parameter {}", mech_name, param_name)),
+no_such_global_parameter::no_such_global_parameter(const std::string& mech_name, const std::string& param_name):
+    arbor_exception(pprintf("mechanism {} has no GLOBAL parameter {}", mech_name, param_name)),
+    mech_name(mech_name),
+    param_name(param_name)
+{}
+
+no_such_range_parameter::no_such_range_parameter(const std::string& mech_name, const std::string& param_name):
+    arbor_exception(pprintf("mechanism {} has no RANGE parameter {}", mech_name, param_name)),
     mech_name(mech_name),
     param_name(param_name)
 {}

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -797,7 +797,7 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
 
         for (const auto& pv: desc.values()) {
             if (!info.parameters.count(pv.first)) {
-                throw no_such_range_parameter(desc.name(), pv.first);
+                throw no_such_parameter(desc.name(), pv.first);
             }
             if (!info.parameters.at(pv.first).valid(pv.second)) {
                 throw invalid_parameter_value(desc.name(), pv.first, pv.second);

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -797,7 +797,7 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
 
         for (const auto& pv: desc.values()) {
             if (!info.parameters.count(pv.first)) {
-                throw no_such_parameter(desc.name(), pv.first);
+                throw no_such_range_parameter(desc.name(), pv.first);
             }
             if (!info.parameters.at(pv.first).valid(pv.second)) {
                 throw invalid_parameter_value(desc.name(), pv.first, pv.second);

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -130,8 +130,14 @@ struct fingerprint_mismatch: arbor_exception {
     std::string mech_name;
 };
 
-struct no_such_parameter: arbor_exception {
-    no_such_parameter(const std::string& mech_name, const std::string& param_name);
+struct no_such_global_parameter: arbor_exception {
+    no_such_global_parameter(const std::string& mech_name, const std::string& param_name);
+    std::string mech_name;
+    std::string param_name;
+};
+
+struct no_such_range_parameter: arbor_exception {
+    no_such_range_parameter(const std::string& mech_name, const std::string& param_name);
     std::string mech_name;
     std::string param_name;
 };

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -130,14 +130,14 @@ struct fingerprint_mismatch: arbor_exception {
     std::string mech_name;
 };
 
-struct no_such_global_parameter: arbor_exception {
-    no_such_global_parameter(const std::string& mech_name, const std::string& param_name);
+struct no_such_global: arbor_exception {
+    no_such_global(const std::string& mech_name, const std::string& param_name);
     std::string mech_name;
     std::string param_name;
 };
 
-struct no_such_range_parameter: arbor_exception {
-    no_such_range_parameter(const std::string& mech_name, const std::string& param_name);
+struct no_such_parameter: arbor_exception {
+    no_such_parameter(const std::string& mech_name, const std::string& param_name);
     std::string mech_name;
     std::string param_name;
 };

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -285,7 +285,7 @@ struct catalogue_state {
                 }
             }
             else {
-                return unexpected_exception_ptr(no_such_parameter(name, param));
+                return unexpected_exception_ptr(no_such_global_parameter(name, param));
             }
 
             deriv.globals[param] = value;

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -285,7 +285,7 @@ struct catalogue_state {
                 }
             }
             else {
-                return unexpected_exception_ptr(no_such_global_parameter(name, param));
+                return unexpected_exception_ptr(no_such_global(name, param));
             }
 
             deriv.globals[param] = value;

--- a/test/unit/test_mechcat.cpp
+++ b/test/unit/test_mechcat.cpp
@@ -422,7 +422,7 @@ TEST(mechcat, implicit_deriv) {
     EXPECT_EQ(4.5, fleeb2_derived.overrides.globals.at("plugh"));
 
     // Requesting an implicitly derived instance with improper parameters should throw.
-    EXPECT_THROW(cat.instance<foo_backend>("fleeb2/fidget=7"), no_such_parameter);
+    EXPECT_THROW(cat.instance<foo_backend>("fleeb2/fidget=7"), no_such_global_parameter);
 
     // Testing for implicit derivation though should not throw.
     EXPECT_TRUE(cat.has("fleeb2/plugh=7"));

--- a/test/unit/test_mechcat.cpp
+++ b/test/unit/test_mechcat.cpp
@@ -422,7 +422,7 @@ TEST(mechcat, implicit_deriv) {
     EXPECT_EQ(4.5, fleeb2_derived.overrides.globals.at("plugh"));
 
     // Requesting an implicitly derived instance with improper parameters should throw.
-    EXPECT_THROW(cat.instance<foo_backend>("fleeb2/fidget=7"), no_such_global_parameter);
+    EXPECT_THROW(cat.instance<foo_backend>("fleeb2/fidget=7"), no_such_global);
 
     // Testing for implicit derivation though should not throw.
     EXPECT_TRUE(cat.has("fleeb2/plugh=7"));


### PR DESCRIPTION
Split the `no_such_parameter` exception such that 
* `mechanism_desc("mech/x=...")` throws `mechanism mech has no global x that can be derived` 
* `mechanism_desc("mech", {"x": ...})` throws `mechanism mech has no parameter x that can be set` 

Addresses #1212 