### PR TITLE
Fix some static analysis warnings

### DIFF
--- a/arbor/benchmark_cell_group.cpp
+++ b/arbor/benchmark_cell_group.cpp
@@ -86,7 +86,7 @@ void benchmark_cell_group::add_sampler(sampler_association_handle h,
                                    sampler_function fn,
                                    sampling_policy policy)
 {
-    std::logic_error("A benchmark_cell group doen't support sampling of internal state!");
+    throw std::logic_error("A benchmark_cell group doen't support sampling of internal state!");
 }
 
 } // namespace arb

--- a/arbor/spike_source_cell_group.cpp
+++ b/arbor/spike_source_cell_group.cpp
@@ -64,7 +64,7 @@ void spike_source_cell_group::clear_spikes() {
 }
 
 void spike_source_cell_group::add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function, sampling_policy) {
-    std::logic_error("A spike_source_cell group doen't support sampling of internal state!");
+    throw std::logic_error("A spike_source_cell group doen't support sampling of internal state!");
 }
 
 } // namespace arb

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -93,7 +93,7 @@ public:
         ncells_exc_(nexc), ncells_inh_(ninh), delay_(delay), seed_(seed) {
         // Make sure that in_degree_prop in the interval (0, 1]
         if (in_degree_prop <= 0.0 || in_degree_prop > 1.0) {
-            std::out_of_range("The proportion of incoming connections should be in the interval (0, 1].");
+            throw std::out_of_range("The proportion of incoming connections should be in the interval (0, 1].");
         }
 
         // Set up the parameters.

--- a/test/unit/test_simd.cpp
+++ b/test/unit/test_simd.cpp
@@ -129,8 +129,9 @@ TYPED_TEST_P(simd_value, elements) {
     EXPECT_TRUE(testing::indexed_eq_n(N, bv, b));
 
     // array rvalue initialization:
+    auto cv_copy = cv;
     simd c(std::move(cv));
-    EXPECT_TRUE(testing::indexed_eq_n(N, cv, c));
+    EXPECT_TRUE(testing::indexed_eq_n(N, cv_copy, c));
 
     // pointer initialization:
     simd d(&dv[0]);
@@ -415,8 +416,9 @@ TYPED_TEST_P(simd_value, mask_elements) {
         EXPECT_TRUE(testing::indexed_eq_n(N, bv, b));
 
         // array rvalue initialization:
+        auto cv_copy = cv;
         mask c(std::move(cv));
-        EXPECT_TRUE(testing::indexed_eq_n(N, cv, c));
+        EXPECT_TRUE(testing::indexed_eq_n(N, cv_copy, c));
 
         // pointer initialization:
         mask d(&dv[0]);


### PR DESCRIPTION
Addresses some of the warnings from static analysis tools in #1084 

* fix some instances where exceptions were constructed, but not thrown
* fix use-after-move in a unit test.