### PR TITLE
Add readme to examples.

### DIFF
--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -200,6 +200,8 @@ For more detailed build configuration options, see the `quick start <quickstart_
     make -j 4
     # 3.2) Build Arbor unit tests.
     make -j 4 tests
+    # 3.3) Build Arbor C++ examples.
+    make -j 4 examples
 
     # 4) Run tests.
     ./bin/unit

--- a/example/dryrun/readme.md
+++ b/example/dryrun/readme.md
@@ -87,15 +87,19 @@ The parameters in the file:
     The total number of cells in the model = num-cells-per-rank *
     num-ranks.
   * `duration`: the length of the simulated time interval, in ms.
-  * `fan-in`: the number of incoming connections on each cell.
   * `min-delay`: the minimum delay of the network.
-  * `spike-frequency`: frequency of the independent Poisson processes that
-    generate spikes for each cell.
-  * `realtime-ratio`: the ratio between time taken to advance a single cell in
-    the simulation and the simulated time. For example, a value of 1 indicates
-    that the cell is simulated in real time, while a value of 0.1 indicates
-    that 10s can be simulated in a single second.
+  
+In addition, these parameters for the synthetic benchmark cell are
+understood:
+  * `depth`: number of levels, excluding soma (default: 5)
+  * `branch-probs`: Probability of a branch occuring (default: 1-0.5).
+  * `compartments`: Compartment count on a branch (default: 20-2).
+  * `lengths`: Length of branch in μm (default: 200-20).
+  * `synapses`: The number of synapses per cell (default: 1).
 
-The network is randomly connected with no self-connections and `fan-in`
-incoming connections on each cell, with every connection having delay of
-`min-delay`.
+Parameters given as ranges will take on the first value at the soma
+and the second at the leaves, values in between will be interpolated
+linearly.
+
+The network is randomly connected with no self-connections, with every
+connection having delay of `min-delay`.

--- a/example/readme.md
+++ b/example/readme.md
@@ -1,0 +1,18 @@
+# C++ Examples
+
+A series of mini-apps to demonstrate specific features.
+Please refer to the respective sub-directories for more
+information.
+
+All examples can be built by setting up the standard
+CMake build process, e.g.
+
+    # go to arbor's source directory   
+    cd arbor
+    # set up a build dir
+    mkdir build
+    cd build
+    # configure (example options for an MPI-enabled build)
+    cmake .. -DARB_VECTORIZE=ON -DARB_WITH_MPI=ON -DCMAKE_CXX_COMPILER=`which g++`
+    make examples
+    

--- a/example/readme.md
+++ b/example/readme.md
@@ -2,17 +2,19 @@
 
 A series of mini-apps to demonstrate specific features.
 Please refer to the respective sub-directories for more
-information.
+detailled descriptions of the individual examples.
 
 All examples can be built by setting up the standard
 CMake build process, e.g.
 
-    # go to arbor's source directory   
+    # go to arbor's source directory
     cd arbor
     # set up a build dir
     mkdir build
     cd build
-    # configure (example options for an MPI-enabled build)
+    # configure (example options for an MPI-enabled SIMD build)
     cmake .. -DARB_VECTORIZE=ON -DARB_WITH_MPI=ON -DCMAKE_CXX_COMPILER=`which g++`
+    # build
     make examples
-    
+    # try out the dryrun example
+    bin/dryrun


### PR DESCRIPTION
Add a readme for the examples, aimed at beginners, who might want to learn Arbor's C++ interface by looking at the examples.