### PR TITLE
Undo hip-clang bug workaround

### DIFF
--- a/arbor/backends/gpu/hip_api.hpp
+++ b/arbor/backends/gpu/hip_api.hpp
@@ -4,12 +4,6 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 
-
-// hipcc compiler bug workaroubd :pow (double, int) not defined
-__device__ __inline__ double pow(double x, int y) {
-    return __ocml_pow_f64(x, (double)y);
-}
-
 namespace arb {
 namespace gpu {
 

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -48,7 +48,7 @@ We recommend using GCC or Clang, for which Arbor has been tested and optimised.
     GCC         8.4.0
     Clang       8.0          Needs GCC 8 or later for standard library.
     Apple Clang 9            Apple LLVM version 9.0.0 (clang-900.0.39.2)
-    Hip Clang   Rocm 3.6     HIP support is currently experimental.
+    Hip Clang   ROCm 3.9     HIP support is currently experimental.
     =========== ============ ============================================
 
 .. _note_CC:


### PR DESCRIPTION
`pow(double x, int y)` is implemented as of ROCm-3.9 (May have been fixed earlier, don't have access to earlier versions)