### PR TITLE
`std::allocator<void>` is deprecated in C++17

### DIFF
--- a/arbor/memory/allocator.hpp
+++ b/arbor/memory/allocator.hpp
@@ -184,7 +184,7 @@ public:
         return &r;
     }
 
-    pointer allocate(size_type cnt, typename std::allocator<void>::const_pointer = 0) {
+    pointer allocate(size_type cnt, const_pointer = 0) {
         if (cnt) {
             return reinterpret_cast<T*>(allocate_policy(cnt*sizeof(T)));
         }

--- a/arbor/memory/allocator.hpp
+++ b/arbor/memory/allocator.hpp
@@ -184,7 +184,7 @@ public:
         return &r;
     }
 
-    pointer allocate(size_type cnt, const_pointer = 0) {
+    pointer allocate(size_type cnt) {
         if (cnt) {
             return reinterpret_cast<T*>(allocate_policy(cnt*sizeof(T)));
         }


### PR DESCRIPTION
... so it has been removed.