### PR TITLE
Fix GIL related error in pybind11 interface.

### DIFF
--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -49,7 +49,12 @@ arb::util::unique_any convert_cell(pybind11::object o) {
         return arb::util::unique_any(cast<arb::benchmark_cell>(o));
     }
     if (isinstance<arb::lif_cell>(o)) {
-        return arb::util::unique_any(cast<arb::lif_cell>(o));
+        try {
+            return arb::util::unique_any(cast<arb::lif_cell>(o));
+        } catch(...) {
+            std::cerr << "ooops" << std::endl;
+            throw;
+        }
     }
     if (isinstance<arb::cable_cell>(o)) {
         return arb::util::unique_any(cast<arb::cable_cell>(o));

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -30,36 +30,6 @@
 #include "strprintf.hpp"
 
 namespace pyarb {
-
-// Convert a cell description inside a Python object to a cell
-// description in a unique_any, as required by the recipe interface.
-//
-// Warning: requires that the GIL has been acquired before calling,
-// if there is a segmentation fault in the cast or isinstance calls,
-// check that the caller has the GIL.
-arb::util::unique_any convert_cell(pybind11::object o) {
-    using pybind11::isinstance;
-    using pybind11::cast;
-
-    pybind11::gil_scoped_acquire guard;
-    if (isinstance<arb::spike_source_cell>(o)) {
-        return arb::util::unique_any(cast<arb::spike_source_cell>(o));
-    }
-    if (isinstance<arb::benchmark_cell>(o)) {
-        return arb::util::unique_any(cast<arb::benchmark_cell>(o));
-    }
-    if (isinstance<arb::lif_cell>(o)) {
-        return arb::util::unique_any(cast<arb::lif_cell>(o));
-    }
-    if (isinstance<arb::cable_cell>(o)) {
-        return arb::util::unique_any(cast<arb::cable_cell>(o));
-    }
-
-    throw pyarb_error("recipe.cell_description returned \""
-                      + std::string(pybind11::str(o))
-                      + "\" which does not describe a known Arbor cell type");
-}
-
 //
 //  proxies
 //

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -49,12 +49,7 @@ arb::util::unique_any convert_cell(pybind11::object o) {
         return arb::util::unique_any(cast<arb::benchmark_cell>(o));
     }
     if (isinstance<arb::lif_cell>(o)) {
-        try {
-            return arb::util::unique_any(cast<arb::lif_cell>(o));
-        } catch(...) {
-            std::cerr << "ooops" << std::endl;
-            throw;
-        }
+        return arb::util::unique_any(cast<arb::lif_cell>(o));
     }
     if (isinstance<arb::cable_cell>(o)) {
         return arb::util::unique_any(cast<arb::cable_cell>(o));

--- a/python/cells.hpp
+++ b/python/cells.hpp
@@ -7,7 +7,6 @@
 #include <arbor/util/unique_any.hpp>
 
 namespace pyarb {
-arb::util::unique_any convert_cell(pybind11::object o);
 
 struct global_props_shim {
     arb::mechanism_catalogue cat;

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -25,9 +25,9 @@ namespace pyarb {
 
 // Convert a cell description inside a Python object to a cell description in a
 // unique_any, as required by the recipe interface.
-// This helper is only to be called while holding the GIL We require this guard
-// across the lifetime of the description object `d`, since this function can be
-// called without holding the GIL, ie from `simulation::init`, and `d` is a
+// This helper is only to be called while holding the GIL. We require this guard
+// across the lifetime of the description object `o`, since this function can be
+// called without holding the GIL, ie from `simulation::init`, and `o` is a
 // python object that can only be destroyed while holding the GIL. The fact that
 // `cell_description` has a scoped GIL does not help with destruction as it
 // happens outside that scope. `Description` needs to be extended in Python,
@@ -93,8 +93,7 @@ static std::vector<arb::event_generator> convert_gen(std::vector<pybind11::objec
 std::vector<arb::event_generator> py_recipe_shim::event_generators(arb::cell_gid_type gid) const {
     return try_catch_pyexception([&](){
         pybind11::gil_scoped_acquire guard;
-        auto result = convert_gen(impl_->event_generators(gid), gid);
-        return result;
+        return convert_gen(impl_->event_generators(gid), gid);
     },
         "Python error already thrown");
 }

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -11,7 +11,6 @@
 #include <arbor/morph/primitives.hpp>
 #include <arbor/recipe.hpp>
 #include <arbor/spike_source_cell.hpp>
-#include <arbor/lif_cell.hpp>
 
 #include "cells.hpp"
 #include "conversion.hpp"

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -11,6 +11,7 @@
 #include <arbor/morph/primitives.hpp>
 #include <arbor/recipe.hpp>
 #include <arbor/spike_source_cell.hpp>
+#include <arbor/lif_cell.hpp>
 
 #include "cells.hpp"
 #include "conversion.hpp"
@@ -25,8 +26,15 @@ namespace pyarb {
 // unwrapped and copied into a arb::util::unique_any.
 arb::util::unique_any py_recipe_shim::get_cell_description(arb::cell_gid_type gid) const {
     return try_catch_pyexception(
-                [&](){ return convert_cell(impl_->cell_description(gid)); },
-                "Python error already thrown");
+        [&](){
+            arb::util::unique_any result;
+            {
+                pybind11::gil_scoped_acquire guard;
+                result = convert_cell(impl_->cell_description(gid));
+            }
+            return result;
+        },
+        "Python error already thrown");
 }
 
 std::vector<arb::event_generator> convert_gen(std::vector<pybind11::object> pygens, arb::cell_gid_type gid) {

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -56,6 +56,7 @@ static arb::util::unique_any convert_cell(pybind11::object o) {
 
 // The py::recipe::cell_decription returns a pybind11::object, that is
 // unwrapped and copied into a arb::util::unique_any.
+ arb::util::unique_any py_recipe_shim::get_cell_description(arb::cell_gid_type gid) const {
     return try_catch_pyexception([&](){
         pybind11::gil_scoped_acquire guard;
         return convert_cell(impl_->cell_description(gid));

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -6,11 +6,13 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
 
+#include <arbor/benchmark_cell.hpp>
 #include <arbor/cable_cell.hpp>
+#include <arbor/lif_cell.hpp>
+#include <arbor/spike_source_cell.hpp>
 #include <arbor/event_generator.hpp>
 #include <arbor/morph/primitives.hpp>
 #include <arbor/recipe.hpp>
-#include <arbor/spike_source_cell.hpp>
 
 #include "cells.hpp"
 #include "conversion.hpp"
@@ -21,28 +23,51 @@
 
 namespace pyarb {
 
-// The py::recipe::cell_decription returns a pybind11::object, that is
-// unwrapped and copied into a arb::util::unique_any.
-arb::util::unique_any py_recipe_shim::get_cell_description(arb::cell_gid_type gid) const {
-    return try_catch_pyexception(
-        [&](){
-            arb::util::unique_any result;
-            {
-                pybind11::gil_scoped_acquire guard;
-                result = convert_cell(impl_->cell_description(gid));
-            }
-            return result;
-        },
-        "Python error already thrown");
-}
-
-std::vector<arb::event_generator> convert_gen(std::vector<pybind11::object> pygens, arb::cell_gid_type gid) {
-    using namespace std::string_literals;
+// Convert a cell description inside a Python object to a cell description in a
+// unique_any, as required by the recipe interface.
+// This helper is only to be called while holding the GIL We require this guard
+// across the lifetime of the description object `d`, since this function can be
+// called without holding the GIL, ie from `simulation::init`, and `d` is a
+// python object that can only be destroyed while holding the GIL. The fact that
+// `cell_description` has a scoped GIL does not help with destruction as it
+// happens outside that scope. `Description` needs to be extended in Python,
+// inheriting from the pybind11 class.
+static arb::util::unique_any convert_cell(pybind11::object o) {
     using pybind11::isinstance;
     using pybind11::cast;
 
-    // Aquire the GIL because it must be held when calling isinstance and cast.
-    pybind11::gil_scoped_acquire guard;
+    if (isinstance<arb::spike_source_cell>(o)) {
+        return arb::util::unique_any(cast<arb::spike_source_cell>(o));
+    }
+    if (isinstance<arb::benchmark_cell>(o)) {
+        return arb::util::unique_any(cast<arb::benchmark_cell>(o));
+    }
+    if (isinstance<arb::lif_cell>(o)) {
+        return arb::util::unique_any(cast<arb::lif_cell>(o));
+    }
+    if (isinstance<arb::cable_cell>(o)) {
+        return arb::util::unique_any(cast<arb::cable_cell>(o));
+    }
+
+    throw pyarb_error("recipe.cell_description returned \""
+                      + std::string(pybind11::str(o))
+                      + "\" which does not describe a known Arbor cell type");
+}
+
+// The py::recipe::cell_decription returns a pybind11::object, that is
+// unwrapped and copied into a arb::util::unique_any.
+    return try_catch_pyexception([&](){
+        pybind11::gil_scoped_acquire guard;
+        return convert_cell(impl_->cell_description(gid));
+    },
+        "Python error already thrown");
+}
+
+// This helper is only to called while holding the GIL, see above.
+static std::vector<arb::event_generator> convert_gen(std::vector<pybind11::object> pygens, arb::cell_gid_type gid) {
+    using namespace std::string_literals;
+    using pybind11::isinstance;
+    using pybind11::cast;
 
     std::vector<arb::event_generator> gens;
     gens.reserve(pygens.size());
@@ -65,9 +90,12 @@ std::vector<arb::event_generator> convert_gen(std::vector<pybind11::object> pyge
 }
 
 std::vector<arb::event_generator> py_recipe_shim::event_generators(arb::cell_gid_type gid) const {
-    return try_catch_pyexception(
-                [&](){ return convert_gen(impl_->event_generators(gid), gid); },
-                "Python error already thrown");
+    return try_catch_pyexception([&](){
+        pybind11::gil_scoped_acquire guard;
+        auto result = convert_gen(impl_->event_generators(gid), gid);
+        return result;
+    },
+        "Python error already thrown");
 }
 
 std::string con_to_string(const arb::cell_connection& c) {


### PR DESCRIPTION
Fixes an issue in the python bindings, that appeared when upgrading to pybind11 v2.6.1, 
see https://github.com/arbor-sim/arbor/issues/1271.

This is triggered by the upgrade, but is actually incorrect in any case. Here is why:

- (PY) Simulation::init releases the GIL
- (CXX) Simulation calls through to the Recipe
- (PY) A python class deriving from (CXX) Recipe returns a python object.
- This (PY) object is then destroyed in python land, which requires the GIL.

Pybind11 only guarantees acquisition of the GIL at edges C++ -> Python.
So, we need an extra GIL acquisition here. Our usecase is actually an example
here
https://pybind11.readthedocs.io/en/stable/advanced/misc.html?highlight=gil#global-interpreter-lock-gil.

Note: We use `OVERLOAD_PURE` here, which acquires the GIL at the edge Python -> C++
for the duration of the wrapped call, *but* that does not cover the destruction of the return
value, thus triggering the bug.

I tested the fix with multiple threads on my machine, but it's quite hard to test.

T

Update:
In addition -- like mentioned in #1271 -- event generators have been fixed. None of the other
methods in recipe produce this issues. Only simulation releases the GIL, no other trampolines 
are used. This should eliminate all of the issues.