### PR TITLE
modcc : report linear test error.

### DIFF
--- a/modcc/printer/cexpr_emit.cpp
+++ b/modcc/printer/cexpr_emit.cpp
@@ -23,10 +23,11 @@ std::ostream& operator<<(std::ostream& out, as_c_double wrap) {
     default:
         double val;
         std::stringstream s;
+        // If wrap.value is an int print it as X.0, this is needed for std::max and std::min
         if (std::modf(wrap.value, &val) == 0) {
             s << io::classic << std::fixed << std::setprecision(1) << wrap.value;
         } else {
-            s << io::classic << std::setprecision(1) << wrap.value;
+            s << io::classic << std::setprecision(17) << wrap.value;
         }
         return out << s.rdbuf();
     }

--- a/modcc/printer/cexpr_emit.cpp
+++ b/modcc/printer/cexpr_emit.cpp
@@ -21,8 +21,14 @@ std::ostream& operator<<(std::ostream& out, as_c_double wrap) {
     case FP_ZERO:
         return out << (neg? "-0.": "0.");
     default:
-        return out <<
-            (std::stringstream{} << io::classic << std::setprecision(17) << wrap.value).rdbuf();
+        double val;
+        std::stringstream s;
+        if (std::modf(wrap.value, &val) == 0) {
+            s << io::classic << std::fixed << std::setprecision(1) << wrap.value;
+        } else {
+            s << io::classic << std::setprecision(1) << wrap.value;
+        }
+        return out << s.rdbuf();
     }
 }
 

--- a/test/unit-modcc/test_printers.cpp
+++ b/test/unit-modcc/test_printers.cpp
@@ -58,15 +58,15 @@ TEST(scalar_printer, constants) {
 
 TEST(scalar_printer, statement) {
     std::vector<testcase> testcases = {
-        {"y=x+3",            "y=x+3"},
+        {"y=x+3",            "y=x+3.0"},
         {"y=y^z",            "y=pow(y,z)"},
-        {"y=exp((x/2) + 3)", "y=exp(x/2+3)"},
+        {"y=exp((x/2) + 3)", "y=exp(x/2.0+3.0)"},
         {"z=a/b/c",          "z=a/b/c"},
         {"z=a/(b/c)",        "z=a/(b/c)"},
         {"z=(a*b)/c",        "z=a*b/c"},
         {"z=a-(b+c)",        "z=a-(b+c)"},
         {"z=(a>0)<(b>0)",    "z=a>0.<(b>0.)"},
-        {"z=a- -2",          "z=a- -2"},
+        {"z=a- -2",          "z=a- -2.0"},
         {"z=fabs(x-z)",      "z=abs(x-z)"},
         {"z=min(x,y)",       "z=min(x,y)"},
         {"z=min(max(a,b),y)","z=min(max(a,b),y)"},
@@ -125,10 +125,10 @@ TEST(CPrinter, proc_body) {
             "}"
             ,
             "value_type k;\n"
-            "minf[i_] = 1-1/(1+exp((v-k)/k));\n"
-            "hinf[i_] = 1/(1+exp((v-k)/k));\n"
+            "minf[i_] = 1.0-1.0/(1.0+exp((v-k)/k));\n"
+            "hinf[i_] = 1.0/(1.0+exp((v-k)/k));\n"
             "mtau[i_] = 0.5;\n"
-            "htau[i_] = 1500;\n"
+            "htau[i_] = 1500.0;\n"
         }
     };
 
@@ -205,15 +205,15 @@ TEST(CPrinter, proc_body_inlined) {
         "r_7_ = 0.;\n"
         "r_8_ = 0.;\n"
         "r_9_=s2[i_]*0.33333333333333331;\n"
-        "r_8_=s1[i_]+2;\n"
-        "if(s1[i_]==3){\n"
-        "   r_7_=2*r_8_;\n"
+        "r_8_=s1[i_]+2.0;\n"
+        "if(s1[i_]==3.0){\n"
+        "   r_7_=2.0*r_8_;\n"
         "}\n"
         "else{\n"
-        "   if(s1[i_]==4){\n"
+        "   if(s1[i_]==4.0){\n"
         "       r_11_ = 0.;\n"
         "       r_12_ = 0.;\n"
-        "       r_12_=6+s1[i_];\n"
+        "       r_12_=6.0+s1[i_];\n"
         "       r_11_=r_12_;\n"
         "       r_7_=r_8_*r_11_;\n"
         "   }\n"
@@ -226,28 +226,28 @@ TEST(CPrinter, proc_body_inlined) {
         "r_14_=0.;\n"
         "r_14_=r_9_/s2[i_];\n"
         "r_15_=log(r_14_);\n"
-        "r_13_=42*r_15_;\n"
+        "r_13_=42.0*r_15_;\n"
         "r_6_=r_9_*r_13_;\n"
         "t0=r_7_*r_6_;\n"
         "t1=exprelr(t0);\n"
-        "ll0_=t1+2;\n"
-        "if(ll0_==3){\n"
-        "   t2=10;\n"
+        "ll0_=t1+2.0;\n"
+        "if(ll0_==3.0){\n"
+        "   t2=10.0;\n"
         "}\n"
         "else{\n"
-        "   if(ll0_==4){\n"
+        "   if(ll0_==4.0){\n"
         "       r_17_=0.;\n"
         "       r_18_=0.;\n"
-        "       r_18_=6+ll0_;\n"
+        "       r_18_=6.0+ll0_;\n"
         "       r_17_=r_18_;\n"
-        "       t2=5*r_17_;\n"
+        "       t2=5.0*r_17_;\n"
         "   }\n"
         "   else{\n"
         "       r_16_=148.4131591025766;\n"
         "       t2=r_16_*ll0_;\n"
         "   }\n"
         "}\n"
-        "s2[i_]=t2+4;\n";
+        "s2[i_]=t2+4.0;\n";
 
     Module m(io::read_all(DATADIR "/mod_files/test6.mod"), "test6.mod");
     Parser p(m, false);
@@ -277,25 +277,25 @@ TEST(CPrinter, proc_body_inlined) {
 TEST(SimdPrinter, simd_if_else) {
     std::vector<const char*> expected_procs = {
             "simd_value u;\n"
-            "simd_mask mask_0_ = S::cmp_gt(i, (double)2);\n"
-            "S::where(mask_0_,u) = (double)7;\n"
-            "S::where(S::logical_not(mask_0_),u) = (double)5;\n"
-            "indirect(s+i_, simd_width_) = S::where(S::logical_not(mask_0_),simd_cast<simd_value>((double)42));\n"
+            "simd_mask mask_0_ = S::cmp_gt(i, (double)2.0);\n"
+            "S::where(mask_0_,u) = (double)7.0;\n"
+            "S::where(S::logical_not(mask_0_),u) = (double)5.0;\n"
+            "indirect(s+i_, simd_width_) = S::where(S::logical_not(mask_0_),simd_cast<simd_value>((double)42.0));\n"
             "indirect(s+i_, simd_width_) = u;"
             ,
             "simd_value u;\n"
-            "simd_mask mask_1_ = S::cmp_gt(i, (double)2);\n"
-            "S::where(mask_1_,u) = (double)7;\n"
-            "S::where(S::logical_not(mask_1_),u) = (double)5;\n"
-            "indirect(s+i_, simd_width_) = S::where(S::logical_and(S::logical_not(mask_1_), mask_input_),simd_cast<simd_value>((double)42));\n"
+            "simd_mask mask_1_ = S::cmp_gt(i, (double)2.0);\n"
+            "S::where(mask_1_,u) = (double)7.0;\n"
+            "S::where(S::logical_not(mask_1_),u) = (double)5.0;\n"
+            "indirect(s+i_, simd_width_) = S::where(S::logical_and(S::logical_not(mask_1_), mask_input_),simd_cast<simd_value>((double)42.0));\n"
             "indirect(s+i_, simd_width_) = S::where(mask_input_, u);"
             ,
-            "simd_mask mask_2_ = S::cmp_gt(simd_cast<simd_value>(indirect(g+i_, simd_width_)), (double)2);\n"
-            "simd_mask mask_3_ = S::cmp_gt(simd_cast<simd_value>(indirect(g+i_, simd_width_)), (double)3);\n"
+            "simd_mask mask_2_ = S::cmp_gt(simd_cast<simd_value>(indirect(g+i_, simd_width_)), (double)2.0);\n"
+            "simd_mask mask_3_ = S::cmp_gt(simd_cast<simd_value>(indirect(g+i_, simd_width_)), (double)3.0);\n"
             "S::where(S::logical_and(mask_2_,mask_3_),i) = (double)0.;\n"
-            "S::where(S::logical_and(mask_2_,S::logical_not(mask_3_)),i) = (double)1;\n"
-            "simd_mask mask_4_ = S::cmp_lt(simd_cast<simd_value>(indirect(g+i_, simd_width_)), (double)1);\n"
-            "indirect(s+i_, simd_width_) = S::where(S::logical_and(S::logical_not(mask_2_),mask_4_),simd_cast<simd_value>((double)2));\n"
+            "S::where(S::logical_and(mask_2_,S::logical_not(mask_3_)),i) = (double)1.0;\n"
+            "simd_mask mask_4_ = S::cmp_lt(simd_cast<simd_value>(indirect(g+i_, simd_width_)), (double)1.0);\n"
+            "indirect(s+i_, simd_width_) = S::where(S::logical_and(S::logical_not(mask_2_),mask_4_),simd_cast<simd_value>((double)2.0));\n"
             "rates(i_, S::logical_and(S::logical_not(mask_2_),S::logical_not(mask_4_)), i);"
     };
 

--- a/test/unit-modcc/test_symdiff.cpp
+++ b/test/unit-modcc/test_symdiff.cpp
@@ -217,6 +217,19 @@ TEST(symbolic_pdiff, nonlinear) {
     }
 }
 
+TEST(symbolic_pdiff, non_differentiable) {
+    struct { const char* exp; } tests[] = {
+            { "max(x)"},
+            { "min(a)"}
+    };
+
+    for (const auto& item: tests) {
+        SCOPED_TRACE(std::string("expressions: ")+item.exp);
+        auto exp = Parser{item.exp}.parse_expression();
+        ASSERT_FALSE(exp);
+    }
+}
+
 inline expression_ptr operator""_expr(const char* literal, std::size_t) {
     return Parser{literal}.parse_expression();
 }
@@ -311,6 +324,18 @@ TEST(linear_test, nonlinear) {
 
     r = linear_test("x+y*x"_expr, {"x", "y"});
     EXPECT_FALSE(r.is_linear);
+}
+
+TEST(linear_test, non_differentiable) {
+    linear_test_result r;
+
+    r = linear_test("max(x)"_expr, {"x"});
+    EXPECT_FALSE(r.is_linear);
+    EXPECT_FALSE(r.is_homogeneous);
+
+    r = linear_test("min(x)"_expr, {"x"});
+    EXPECT_FALSE(r.is_linear);
+    EXPECT_FALSE(r.is_homogeneous);
 }
 
 TEST(linear_test, diagonality) {

--- a/test/unit-modcc/test_symdiff.cpp
+++ b/test/unit-modcc/test_symdiff.cpp
@@ -329,11 +329,11 @@ TEST(linear_test, nonlinear) {
 TEST(linear_test, non_differentiable) {
     linear_test_result r;
 
-    r = linear_test("max(x)"_expr, {"x"});
+    r = linear_test("max(x, y)"_expr, {"x", "y"});
     EXPECT_FALSE(r.is_linear);
     EXPECT_FALSE(r.is_homogeneous);
 
-    r = linear_test("min(x)"_expr, {"x"});
+    r = linear_test("min(x, y)"_expr, {"x", "y"});
     EXPECT_FALSE(r.is_linear);
     EXPECT_FALSE(r.is_homogeneous);
 }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ set(test_mechanisms
     test1_kin_steadystate
     fixed_ica_current
     point_ica_current
+    non_linear
     linear_ca_conc
     test_cl_valence
     test_ca_read_valence

--- a/test/unit/mod/non_linear.mod
+++ b/test/unit/mod/non_linear.mod
@@ -1,0 +1,32 @@
+NEURON {
+    POINT_PROCESS non_linear
+    RANGE tau, e
+    NONSPECIFIC_CURRENT i
+}
+
+PARAMETER {
+    tau = 2.0 (ms) : the default for Neuron is 0.1
+    e = 0   (mV)
+}
+
+STATE {
+    g
+}
+
+INITIAL {
+    g=0
+}
+
+BREAKPOINT {
+    SOLVE state METHOD cnexp
+    i = g*(v - e)
+}
+
+DERIVATIVE state {
+    g' = -g/tau
+}
+
+NET_RECEIVE(weight) {
+     g = max(0, min(g + weight, 10))
+}
+

--- a/test/unit/test_mechinfo.cpp
+++ b/test/unit/test_mechinfo.cpp
@@ -5,6 +5,7 @@
 #include <arbor/cable_cell.hpp>
 
 #include "../gtest.h"
+#include "unit_test_catalogue.hpp"
 
 // TODO: This test is really checking part of the recipe description
 // for cable1d cells, so move it there. Make actual tests for mechinfo
@@ -39,4 +40,17 @@ TEST(mechanism_desc, setting) {
     EXPECT_EQ(p["a"], m["a"]);
     EXPECT_EQ(p["b"], m["b"]);
     EXPECT_EQ(p["d"], m["d"]);
+}
+
+TEST(mechanism_desc, linearity) {
+    {
+        mechanism_catalogue cat = arb::global_default_catalogue();
+        EXPECT_TRUE(cat["expsyn"].linear);
+        EXPECT_TRUE(cat["exp2syn"].linear);
+    }
+    {
+        mechanism_catalogue cat = make_unit_test_catalogue();
+        EXPECT_FALSE(cat["non_linear"].linear);
+    }
+
 }

--- a/test/unit/unit_test_catalogue.cpp
+++ b/test/unit/unit_test_catalogue.cpp
@@ -11,6 +11,7 @@
 #include "mechanisms/celsius_test.hpp"
 #include "mechanisms/diam_test.hpp"
 #include "mechanisms/param_as_state.hpp"
+#include "mechanisms/non_linear.hpp"
 #include "mechanisms/test0_kin_diff.hpp"
 #include "mechanisms/test_linear_state.hpp"
 #include "mechanisms/test_linear_init.hpp"
@@ -80,6 +81,7 @@ mechanism_catalogue make_unit_test_catalogue(const mechanism_catalogue& from) {
     ADD_MECH(cat, test1_kin_compartment)
     ADD_MECH(cat, test4_kin_compartment)
     ADD_MECH(cat, fixed_ica_current)
+    ADD_MECH(cat, non_linear)
     ADD_MECH(cat, point_ica_current)
     ADD_MECH(cat, linear_ca_conc)
     ADD_MECH(cat, test_cl_valence)


### PR DESCRIPTION
* Fixes segfault in modcc: can be reproduced with a synapse that use `max` or `min` expressions in the `net_receive` block: we test for linearity to check whether they can be coalesced; we cannot differentiate the expression; an error is raised but not reported; seg fault. 
* Fixes ` as_c_double` printing which does not print integers as doubles as intended. 

Fixes #1275 