### PR TITLE
Added some lines to help sell the recipe concept

### DIFF
--- a/doc/concepts/recipe.rst
+++ b/doc/concepts/recipe.rst
@@ -17,6 +17,12 @@ building phase to provide information about cells in the model, such as:
   * **Gap junction connections** on a cell.
   * **Probes** on a cell.
 
+Recipes are structured in such a way that during the lifetime of the simulation properties
+of each cell in the network can be retrieved rapidly by their global identifier (`gid`).
+To be able to quickly look-up properties related to the connections going in and out of a
+cell (think of synapses, gap junctions, but also probes and input events) is a particularly
+important ingredient that helps make Arbor both easily distributable over many nodes and fast.
+
 To better illustrate the content of a recipe, let's consider the following network of
 three cells:
 
@@ -24,10 +30,10 @@ three cells:
      of the soma, a spike detector is attached, it generates a spiking event when the
      voltage goes above 10 mV. In the same spot on the soma, a current clamp is also
      attached, with the intention of triggering some spikes. All of the preceding info:
-     the morphology, dynamics, spike detector and current clamp are what is refered to in
+     the morphology, dynamics, spike detector and current clamp are what is referred to in
      Arbor as the **description** of the cell.
-   | ``Cell 0`` should be modeled as a :ref:`cable cell<modelcablecell>`,
-     (because cable cells allow complex dynamics such as ``hh``). This is refered to as
+   | ``Cell 0`` should be modelled as a :ref:`cable cell<modelcablecell>`,
+     (because cable cells allow complex dynamics such as ``hh``). This is referred to as
      the **kind** of the cell.
    | It's quite expensive to build cable cells, so we don't want to do this too often.
      But when the simulation is first set up, it needs to know how cells interact with
@@ -66,7 +72,7 @@ The recipe is used to distribute the model across machines and is used in the si
 Technical details of the recipe class are presented in the  :ref:`Python <pyrecipe>` and
 :ref:`C++ <cpprecipe>` APIs.
 
-Are recipes always neccessary?
+Are recipes always necessary?
 ------------------------------
 
 Yes. However, we provide a python :class:`single_cell_model <py_single_cell_model>`

--- a/doc/concepts/recipe.rst
+++ b/doc/concepts/recipe.rst
@@ -17,10 +17,10 @@ building phase to provide information about cells in the model, such as:
   * **Gap junction connections** on a cell.
   * **Probes** on a cell.
 
-Recipes are structured in such a way that during the lifetime of the simulation properties
-of each cell in the network can be retrieved rapidly by their global identifier (`gid`).
+Recipes are structured to provide a consistent interface for describing each cell in the
+network using their global identifier (`gid`).
 To be able to quickly look-up properties related to the connections going in and out of a
-cell (think of synapses, gap junctions, but also probes and input events) is a particularly
+cell (think of synapses, gap junctions, but also probes and spike inputs) is a particularly
 important ingredient that helps make Arbor both easily distributable over many nodes and fast.
 
 To better illustrate the content of a recipe, let's consider the following network of

--- a/doc/concepts/recipe.rst
+++ b/doc/concepts/recipe.rst
@@ -19,9 +19,9 @@ building phase to provide information about cells in the model, such as:
 
 Recipes are structured to provide a consistent interface for describing each cell in the
 network using their global identifier (`gid`).
-To be able to quickly look-up properties related to the connections going in and out of a
-cell (think of synapses, gap junctions, but also probes and spike inputs) is a particularly
-important ingredient that helps make Arbor both easily distributable over many nodes and fast.
+This allows the simulator to be able to quickly look-up properties related to the connections
+going in and out of a cell (think of synapses, gap junctions, but also probes and spike inputs);
+which helps make Arbor fast and easily distributable over many nodes.
 
 To better illustrate the content of a recipe, let's consider the following network of
 three cells:


### PR DESCRIPTION
Now we connect to a feature we see in the API and new tutorials: why a recipe overrides functions related to connections based on gid. The 'why recipes' section now has something to build on as well.