### PR TITLE
Fix CMake to use correct PYTHON_EXECUTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ option(ARB_WITH_PYTHON "enable Python front end" OFF)
 
 if (ARB_WITH_PYTHON)
     # Find path in which to install the Python module.
-    find_package(PythonInterp REQUIRED)
+    find_package (Python3 COMPONENTS Interpreter)
     # Ask the above found Python where it keeps its system (platform) packages.
     execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib'))" OUTPUT_VARIABLE ARB_PYTHON_LIB_PATH_DEFAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
     # Default to installing in that path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,15 +59,6 @@ option(ARB_WITH_NEUROML "build NeuroML support library" OFF)
 
 option(ARB_WITH_PYTHON "enable Python front end" OFF)
 
-if (ARB_WITH_PYTHON)
-    # Find path in which to install the Python module.
-    find_package (Python3 COMPONENTS Interpreter)
-    # Ask the above found Python where it keeps its system (platform) packages.
-    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib'))" OUTPUT_VARIABLE ARB_PYTHON_LIB_PATH_DEFAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
-    # Default to installing in that path
-    set(ARB_PYTHON_LIB_PATH ${ARB_PYTHON_LIB_PATH_DEFAULT} CACHE PATH "path for installing Python module for Arbor.")
-endif()
-
 #----------------------------------------------------------
 # Global CMake configuration
 #----------------------------------------------------------

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,13 +14,6 @@ endif()
 set(PYBIND11_CPP_STANDARD -std=c++17)
 add_subdirectory(pybind11)
 
-# Find path in which to install the Python module.
-find_package(PythonInterp REQUIRED)
-# Ask the above found Python where it keeps its system (platform) packages.
-execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib'))" OUTPUT_VARIABLE ARB_PYTHON_LIB_PATH_DEFAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
-# Default to installing in that path
-set(ARB_PYTHON_LIB_PATH ${ARB_PYTHON_LIB_PATH_DEFAULT} CACHE PATH "path for installing Python module for Arbor.")
-
 set(pyarb_source
     cable_probes.cpp
     cells.cpp
@@ -81,5 +74,10 @@ file(COPY "${PROJECT_SOURCE_DIR}/python/__init__.py" DESTINATION "${python_mod_p
 file(COPY "${PROJECT_SOURCE_DIR}/VERSION" DESTINATION "${python_mod_path}")
 
 # Set the installation path
+
+# Ask Python where it keeps its system (platform) packages.
+execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib'))" OUTPUT_VARIABLE ARB_PYTHON_LIB_PATH_DEFAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Default to installing in that path, override with user specified ARB_PYTHON_LIB_PATH
+set(ARB_PYTHON_LIB_PATH ${ARB_PYTHON_LIB_PATH_DEFAULT} CACHE PATH "path for installing Python module for Arbor.")
 
 install(DIRECTORY ${python_mod_path} DESTINATION ${ARB_PYTHON_LIB_PATH})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,6 +14,13 @@ endif()
 set(PYBIND11_CPP_STANDARD -std=c++17)
 add_subdirectory(pybind11)
 
+# Find path in which to install the Python module.
+find_package(PythonInterp REQUIRED)
+# Ask the above found Python where it keeps its system (platform) packages.
+execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib'))" OUTPUT_VARIABLE ARB_PYTHON_LIB_PATH_DEFAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Default to installing in that path
+set(ARB_PYTHON_LIB_PATH ${ARB_PYTHON_LIB_PATH_DEFAULT} CACHE PATH "path for installing Python module for Arbor.")
+
 set(pyarb_source
     cable_probes.cpp
     cells.cpp


### PR DESCRIPTION
Locally `find_package(PythonInterp REQUIRED)` does not overwrite `${PYTHON_EXECUTABLE}`, but in the macos builds [on Travis](https://travis-ci.org/github/arbor-sim/arbor/jobs/750174548) it seems to go wrong. Since I can't reproduce this locally, I use this PR to test.

Of interest:
* https://gitlab.kitware.com/cmake/cmake/-/issues/19492
* https://reviews.llvm.org/D64881