### PR TITLE
Docs: recent pip please

### DIFF
--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -6,7 +6,7 @@ Python Installation
 Arbor's Python API will be the most convenient interface for most users.
 
 .. note::
-    Arbor requires Python version 3.6 and later.
+    Arbor requires Python version 3.6 and later. It is advised that you update `pip` as well.
 
 Getting Arbor
 -------------


### PR DESCRIPTION
Pip <20 does not [change the default install path from system to user upon not being run with root privileges](https://pip.pypa.io/en/stable/news/#id226). By insisting on a recent pip, we nudge users onto the happy path, without a very unhelpful error message in case they didn't run with root privileges.

It appears not possible to test for write-permissions on the install path, because setup.py does not know about the final install path! [Docs are sparse.](https://docs.python.org/3/distutils/apiref.html#module-distutils.command.build_ext) I'm open to other solutions, but please consider: this page and pip install is first and foremost for new users, so I want that process to go smoothly, especially if they have `install/python.html` open.