### PR TITLE
Use JFrog as a registry and fix build errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ stages:
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
   script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
     - docker build -f $BUILD_DOCKERFILE --network=host --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -t $BUILD_IMAGE .
     - docker push $BUILD_IMAGE
     - docker build -f $DEPLOY_DOCKERFILE --network=host --build-arg BUILD_ENV=$BUILD_IMAGE -t $DEPLOY_IMAGE .
@@ -26,17 +26,17 @@ build release:
   extends: .build_docker_images
   variables:
     BUILD_DOCKERFILE: ci/release/build.Dockerfile
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/release/build:latest
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release/build:latest
     DEPLOY_DOCKERFILE: ci/release/deploy.Dockerfile
-    DEPLOY_IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
 
 build codecov:
   extends: .build_docker_images
   variables:
     BUILD_DOCKERFILE: ci/codecov/build.Dockerfile
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/codecov/build:latest
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov/build:latest
     DEPLOY_DOCKERFILE: ci/codecov/deploy.Dockerfile
-    DEPLOY_IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
 
 notify_github_start:
   stage: build
@@ -62,7 +62,7 @@ variables:
 ### Release tests ###
 allocate release:
   stage: allocate
-  image: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   only: ['master', 'staging', 'trying']
   extends: .daint_alloc
   variables:
@@ -71,7 +71,7 @@ allocate release:
 
 single node release:
   extends: .daint
-  image: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   only: ['master', 'staging', 'trying']
   stage: test
   script:
@@ -85,7 +85,7 @@ single node release:
 
 multi node release:
   extends: .daint
-  image: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   only: ['master', 'staging', 'trying']
   stage: test
   script:
@@ -97,7 +97,7 @@ multi node release:
 
 deallocate release:
   only: ['master', 'staging', 'trying']
-  image: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   stage: cleanup
   extends: .daint_dealloc
   variables:
@@ -107,7 +107,7 @@ deallocate release:
 allocate codecov:
   stage: allocate
   only: ['master', 'staging', 'trying']
-  image: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   extends: .daint_alloc
   variables:
     PULL_IMAGE: 'YES'
@@ -116,7 +116,7 @@ allocate codecov:
 single node codecov:
   extends: .daint
   only: ['master', 'staging', 'trying']
-  image: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   stage: test
   script:
     - codecov_pre
@@ -135,7 +135,7 @@ single node codecov:
 multi node codecov:
   extends: .daint
   only: ['master', 'staging', 'trying']
-  image: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   stage: test
   script:
     - codecov_pre
@@ -152,7 +152,7 @@ multi node codecov:
 upload codecov reports:
   extends: .daint
   only: ['master', 'staging', 'trying']
-  image: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   stage: upload_reports
   variables:
     SLURM_JOB_NUM_NODES: 1
@@ -162,7 +162,7 @@ upload codecov reports:
 
 deallocate codecov:
   only: ['master', 'staging', 'trying']
-  image: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
+  image: $CSCS_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   stage: cleanup
   extends: .daint_dealloc
   variables:

--- a/arborio/CMakeLists.txt
+++ b/arborio/CMakeLists.txt
@@ -8,9 +8,9 @@ if(ARB_WITH_NEUROML)
             with_xml.cpp
             xmlwrap.cpp
         )
+    find_package(LibXml2 REQUIRED)
 endif()
 
-find_package(LibXml2 REQUIRED)
 
 add_library(arborio ${arborio-sources})
 

--- a/ci/codecov/build.Dockerfile
+++ b/ci/codecov/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+FROM nvidia/cuda:10.2-devel-ubuntu18.04
 
 WORKDIR /root
 
@@ -10,17 +10,21 @@ ENV MPICH_VERSION ${MPICH_VERSION}
 
 # Install basic tools
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
-    build-essential lcov \
     python3 \
-    git tar wget curl && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install g++8
-RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
-    gcc-8 g++-8 && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
+    git tar wget curl \
+    gcc-8 g++-8 make && \
+    update-alternatives \
+        --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-8 && \
     update-alternatives --config gcc && \
     rm -rf /var/lib/apt/lists/*
+
+RUN wget -q "https://github.com/linux-test-project/lcov/archive/v1.14.tar.gz" && \
+    tar -xzf v1.14.tar.gz && \
+    cd lcov-1.14 && \
+    make install -j$(nproc) && \
+    rm -rf lcov-1.14 v1.14.tar.gz
 
 # Install cmake
 RUN wget -qO- "https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local

--- a/ci/codecov/build.Dockerfile
+++ b/ci/codecov/build.Dockerfile
@@ -15,6 +15,11 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     git tar wget curl && \
     rm -rf /var/lib/apt/lists/*
 
+# Install g++8
+RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
+    g++-8 && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install cmake
 RUN wget -qO- "https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
 

--- a/ci/codecov/build.Dockerfile
+++ b/ci/codecov/build.Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
 
 # Install g++8
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
-    g++-8 && \
+    gcc-8 g++-8 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
+    update-alternatives --config gcc && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/ci/release/build.Dockerfile
+++ b/ci/release/build.Dockerfile
@@ -15,6 +15,11 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     git tar wget curl && \
     rm -rf /var/lib/apt/lists/*
 
+# Install g++8
+RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
+    g++-8 && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install cmake
 RUN wget -qO- "https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
 

--- a/ci/release/build.Dockerfile
+++ b/ci/release/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+FROM nvidia/cuda:10.2-devel-ubuntu18.04
 
 WORKDIR /root
 
@@ -10,15 +10,12 @@ ENV MPICH_VERSION ${MPICH_VERSION}
 
 # Install basic tools
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
-    build-essential \
     python3 \
-    git tar wget curl && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install g++8
-RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
-    gcc-8 g++-8 && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
+    git tar wget curl \
+    gcc-8 g++-8 make && \
+    update-alternatives \
+        --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
     update-alternatives --config gcc && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/release/build.Dockerfile
+++ b/ci/release/build.Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
 
 # Install g++8
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
-    g++-8 && \
+    gcc-8 g++-8 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
+    update-alternatives --config gcc && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake


### PR DESCRIPTION
* Make Gitlab CI push images to CSCS' JFrog registry reg.giuv.cscs.ch so that sarus can pull images on Daint again. 
  This URL is probably temporary until JFrog officially goes into production later this month.
  Unfortunately JFrog is currently behind the firewall.
* Upgrade g++ to g++8 on the Docker image.
* Only require libxml when compiling with NeuroML support.