### PR TITLE
Modcc: parse the unit of `FUNCTION`

### DIFF
--- a/modcc/parser.cpp
+++ b/modcc/parser.cpp
@@ -973,6 +973,14 @@ symbol_ptr Parser::parse_function() {
     auto p = parse_prototype();
     if (p == nullptr) return nullptr;
 
+    // Functions may have a unit attached
+    if (token_.type == tok::lparen) {
+        unit_description();
+        if (status_ == lexerStatus::error) {
+            return {};
+        }
+    }
+
     // check for opening left brace {
     if (!expect(tok::lbrace)) return nullptr;
 

--- a/test/unit-modcc/test_parser.cpp
+++ b/test/unit-modcc/test_parser.cpp
@@ -205,17 +205,46 @@ TEST(Parser, net_receive) {
 }
 
 TEST(Parser, function) {
-    char str[] =
-        "FUNCTION foo(x, y) {"
-        "  LOCAL a\n"
-        "  a = 3\n"
-        "  b = x * y + 2\n"
-        "  y = x + y * 2\n"
-        "  foo = a * x + y\n"
-        "}";
+    {
+        char str[] =
+            "FUNCTION foo(x, y) {"
+            "  LOCAL a\n"
+            "  a = 3\n"
+            "  b = x * y + 2\n"
+            "  y = x + y * 2\n"
+            "  foo = a * x + y\n"
+            "}";
 
-    std::unique_ptr<Symbol> sym;
-    EXPECT_TRUE(check_parse(sym, &Parser::parse_function, str));
+        std::unique_ptr<Symbol> sym;
+        EXPECT_TRUE(check_parse(sym, &Parser::parse_function, str));
+    }
+    {
+        char str[] =
+            "FUNCTION foo(x (mv), y (/mA)) {"
+            "  foo = x * y\n"
+            "}";
+
+        std::unique_ptr<Symbol> sym;
+        EXPECT_TRUE(check_parse(sym, &Parser::parse_function, str));
+    }
+    {
+        char str[] =
+            "FUNCTION foo(x (mv), y (/mA)) (mv/mA) {"
+            "  foo = x * y\n"
+            "}";
+
+        std::unique_ptr<Symbol> sym;
+        EXPECT_TRUE(check_parse(sym, &Parser::parse_function, str));
+    }
+    {
+        char str[] =
+            "FUNCTION foo(x (mv), y (/mA)) (mv-mA) {"
+            "  foo = x * y\n"
+            "}";
+
+        std::unique_ptr<Symbol> sym;
+        EXPECT_FALSE(check_parse(sym, &Parser::parse_function, str));
+    }
 }
 
 TEST(Parser, parse_solve) {


### PR DESCRIPTION
Parse and ignore the units of a FUNCTION in nmodl. 
For example, parse `(mV)` in the following:
```
FUCNTION foo(v) (mV) {
  foo = v + 5;
}
```