### PR TITLE
Fixes for codecov

### DIFF
--- a/ci/codecov/build.Dockerfile
+++ b/ci/codecov/build.Dockerfile
@@ -20,14 +20,11 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     update-alternatives --config gcc && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -q "https://github.com/linux-test-project/lcov/archive/v1.14.tar.gz" && \
-    tar -xzf v1.14.tar.gz && \
-    cd lcov-1.14 && \
+RUN wget -q "https://github.com/linux-test-project/lcov/archive/v1.15.tar.gz" && \
+    tar -xzf v1.15.tar.gz && \
+    cd lcov-1.15 && \
     make install -j$(nproc) && \
-    rm -rf lcov-1.14 v1.14.tar.gz
-
-# Install cmake
-RUN wget -qO- "https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+    rm -rf lcov-1.15 v1.15.tar.gz
 
 # Install MPICH ABI compatible with Cray's lib on Piz Daint
 RUN wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz && \
@@ -36,6 +33,10 @@ RUN wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPIC
     ./configure --disable-fortran && \
     make install -j$(nproc) && \
     rm -rf mpich-${MPICH_VERSION}.tar.gz mpich-${MPICH_VERSION}
+
+
+# Install cmake
+RUN wget -qO- "https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
 
 # Install bundle tooling for creating small Docker images
 RUN wget -q https://github.com/haampie/libtree/releases/download/v1.2.0/libtree_x86_64.tar.gz && \

--- a/ci/codecov/deploy.Dockerfile
+++ b/ci/codecov/deploy.Dockerfile
@@ -28,9 +28,8 @@ RUN mkdir ${BUILD_DIR} && cd ${BUILD_DIR} && \
       -DARB_GPU=cuda \
       -DARB_USE_BUNDLED_LIBS=ON \
       -DCMAKE_BUILD_TYPE=Debug \
-      -DCMAKE_CXX_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage" \
-      -DCMAKE_EXE_LINKER_FLAGS="-fprofile-arcs -ftest-coverage" \
-      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_FLAGS="-g -O0 --coverage" \
+      -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
       -DCMAKE_INSTALL_PREFIX=/usr && \
     make -j$(nproc) tests && \
     libtree --chrpath \

--- a/ci/codecov_post
+++ b/ci/codecov_post
@@ -10,13 +10,10 @@ mkdir -p "$SHARED_REPORTS"
 
 # Create coverage reports for code run
 echo "Combining reports"
-lcov --no-external --capture --base-directory $SOURCE_DIR --directory $BUILD_DIR --output-file "$LOCAL_REPORTS/run.info" &> /dev/null
-lcov --add-tracefile "$LOCAL_REPORTS/baseline-codecov.info" --add-tracefile "$LOCAL_REPORTS/run.info" --output-file "$LOCAL_REPORTS/combined.info" &> /dev/null
-lcov --remove "$LOCAL_REPORTS/combined.info" "$SOURCE_DIR/test/*" --output-file "$LOCAL_REPORTS/combined.info" &> /dev/null
-lcov --remove "$LOCAL_REPORTS/combined.info" "$SOURCE_DIR/CMakeCXXCompilerId.cpp" --output-file "$LOCAL_REPORTS/combined.info" &> /dev/null
-lcov --remove "$LOCAL_REPORTS/combined.info" "$SOURCE_DIR/ext/*" --output-file "$LOCAL_REPORTS/combined.info" &> /dev/null
+lcov --exclude "*/ext/*" --exclude "*/test/*" --exclude "*/mechanisms/*" --no-external --capture --base-directory $SOURCE_DIR --directory $BUILD_DIR --output-file "$LOCAL_REPORTS/run.info"
+lcov --add-tracefile "$LOCAL_REPORTS/baseline-codecov.info" --add-tracefile "$LOCAL_REPORTS/run.info" --output-file "$LOCAL_REPORTS/combined.info"
 
 # Only keep our own source
-lcov --extract "$LOCAL_REPORTS/combined.info" "$SOURCE_DIR/*" --output-file "$LOCAL_REPORTS/combined.info" &> /dev/null
+lcov --extract "$LOCAL_REPORTS/combined.info" "$SOURCE_DIR/*" --output-file "$LOCAL_REPORTS/combined.info"
 
 cp "$LOCAL_REPORTS/combined.info" "$SHARED_REPORTS/codecov-$REPORT_NAME.info"

--- a/ci/codecov_pre
+++ b/ci/codecov_pre
@@ -7,4 +7,4 @@ LOCAL_REPORTS="/codecov-reports"
 mkdir -p "$LOCAL_REPORTS"
 
 echo "Generating baseline codecov report"
-lcov --no-external --capture --initial --base-directory $SOURCE_DIR --directory $BUILD_DIR --output-file "$LOCAL_REPORTS/baseline-codecov.info" &> /dev/null
+lcov --exclude "*/ext/*" --exclude "*/test/*" --exclude "*/mechanisms/*" --no-external --capture --initial --base-directory $SOURCE_DIR --directory $BUILD_DIR --output-file "$LOCAL_REPORTS/baseline-codecov.info"

--- a/ci/gitlab-cscs.yml
+++ b/ci/gitlab-cscs.yml
@@ -34,7 +34,7 @@ build codecov:
   extends: .build_docker_images
   variables:
     BUILD_DOCKERFILE: ci/codecov/build.Dockerfile
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov/build:latest
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov/build:v2
     DEPLOY_DOCKERFILE: ci/codecov/deploy.Dockerfile
     DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
 


### PR DESCRIPTION
- remove repeated CMAKE_BUILD_TYPE
- bump lcov to 1.15
- use new --exclude flag to skip generated sources

With gcc 8 as a compiler + a new version of lcov (#1350) codecov started tracking generated source files and coverage dropped to < 60%. Not sure if this is a bug in lcov or not. I've added these new flags for lcov: `--exclude "*/ext/*" --exclude "*/test/*" --exclude "*/mechanisms/*"` to fix it.