### PR TITLE
Make `pas/e` GLOBAL instead of RANGE

### DIFF
--- a/doc/concepts/decor.rst
+++ b/doc/concepts/decor.rst
@@ -139,23 +139,23 @@ combination of global parameter values.
 
 Take for example a mechanism passive leaky dynamics:
 
-* Name: ``"passive"``.
-* Global variable: reversal potential ``"el"``.
+* Name: ``"passive"`` (the built-in mechanism is called just ``"pas"``).
+* Global variable: reversal potential ``"e"``.
 * Range variable: conductance ``"g"``.
 
 .. code-block:: Python
 
-    # Create pas mechanism with default parameter values (set in NMODL file).
+    # Create passive mechanism with default parameter values (set in NMODL file).
     m1 = arbor.mechanism('passive')
 
-    # Create default mechanism with custom conductance (range)
+    # Create mechanism with custom conductance (range)
     m2 = arbor.mechanism('passive', {'g': 0.1})
 
-    # Create a new pas mechanism with that changes reversal potential (global)
-    m3 = arbor.mechanism('passive/el=-45')
+    # Create a new passive mechanism with that changes reversal potential (global)
+    m3 = arbor.mechanism('passive/e=-45')
 
     # Create an instance of the same mechanism, that also sets conductance (range)
-    m4 = arbor.mechanism('passive/el=-45', {'g': 0.1})
+    m4 = arbor.mechanism('passive/e=-45', {'g': 0.1})
 
     decor = arbor.decor()
     decor.paint('"soma"', m1)

--- a/doc/concepts/decor.rst
+++ b/doc/concepts/decor.rst
@@ -137,25 +137,25 @@ Because a global parameter is fixed over the entire spatial extent
 of a density mechanism, a new mechanism has to be created for every
 combination of global parameter values.
 
-Take for example a mechanism passive leaky dynamics:
+Take for example the built-in mechanism for passive leaky dynamics:
 
-* Name: ``"passive"`` (the built-in mechanism is called just ``"pas"``).
+* Name: ``"pas"``
 * Global variable: reversal potential ``"e"``.
 * Range variable: conductance ``"g"``.
 
 .. code-block:: Python
 
     # Create passive mechanism with default parameter values (set in NMODL file).
-    m1 = arbor.mechanism('passive')
+    m1 = arbor.mechanism('pas')
 
     # Create mechanism with custom conductance (range)
-    m2 = arbor.mechanism('passive', {'g': 0.1})
+    m2 = arbor.mechanism('pas', {'g': 0.1})
 
     # Create a new passive mechanism with that changes reversal potential (global)
-    m3 = arbor.mechanism('passive/e=-45')
+    m3 = arbor.mechanism('pas/e=-45')
 
     # Create an instance of the same mechanism, that also sets conductance (range)
-    m4 = arbor.mechanism('passive/e=-45', {'g': 0.1})
+    m4 = arbor.mechanism('pas/e=-45', {'g': 0.1})
 
     decor = arbor.decor()
     decor.paint('"soma"', m1)

--- a/doc/concepts/mechanisms.rst
+++ b/doc/concepts/mechanisms.rst
@@ -97,17 +97,17 @@ that specifies values for range parameters.
 For example, consider a mechanism that models passive leaky dynamics with
 the following parameters:
 
-* *Name*: ``"passive"``.
-* *Global parameter*: reversal potential ``el``, default -65 mV.
+* *Name*: ``"pas"``.
+* *Global parameter*: reversal potential ``e``, default -70 mV.
 * *Range parameter*: conductance ``g``, default 0.001 S⋅cm⁻².
 
 The following example mechanism descriptions for our passive mechanism show that parameters and
 ion species dependencies only need to be specified when they differ from their defaults:
 
-* ``("passive")``: the passive mechanism with default parameters.
-* ``("passive/el=-80")``: derive a new passive mechanism with a non-default value for global parameter.
-* ``("passive", {"gl": 0.005})``: passive mechanism with a new a non-default range parameter value.
-* ``("passive/el=-80", {"gl": 0.005})``: derive a new passive mechanism that overrides both
+* ``("pas")``: the passive mechanism with default parameters.
+* ``("pas/e=-80")``: derive a new passive mechanism with a non-default value for global parameter.
+* ``("pas", {"g": 0.005})``: passive mechanism with a new a non-default range parameter value.
+* ``("pas/e=-80", {"g": 0.005})``: derive a new passive mechanism that overrides both
 
 Similarly to global parameters, ion species can be renamed in the mechanism name.
 This allows the use of generic mechanisms that can be adapted to a specific species

--- a/doc/python/mechanisms.rst
+++ b/doc/python/mechanisms.rst
@@ -41,7 +41,7 @@ mechanism that is to be painted or placed on the cable cell.
         hh = arbor.mechanism('hh')
 
         # A passive leaky channel with custom parameters
-        pas = arbor.mechanism('pas', {'e': -55, 'gl': 0.02})
+        pas = arbor.mechanism('pas/e=-55.0', {'g': 0.02})
 
         # Reversal potential using Nernst equation with GLOBAL parameter values
         # for Faraday's constant and the target ion species, set with a '/' followed
@@ -96,13 +96,13 @@ mechanism that is to be painted or placed on the cable cell.
         m2 = arbor.mechanism('pas', {'g', 0.1})
 
         # Create a new pas mechanism with that changes reversal potential (global).
-        m3 = arbor.mechanism('pas/el=-45')
+        m3 = arbor.mechanism('pas/e=-45')
 
         # Create an instance of the same mechanism, that also sets conductance (range).
-        m4 = arbor.mechanism('pas/el=-45', {'g', 0.1})
+        m4 = arbor.mechanism('pas/e=-45', {'g', 0.1})
 
         # This is an equivalent to m4, using set method to specify range parameters.
-        m5 = arbor.mechanism('pas/el=-45')
+        m5 = arbor.mechanism('pas/e=-45')
         m5.set('g', 0.1)
 
         # Decorate the 'soma' on a cable_cell.
@@ -110,7 +110,7 @@ mechanism that is to be painted or placed on the cable cell.
         cell.paint('"soma"', m1)
         cell.paint('"soma"', m2) # Error: can't place the same mechanism on overlapping regions
         cell.paint('"soma"', m3) # This would be ok: m3 is a new, derived mechanism by virtue of
-                                 # having a different name, i.e. 'pas/el=-45' vs. 'pas'.
+                                 # having a different name, i.e. 'pas/e=-45' vs. 'pas'.
 
 
 .. py:class:: mechanism_info

--- a/example/gap_junctions/gap_junctions.cpp
+++ b/example/gap_junctions/gap_junctions.cpp
@@ -302,9 +302,8 @@ arb::cable_cell gj_cell(cell_gid_type gid, unsigned ncell, double stim_duration)
     arb::mechanism_desc kamt("kamt");
     kamt["gbar"] = 0.004;
 
-    arb::mechanism_desc pas("pas");
+    arb::mechanism_desc pas("pas/e=-65.0");
     pas["g"] =  1.0/12000.0;
-    pas["e"] =  -65;
 
     // Paint density channels on all parts of the cell
     decor.paint("(all)", nax);

--- a/example/lfp/lfp.cpp
+++ b/example/lfp/lfp.cpp
@@ -91,7 +91,7 @@ private:
 
         // Add pas and hh mechanisms:
         dec.paint(reg::tagged(1), "hh"); // (default parameters)
-        dec.paint(reg::tagged(4), mechanism_desc("pas").set("e", -70));
+        dec.paint(reg::tagged(4), mechanism_desc("pas/e=-70.0"));
 
         // Add exponential synapse at centre of soma.
         synapse_location_ = ls::on_components(0.5, reg::tagged(1));

--- a/mechanisms/default/pas.mod
+++ b/mechanisms/default/pas.mod
@@ -1,23 +1,21 @@
+NEURON {
+    SUFFIX pas
+    NONSPECIFIC_CURRENT i
+    RANGE g
+    GLOBAL e
+}
+
 UNITS {
     (mV) = (millivolt)
     (S) = (siemens)
 }
 
-NEURON {
-    SUFFIX pas
-    NONSPECIFIC_CURRENT i
-    RANGE g, e
-}
 
 INITIAL {}
 
 PARAMETER {
     g = .001 (S/cm2)
-    e = -65  (mV) : we use -65 for the ball and stick model, instead of Neuron default of -70
-}
-
-ASSIGNED {
-    v (mV)
+    e = -70  (mV) : Taken from nrn
 }
 
 BREAKPOINT {


### PR DESCRIPTION
- Make reversal potential `e` a global parameter of `pas` to avoid inconsistency 
  (reversal potential is represented by a RANGE parameter, despite it not being a conductance multiplier see #1052)
- Adjust default value of `e` to -70mV (as in Neuron)
- Streamline docs,  which use `passive`, `el`, and `gl` instead of `passive`, `e`, and `g`.

Closes #1052