### PR TITLE
Workaround for MacOS+OpenMPI4

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -88,6 +88,9 @@ jobs:
         CXX:        ${{ matrix.config.cxx }}
         # We set PYTHONPATH instead of installing arbor to avoid distribution/OS specific behaviour.
         PYTHONPATH: ${{ github.workspace }}/build/python
+        # This is a workaround for the unfortunate interaction of MacOS and OpenMPI 4
+        # See https://github.com/open-mpi/ompi/issues/6518
+        OMPI_MCA_btl: "self,tcp"
     steps:
       - name: Set up cmake
         uses: jwlawson/actions-setup-cmake@v1.7


### PR DESCRIPTION
Use TCP BTL for MPI to avoid running into a sporadic SEGFAULT on MacOS.
See here
https://github.com/open-mpi/ompi/issues/6518