### PR TITLE
Hush catalogue build output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,14 @@ set_property(CACHE PROPERTY STRINGS "none" "cuda" "cuda-clang" "hip")
 option(ARB_USE_BUNDLED_LIBS "Use bundled 3rd party libraries" OFF)
 
 #----------------------------------------------------------
+# Debug support
+#----------------------------------------------------------
+
+# Print builtin catalogue configuration while building
+option(ARB_CAT_VERBOSE "Print catalogue build information" OFF)
+mark_as_advanced(ARB_CAT_VERBOSE)
+
+#----------------------------------------------------------
 # Configure-time features for Arbor:
 #----------------------------------------------------------
 

--- a/mechanisms/BuildModules.cmake
+++ b/mechanisms/BuildModules.cmake
@@ -58,7 +58,7 @@ function(build_modules)
 endfunction()
 
 function("make_catalogue")
-  cmake_parse_arguments(MK_CAT "" "NAME;SOURCES;OUTPUT;ARBOR;STANDALONE" "MECHS" ${ARGN})
+  cmake_parse_arguments(MK_CAT "" "NAME;SOURCES;OUTPUT;ARBOR;STANDALONE;VERBOSE" "MECHS" ${ARGN})
   set(MK_CAT_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/${MK_CAT_NAME}")
 
   # Need to set ARB_WITH_EXTERNAL_MODCC *and* modcc
@@ -67,14 +67,16 @@ function("make_catalogue")
     set(external_modcc MODCC ${modcc})
   endif()
 
-  message("Catalogue name:       ${MK_CAT_NAME}")
-  message("Catalogue mechanisms: ${MK_CAT_MECHS}")
-  message("Catalogue sources:    ${MK_CAT_SOURCES}")
-  message("Catalogue output:     ${MK_CAT_OUT_DIR}")
-  message("Arbor source tree:    ${MK_CAT_ARBOR}")
-  message("Build as standalone:  ${MK_CAT_STANDALONE}")
-  message("Source directory:     ${PROJECT_SOURCE_DIR}")    
-  message("Arbor arch:           ${ARB_CXXOPT_ARCH}")    
+  if(MK_CAT_VERBOSE)
+    message("Catalogue name:       ${MK_CAT_NAME}")
+    message("Catalogue mechanisms: ${MK_CAT_MECHS}")
+    message("Catalogue sources:    ${MK_CAT_SOURCES}")
+    message("Catalogue output:     ${MK_CAT_OUT_DIR}")
+    message("Arbor source tree:    ${MK_CAT_ARBOR}")
+    message("Build as standalone:  ${MK_CAT_STANDALONE}")
+    message("Source directory:     ${PROJECT_SOURCE_DIR}")
+    message("Arbor arch:           ${ARB_CXXOPT_ARCH}")
+  endif()
 
   file(MAKE_DIRECTORY "${MK_CAT_OUT_DIR}")
 

--- a/mechanisms/BuildModules.cmake
+++ b/mechanisms/BuildModules.cmake
@@ -74,7 +74,6 @@ function("make_catalogue")
     message("Catalogue output:     ${MK_CAT_OUT_DIR}")
     message("Arbor source tree:    ${MK_CAT_ARBOR}")
     message("Build as standalone:  ${MK_CAT_STANDALONE}")
-    message("Source directory:     ${PROJECT_SOURCE_DIR}")
     message("Arbor arch:           ${ARB_CXXOPT_ARCH}")
   endif()
 
@@ -101,9 +100,9 @@ function("make_catalogue")
 
   add_custom_command(
     OUTPUT ${catalogue_${MK_CAT_NAME}_source}
-    COMMAND ${PROJECT_SOURCE_DIR}/mechanisms/generate_catalogue ${catalogue_${MK_CAT_NAME}_options} ${MK_CAT_MECHS}
+    COMMAND ${MK_CAT_ARBOR}/mechanisms/generate_catalogue ${catalogue_${MK_CAT_NAME}_options} ${MK_CAT_MECHS}
     COMMENT "Building catalogue ${MK_CAT_NAME}"
-    DEPENDS ${PROJECT_SOURCE_DIR}/mechanisms/generate_catalogue)
+    DEPENDS ${MK_CAT_ARBOR}/mechanisms/generate_catalogue)
 
   add_custom_target(${MK_CAT_NAME}_catalogue_cpp_target DEPENDS ${catalogue_${MK_CAT_NAME}_source})
   add_dependencies(build_catalogue_${MK_CAT_NAME}_mods ${MK_CAT_NAME}_catalogue_cpp_target)

--- a/mechanisms/CMakeLists.txt
+++ b/mechanisms/CMakeLists.txt
@@ -7,7 +7,8 @@ make_catalogue(
   OUTPUT "CAT_BBP_SOURCES"
   MECHS CaDynamics_E2 Ca_HVA Ca_LVAst Ih Im K_Pst K_Tst Nap_Et2 NaTa_t NaTs2_t SK_E2 SKv3_1
   ARBOR "${PROJECT_SOURCE_DIR}"
-  STANDALONE FALSE)
+  STANDALONE FALSE
+  VERBOSE ${ARB_CAT_VERBOSE})
 
 make_catalogue(
   NAME allen
@@ -15,7 +16,8 @@ make_catalogue(
   OUTPUT "CAT_ALLEN_SOURCES"
   MECHS CaDynamics Ca_HVA Ca_LVA Ih Im Im_v2 K_P K_T Kd Kv2like Kv3_1 NaTa NaTs NaV Nap SK
   ARBOR "${PROJECT_SOURCE_DIR}"
-  STANDALONE FALSE)
+  STANDALONE FALSE
+  VERBOSE ${ARB_CAT_VERBOSE})
 
 make_catalogue(
   NAME default
@@ -23,7 +25,8 @@ make_catalogue(
   OUTPUT "CAT_DEFAULT_SOURCES"
   MECHS exp2syn expsyn expsyn_stdp hh kamt kdrmt nax nernst pas
   ARBOR "${PROJECT_SOURCE_DIR}"
-  STANDALONE FALSE)
+  STANDALONE FALSE
+  VERBOSE ${ARB_CAT_VERBOSE})
 
 # Join sources
 set(arbor_mechanism_sources

--- a/scripts/build-catalogue
+++ b/scripts/build-catalogue
@@ -71,7 +71,7 @@ mod_dir = pwd / Path(args['modpfx'])
 mods    = [ f[:-4] for f in os.listdir(mod_dir) if f.endswith('.mod') ]
 verbose = args['verbose'] and not args['quiet']
 quiet   = args['quiet']
-arb     = args['source'].resolve()
+arb     = args['source']
 
 cmake = f"""
 cmake_minimum_required(VERSION 3.9)

--- a/scripts/build-catalogue
+++ b/scripts/build-catalogue
@@ -54,6 +54,9 @@ def parse_arguments():
                         action='store_true',
                         help='Verbose.')
 
+    parser.add_argument('-q', '--quiet',
+                        action='store_true',
+                        help='Less output.')
 
     parser.add_argument('-h', '--help',
                         action='help',
@@ -66,9 +69,9 @@ pwd     = Path.cwd()
 name    = args['name']
 mod_dir = pwd / Path(args['modpfx'])
 mods    = [ f[:-4] for f in os.listdir(mod_dir) if f.endswith('.mod') ]
-verbose = args['verbose']
+verbose = args['verbose'] and not args['quiet']
+quiet   = args['quiet']
 arb     = args['source'].resolve()
-print(arb)
 
 cmake = f"""
 cmake_minimum_required(VERSION 3.9)
@@ -91,17 +94,15 @@ make_catalogue(
   MECHS {' '.join(mods)}
   ARBOR {arb}
   STANDALONE ON
-  VERBOSE ON)
+  VERBOSE {"ON" if verbose else "OFF"})
 """
 
-print(cmake)
-
-print(f"Building catalogue '{name}' from mechanisms in {mod_dir}")
-for m in mods:
-    print(" *", m)
+if not quiet:
+    print(f"Building catalogue '{name}' from mechanisms in {mod_dir}")
+    for m in mods:
+        print(" *", m)
 
 with TemporaryDirectory() as tmp:
-    print(f"Setting up temporary build directory: {tmp}")
     tmp = Path(tmp)
     shutil.copytree(mod_dir, tmp / 'mod')
     os.mkdir(tmp / 'build')
@@ -110,10 +111,8 @@ with TemporaryDirectory() as tmp:
         fd.write(cmake)
     shutil.copy2(f'{arb}/mechanisms/BuildModules.cmake', tmp)
     shutil.copy2(f'{arb}/mechanisms/generate_catalogue', tmp)
-    print("Configuring...")
     sp.run('cmake ..', shell=True, check=True, capture_output=not verbose)
-    print("Building...")
     sp.run('make',     shell=True, capture_output=not verbose)
-    print("Cleaning-up...")
     shutil.copy2(f'{name}-catalogue.so', pwd)
-    print(f'Catalogue has been built and copied to {pwd}/{name}-catalogue.so')
+    if not quiet:
+        print(f'Catalogue has been built and copied to {pwd}/{name}-catalogue.so')

--- a/scripts/build-catalogue
+++ b/scripts/build-catalogue
@@ -43,7 +43,7 @@ def parse_arguments():
                         metavar='source',
                         type=str,
                         default=Path(__file__).parents[1].resolve(),
-                        help='Path to arbor sources; defaults to parent of this script\'s directory')
+                        help='Path to arbor sources; defaults to parent of this script\'s directory.')
 
     parser.add_argument('modpfx',
                         metavar='modpfx',
@@ -60,7 +60,7 @@ def parse_arguments():
 
     parser.add_argument('-h', '--help',
                         action='help',
-                        help='display this help and exit')
+                        help='Display this help and exit.')
 
     return vars(parser.parse_args())
 

--- a/scripts/build-catalogue
+++ b/scripts/build-catalogue
@@ -67,13 +67,17 @@ name    = args['name']
 mod_dir = pwd / Path(args['modpfx'])
 mods    = [ f[:-4] for f in os.listdir(mod_dir) if f.endswith('.mod') ]
 verbose = args['verbose']
-arb     = args['source']
+arb     = args['source'].resolve()
+print(arb)
 
-cmake = """
+cmake = f"""
 cmake_minimum_required(VERSION 3.9)
-project({catalogue}-cat LANGUAGES CXX)
+project({name}-cat LANGUAGES CXX)
 
 find_package(arbor REQUIRED)
+
+set(CMAKE_CXX_COMPILER ${{ARB_CXX}})
+set(CMAKE_CXX_FLAGS    ${{ARB_CXX_FLAGS}})
 
 include(BuildModules.cmake)
 
@@ -81,14 +85,16 @@ set(ARB_WITH_EXTERNAL_MODCC true)
 find_program(modcc NAMES modcc)
 
 make_catalogue(
-  NAME {catalogue}
+  NAME {name}
   SOURCES "${{CMAKE_CURRENT_SOURCE_DIR}}/mod"
-  OUTPUT "CAT_{catalogue}_SOURCES"
-  MECHS {mods}
+  OUTPUT "CAT_{name.upper()}_SOURCES"
+  MECHS {' '.join(mods)}
   ARBOR {arb}
   STANDALONE ON
   VERBOSE ON)
 """
+
+print(cmake)
 
 print(f"Building catalogue '{name}' from mechanisms in {mod_dir}")
 for m in mods:
@@ -101,7 +107,7 @@ with TemporaryDirectory() as tmp:
     os.mkdir(tmp / 'build')
     os.chdir(tmp / 'build')
     with open(tmp / 'CMakeLists.txt', 'w') as fd:
-        fd.write(cmake.format(catalogue=name, mods=' '.join(mods), arb=arb))
+        fd.write(cmake)
     shutil.copy2(f'{arb}/mechanisms/BuildModules.cmake', tmp)
     shutil.copy2(f'{arb}/mechanisms/generate_catalogue', tmp)
     print("Configuring...")

--- a/scripts/build-catalogue
+++ b/scripts/build-catalogue
@@ -85,7 +85,9 @@ make_catalogue(
   SOURCES "${{CMAKE_CURRENT_SOURCE_DIR}}/mod"
   OUTPUT "CAT_{catalogue}_SOURCES"
   MECHS {mods}
-  ARBOR {arb})
+  ARBOR {arb}
+  STANDALONE ON
+  VERBOSE ON)
 """
 
 print(f"Building catalogue '{name}' from mechanisms in {mod_dir}")


### PR DESCRIPTION
This produces less output when building catalogues, it used to spam the CMake configure log.
The old behaviour can be toggled back on by the advanced flag `ARB_CAT_VERBOSE`. I also
added some fixes build scripts.
- [CMake] Correctly pick up the compiler used for arbor.
- [CMake] Set the path to scripts properly.
- [build-cat] Produce less output per default
- [build-cat] Add `quiet` flag for even less output

