### PR TITLE
Update Readme: dedup citation section. Advertise Py3.9 compat PyPI. Typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,4 @@ An installation guide and library documentation are available online at [Read th
 
 ### Citing Arbor
 
-The Arbor software can be cited via Zenodo: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1459678.svg)](https://doi.org/10.5281/zenodo.1459678).
-
-Previous versions of Arbor can be cited specifically:
-* Version 0.5: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4428108.svg)](https://doi.org/10.5281/zenodo.4428108)
-* Version 0.2: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2583709.svg)](https://doi.org/10.5281/zenodo.2583709)
-* Version 0.1: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1459679.svg)](https://doi.org/10.5281/zenodo.1459679)
-
-The following BibTeX entry can be used to cite Arbor:
-
-```
-@INPROCEEDINGS{
-    paper:arbor2019,
-    author={N. A. {Akar} and B. {Cumming} and V. {Karakasis} and A. {Küsters} and W. {Klijn} and A. {Peyser} and S. {Yates}},
-    booktitle={2019 27th Euromicro International Conference on Parallel, Distributed and Network-Based Processing (PDP)},
-    title={{Arbor --- A Morphologically-Detailed Neural Network Simulation Library for Contemporary High-Performance Computing Architectures}},
-    year={2019}, month={feb}, volume={}, number={},
-    pages={274--282},
-    doi={10.1109/EMPDP.2019.8671560},
-    ISSN={2377-5750}}
-```
-
-Alternative citation formats for the paper can be [downloaded here](https://ieeexplore.ieee.org/abstract/document/8671560), and a preprint is available at [arXiv](https://arxiv.org/abs/1901.07454).
+Please refer to [our documentation](https://arbor.readthedocs.io/en/latest/index.html#citing-arbor).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,9 @@
 Arbor
 =====
 
-.. image:: https://github.com/arbor-sim/arbor/workflows/Basic%20Tests%20and%20Documentation/badge.svg
+|testbadge| |zlatest|
+
+.. |testbadge| image:: https://github.com/arbor-sim/arbor/workflows/Basic%20Tests%20and%20Documentation/badge.svg
     :target: https://github.com/arbor-sim/arbor/actions?query=workflow%3A%22Basic+Tests+and+Documentation%22
 
 Welcome to the documentation for Arbor, the multi-compartment neural network simulation library.
@@ -32,6 +34,28 @@ Documentation organisation
 Citing Arbor
 ------------
 
+The Arbor software can be cited via Zenodo: |zlatest|
+
+.. |zlatest| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1459678.svg
+    :target: https://doi.org/10.5281/zenodo.1459678
+
+Previous versions of Arbor can be cited specifically:
+
+* Version 0.5: |z05|
+* Version 0.2: |z02|
+* Version 0.1: |z01|
+
+.. |z05| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4428108.svg
+    :target: https://doi.org/10.5281/zenodo.4428108
+
+.. |z02| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2583709.svg
+    :target: https://doi.org/10.5281/zenodo.2583709
+
+.. |z01| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1459679.svg
+    :target: https://doi.org/10.5281/zenodo.1459679
+
+The following BibTeX entry can be used to cite the Arbor introductory paper:
+
 .. code-block:: latex
 
     @INPROCEEDINGS{
@@ -49,7 +73,7 @@ Alternative citation formats for the paper can be `downloaded here <https://ieee
 Acknowledgements
 ----------------
 
-This research has received funding from th  European Unions Horizon 2020 Framework Programme for Research and
+This research has received funding from the European Unions Horizon 2020 Framework Programme for Research and
 Innovation under the Specific Grant Agreement No. 720270 (Human Brain Project SGA1), and Specific Grant Agreement
 No. 785907 (Human Brain Project SGA2).
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -74,8 +74,8 @@ Acknowledgements
 ----------------
 
 This research has received funding from the European Unions Horizon 2020 Framework Programme for Research and
-Innovation under the Specific Grant Agreement No. 720270 (Human Brain Project SGA1), and Specific Grant Agreement
-No. 785907 (Human Brain Project SGA2).
+Innovation under the Specific Grant Agreement No. 720270 (Human Brain Project SGA1), Specific Grant Agreement
+No. 785907 (Human Brain Project SGA2), and Specific Grant Agreement No. 945539 (Human Brain Project SGA3).
 
 Arbor is an `eBrains project <https://ebrains.eu/service/arbor/>`_.
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     name='arbor',
     packages=['arbor'],
     version=version_,
-    author='CSCS and FSJ',
+    author='CSCS and FZJ',
     url='https://github.com/arbor-sim/arbor',
     description='High performance simulation of networks of multicompartment neurons.',
     long_description='',
@@ -21,6 +21,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     project_urls={
         'Source': 'https://github.com/arbor-sim/arbor',

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: C++',
     ],
     project_urls={


### PR DESCRIPTION
* Update `README.md`: moved citation to `doc/index.rst`.
* Advertise Py3.9 compat PyPI in setup.py
* Fix typos.