### PR TITLE
Binary Python wheels and sdist generated by Github Action

### DIFF
--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BEFORE_BUILD: pip install numpy setuptools
+          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -111,13 +111,13 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BEFORE_BUILD: pip install numpy setuptools
+          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
 
-        run: |
-          pip install cibuildwheel
-          cibuildwheel --output-dir dist
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.whl
 
       - name: Publish distribution 📦 to Test PyPI
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -1,4 +1,4 @@
-name: Arbor
+name: Arbor in Wheels
 
 on:
   push:
@@ -8,8 +8,8 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -61,8 +61,6 @@ jobs:
           $CC --version
           $CXX --version
           python --version
-          mpic++ --show
-          mpicc --show
           echo $PYTHONPATH
 
       ##cibuildwheel setup

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -52,32 +52,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.config.py }}
-      - name: OpenMPI cache
-        uses: actions/cache@v2
-        id:   cache-ompi
-        with:
-          path: ~/openmpi-4.0.2
-          key:  ${{ matrix.config.os }}-openmpi-4.0.2-${{ matrix.config.cxx }}
-      - name: Build OpenMPI
-        if: ${{ steps.cache-ompi.outputs.cache-hit != 'true' }}
-        run: |
-           echo cache-hit='${{ steps.cache-ompi.outputs.cache-hit }}'
-           cd ~
-           wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.2.tar.gz
-           tar -xvf ./openmpi-4.0.2.tar.gz
-           cd openmpi-4.0.2
-           ./configure --disable-mpi-fortran
-           make -j4
-      - name: Install OpenMPI
-        run: |
-           echo "Going to install ompi"
-           cd ~
-           cd openmpi-4.0.2
-           sudo make install
-           cd -
-      - name: Update shared library cache
-        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
-        run: sudo ldconfig
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -24,23 +24,20 @@ jobs:
             mpi:   "ON",
             simd:  "OFF"
           }
-        - {
-            name:  "MacOS Max",
-            os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
-            cc:    "clang",
-            cxx:   "clang++",
-            py:    "3.9",
-            cmake: "3.19.x",
-            mpi:   "ON",
-            simd:  "OFF"
-          }
+        # - {
+        #     name:  "MacOS Max",
+        #     os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
+        #     cc:    "clang",
+        #     cxx:   "clang++",
+        #     py:    "3.9",
+        #     cmake: "3.19.x",
+        #     mpi:   "ON",
+        #     simd:  "OFF"
+        #   }
 
     env:
         CC:         ${{ matrix.config.cc }}
         CXX:        ${{ matrix.config.cxx }}
-        # This is a workaround for the unfortunate interaction of MacOS and OpenMPI 4
-        # See https://github.com/open-mpi/ompi/issues/6518
-        OMPI_MCA_btl: "self,tcp"
 
     steps:
       ## system setup
@@ -63,30 +60,43 @@ jobs:
           python --version
           echo $PYTHONPATH
 
-      ##cibuildwheel setup
-      - name: Build wheels Linux
-        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
-        uses: joerick/cibuildwheel@v1.9.0
-        with:
-          output-dir: dist
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build the wheel
+        run: |
+          python -m cibuildwheel --output-dir dist
         env:
           CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
           CIBW_BUILD: "cp3?-manylinux_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
-      - name: Build wheels macos
-        if: ${{ startsWith(matrix.config.os, 'macos') }}
-        uses: joerick/cibuildwheel@v1.9.0
-        with:
-          output-dir: dist
-        env:
-          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
-          CIBW_BUILD: "cp3?-macosx_x86_64"
-          CIBW_SKIP: "cp35-*"
+      ##cibuildwheel setup
+      # - name: Build wheels Linux
+      #   if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+      #   uses: joerick/cibuildwheel@v1.9.0
+      #   with:
+      #     output-dir: dist
+      #   env:
+      #     CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
+      #     CIBW_BUILD: "cp3?-manylinux_x86_64"
+      #     CIBW_SKIP: "cp35-*"
+      #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+
+      # - name: Build wheels macos
+      #   if: ${{ startsWith(matrix.config.os, 'macos') }}
+      #   uses: joerick/cibuildwheel@v1.9.0
+      #   with:
+      #     output-dir: dist
+      #   env:
+      #     CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
+      #     CIBW_BUILD: "cp3?-macosx_x86_64"
+      #     CIBW_SKIP: "cp35-*"
 
       - uses: actions/upload-artifact@v2
         with:
+          name: wheels
           path: dist/*.whl
 
       - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -110,25 +110,3 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
-
-  upload:
-    name: upload to pypi
-    runs-on: "ubuntu-20.04"
-    needs: [build_wheels]
-    steps:
-      - uses: actions/download-artifact@v2
-        # with:
-        #   name: build_wheels
-        #   path: path/to/artifact
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: path/to/artifact
-      - name: Publish distribution 📦 to Test PyPI
-        if: github.ref == 'refs/heads/master'
-        run: |
-          pip install twine
-          twine upload -r testpypi wheelhouse/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.ciwheeltest }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -93,6 +93,7 @@ jobs:
     name: upload to pypi
     runs-on: "ubuntu-20.04"
     needs: [build_wheels]
+    steps:
       - uses: actions/download-artifact@v2
         # with:
         #   name: build_wheels

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -14,16 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-            name:  "Linux Max GCC",
-            os:    "ubuntu-20.04",
-            cc:    "gcc-10",
-            cxx:   "g++-10",
-            py:    "3.9",
-            cmake: "3.19.x",
-            mpi:   "ON",
-            simd:  "OFF"
-          }
+        # - {
+        #     name:  "Linux Max GCC",
+        #     os:    "ubuntu-20.04",
+        #     cc:    "gcc-10",
+        #     cxx:   "g++-10",
+        #     py:    "3.9",
+        #     cmake: "3.19.x",
+        #     mpi:   "OFF",
+        #     simd:  "OFF"
+        #   }
         - {
             name:  "MacOS Max",
             os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
@@ -31,7 +31,7 @@ jobs:
             cxx:   "clang++",
             py:    "3.9",
             cmake: "3.19.x",
-            mpi:   "ON",
+            mpi:   "OFF",
             simd:  "OFF"
           }
 
@@ -69,6 +69,10 @@ jobs:
           /usr/libexec/PlistBuddy -c "Print:ProductName" \
           -c "Print:ProductVersion" \
           -c "Print:ProductBuildVersion" /System/Library/CoreServices/SystemVersion.plist
+          clang --version         # Print apple gcc/clang version
+          xcode-select --install  # Try to install CLI tools (may error 'already installed')
+          softwareupdate --all --install --force  # Try to update
+          clang --version         # see our presents
       - name: Build wheels macos
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         uses: joerick/cibuildwheel@v1.9.0

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -78,7 +78,7 @@ jobs:
   upload_test_pypi:
     name: upload to test pypi
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
+    needs: [build_binary_wheels, build_sdist]
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -98,7 +98,7 @@ jobs:
   upload_pypi:
     name: upload to pypi
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
+    needs: [build_binary_wheels, build_sdist]
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           output-dir: dist
         env:
+          MACOSX_DEPLOYMENT_TARGET: "10.15"
           CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
@@ -99,7 +100,7 @@ jobs:
       - name: Publish distribution 📦 to Test PyPI
         run: |
           pip install twine
-          twine upload -r testpypi wheelhouse/*
+          twine upload -r testpypi dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
@@ -120,7 +121,7 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         run: |
           pip install twine
-          twine upload wheelhouse/*
+          twine upload dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.ciwheel }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -65,7 +65,7 @@ jobs:
           python -m pip install wheel numpy
       - name: Build the wheel
         run: |
-          python ./arbor/setup.py build_ext bdist_wheel
+          python setup.py build_ext bdist_wheel
 
       ##cibuildwheel setup
       # - name: Build wheels Linux

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: artifact
+          name: dist
         #   path: path/to/artifact
       - name: Display structure of downloaded files
         run: ls -R
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: artifact
+          name: dist
         #   path: path/to/artifact
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -87,7 +87,7 @@ jobs:
           name: dist
           path: dist/*.whl
 
-  upload_test:
+  upload_test_pypi:
     name: upload to pypi
     runs-on: ubuntu-latest
     needs: [build_wheels]
@@ -107,7 +107,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
 
-  upload_test:
+  upload_pypi:
     name: upload to pypi
     runs-on: ubuntu-latest
     needs: [build_wheels]

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -92,7 +92,7 @@ jobs:
   upload:
     name: upload to pypi
     runs-on: "ubuntu-20.04"
-    needs: [sdist, wheels]
+    needs: [build_wheels]
       - uses: actions/download-artifact@v2
         # with:
         #   name: build_wheels

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -60,17 +60,12 @@ jobs:
           python --version
           echo $PYTHONPATH
 
-      - name: Install cibuildwheel
+      - name: Install pip deps
         run: |
-          python -m pip install cibuildwheel
+          python -m pip install wheel numpy
       - name: Build the wheel
         run: |
-          python -m cibuildwheel --output-dir dist
-        env:
-          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
-          CIBW_BUILD: "cp3?-manylinux_x86_64"
-          CIBW_SKIP: "cp35-*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          python ./arbor/setup.py build_ext bdist_wheel
 
       ##cibuildwheel setup
       # - name: Build wheels Linux

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -65,16 +65,6 @@ jobs:
 
       - name: Build wheels macos
         if: ${{ startsWith(matrix.config.os, 'macos') }}
-        run: |
-          /usr/libexec/PlistBuddy -c "Print:ProductName" \
-          -c "Print:ProductVersion" \
-          -c "Print:ProductBuildVersion" /System/Library/CoreServices/SystemVersion.plist
-          clang --version         # Print apple gcc/clang version
-          xcode-select --install  # Try to install CLI tools (may error 'already installed')
-          softwareupdate --all --install --force  # Try to update
-          clang --version         # see our presents
-      - name: Build wheels macos
-        if: ${{ startsWith(matrix.config.os, 'macos') }}
         uses: joerick/cibuildwheel@v1.9.0
         with:
           output-dir: dist

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -65,7 +65,10 @@ jobs:
 
       - name: Build wheels macos
         if: ${{ startsWith(matrix.config.os, 'macos') }}
-        run: uname -a
+        run: |
+          /usr/libexec/PlistBuddy -c "Print:ProductName" \
+          -c "Print:ProductVersion" \
+          -c "Print:ProductBuildVersion" /System/Library/CoreServices/SystemVersion.plist
       - name: Build wheels macos
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         uses: joerick/cibuildwheel@v1.9.0
@@ -88,7 +91,7 @@ jobs:
           path: dist/*.whl
 
   upload_test_pypi:
-    name: upload to pypi
+    name: upload to test pypi
     runs-on: ubuntu-latest
     needs: [build_wheels]
     steps:

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -24,16 +24,16 @@ jobs:
             mpi:   "ON",
             simd:  "OFF"
           }
-        # - {
-        #     name:  "MacOS Max",
-        #     os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
-        #     cc:    "clang",
-        #     cxx:   "clang++",
-        #     py:    "3.9",
-        #     cmake: "3.19.x",
-        #     mpi:   "ON",
-        #     simd:  "OFF"
-        #   }
+        - {
+            name:  "MacOS Max",
+            os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
+            cc:    "clang",
+            cxx:   "clang++",
+            py:    "3.9",
+            cmake: "3.19.x",
+            mpi:   "ON",
+            simd:  "OFF"
+          }
 
     env:
         CC:         ${{ matrix.config.cc }}
@@ -61,7 +61,11 @@ jobs:
           CIBW_BUILD: "cp3?-manylinux_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          # CIBW_TEST_COMMAND: TODO
 
+      - name: Build wheels macos
+        if: ${{ startsWith(matrix.config.os, 'macos') }}
+        run: uname -a
       - name: Build wheels macos
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         uses: joerick/cibuildwheel@v1.9.0
@@ -71,42 +75,55 @@ jobs:
           CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
+          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_BUILD_VERBOSITY: 3
+          # CIBW_TEST_COMMAND: TODO
 
-      # - name: auditwheel
-      #   run: |
-      #     pip install auditwheel
-      #     for whl in ./dist/*.whl; do
-      #         auditwheel repair "$whl"
-      #     done
-
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: wheelhouse
-      #     path: wheelhouse/*.whl
+      # this action runs auditwheel automatically with the following args:
+      # https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command
 
       - uses: actions/upload-artifact@v2
         with:
           name: dist
           path: dist/*.whl
 
-  upload:
+  upload_test:
     name: upload to pypi
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
     needs: [build_wheels]
     steps:
       - uses: actions/download-artifact@v2
-        # with:
-        #   name: build_wheels
+        with:
+          name: artifact
         #   path: path/to/artifact
-
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: path/to/artifact
       - name: Publish distribution 📦 to Test PyPI
-        if: github.ref == 'refs/heads/master'
         run: |
           pip install twine
           twine upload -r testpypi wheelhouse/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
+
+  upload_test:
+    name: upload to pypi
+    runs-on: ubuntu-latest
+    needs: [build_wheels]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+        #   path: path/to/artifact
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: path/to/artifact
+      - name: Publish distribution 📦 to PyPI
+        run: |
+          pip install twine
+          twine upload wheelhouse/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.ciwheel }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -24,16 +24,16 @@ jobs:
             mpi:   "ON",
             simd:  "OFF"
           }
-        - {
-            name:  "MacOS Max",
-            os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
-            cc:    "clang",
-            cxx:   "clang++",
-            py:    "3.9",
-            cmake: "3.19.x",
-            mpi:   "ON",
-            simd:  "OFF"
-          }
+        # - {
+        #     name:  "MacOS Max",
+        #     os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
+        #     cc:    "clang",
+        #     cxx:   "clang++",
+        #     py:    "3.9",
+        #     cmake: "3.19.x",
+        #     mpi:   "ON",
+        #     simd:  "OFF"
+        #   }
 
     env:
         CC:         ${{ matrix.config.cc }}
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      ##cibuildwheel setup
+      ##cibuildwheel setup. produces wheels already manylinux, so no auditwheel needed.
       - name: Build wheels Linux
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
         uses: joerick/cibuildwheel@v1.9.0
@@ -72,22 +72,44 @@ jobs:
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
 
-      - name: auditwheel
-        run: |
-          pip install auditwheel
-          for whl in ./dist/*.whl; do
-              auditwheel repair "$whl"
-          done
+      # - name: auditwheel
+      #   run: |
+      #     pip install auditwheel
+      #     for whl in ./dist/*.whl; do
+      #         auditwheel repair "$whl"
+      #     done
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheelhouse
-          path: wheelhouse/*.whl
+      # - uses: actions/upload-artifact@v2
+      #   with:
+      #     name: wheelhouse
+      #     path: wheelhouse/*.whl
 
       - uses: actions/upload-artifact@v2
         with:
           name: dist
           path: dist/*.whl
+
+  upload:
+    name: upload to pypi
+    runs-on: "ubuntu-20.04"
+    needs: [build_wheels]
+    steps:
+      - uses: actions/download-artifact@v2
+        # with:
+        #   name: build_wheels
+        #   path: path/to/artifact
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: path/to/artifact
+      - name: Publish distribution 📦 to Test PyPI
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pip install twine
+          twine upload -r testpypi wheelhouse/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
 
   upload:
     name: upload to pypi

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -1,4 +1,4 @@
-name: Arbor in Wheels
+name: Arbor on Wheels
 
 on:
   push:
@@ -38,8 +38,6 @@ jobs:
     env:
         CC:         ${{ matrix.config.cc }}
         CXX:        ${{ matrix.config.cxx }}
-        # We set PYTHONPATH instead of installing arbor to avoid distribution/OS specific behaviour.
-        PYTHONPATH: ${{ github.workspace }}/build/python
         # This is a workaround for the unfortunate interaction of MacOS and OpenMPI 4
         # See https://github.com/open-mpi/ompi/issues/6518
         OMPI_MCA_btl: "self,tcp"
@@ -101,7 +99,7 @@ jobs:
           output-dir: dist
         env:
           CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
-          CIBW_BUILD: "cp3?-macosx_x86_64"
+          CIBW_BUILD: "cp3?-manylinux_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -22,7 +22,6 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      ##cibuildwheel setup. produces wheels already manylinux, so no auditwheel needed.
       - name: Build wheels Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         uses: joerick/cibuildwheel@v1.9.0
@@ -75,43 +74,19 @@ jobs:
           name: dist
           path: dist/*.tar.gz
 
-  upload_test_pypi:
-    name: upload to test pypi
-    runs-on: ubuntu-latest
-    needs: [build_binary_wheels, build_sdist]
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-        #   path: path/to/artifact
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: path/to/artifact
-      - name: Publish distribution 📦 to Test PyPI
-        run: |
-          pip install twine
-          twine upload -r testpypi dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
-
-  upload_pypi:
-    name: upload to pypi
-    runs-on: ubuntu-latest
-    needs: [build_binary_wheels, build_sdist]
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-        #   path: path/to/artifact
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: path/to/artifact
-      - name: Publish distribution 📦 to PyPI
-        run: |
-          pip install twine
-          twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.ciwheel }}
+# TODO
+  # upload_test_pypi:
+  #   name: upload to test pypi
+  #   runs-on: ubuntu-latest
+  #   needs: [build_binary_wheels, build_sdist]
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist
+  #     - name: Publish distribution 📦 to Test PyPI
+  #       run: |
+  #         pip install twine
+  #         twine upload -r testpypi dist/*
+  #       env:
+  #         TWINE_USERNAME: __token__
+  #         TWINE_PASSWORD: ${{ secrets.ciwheeltest }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -8,22 +8,24 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.config.os }}
-    runs-on: ${{ matrix.config.os }}
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        config:
-        - {
-            name:  "Linux Max GCC",
-            os:    "ubuntu-20.04",
-            cc:    "gcc-10",
-            cxx:   "g++-10",
-            py:    ["3.6","3.7","3.8","3.9"],
-            cmake: "3.19.x",
-            mpi:   "ON",
-            simd:  "OFF"
-          }
+        os: [ubuntu-20.04]
+        py: ["3.6","3.7","3.8","3.9"]
+        # config:
+        # - {
+        #     name:  "Linux Max GCC",
+        #     os:    "ubuntu-20.04",
+        #     cc:    "gcc-10",
+        #     cxx:   "g++-10",
+        #     py:    ["3.6","3.7","3.8","3.9"],
+        #     cmake: "3.19.x",
+        #     mpi:   "ON",
+        #     simd:  "OFF"
+        #   }
         # - {
         #     name:  "MacOS Max",
         #     os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
@@ -36,19 +38,19 @@ jobs:
         #   }
 
     env:
-        CC:         ${{ matrix.config.cc }}
-        CXX:        ${{ matrix.config.cxx }}
+        CC: "gcc-10"
+        CXX: "g++-10"
 
     steps:
       ## system setup
       - name: Set up cmake
         uses: jwlawson/actions-setup-cmake@v1.7
         with:
-          cmake-version: ${{ matrix.config.cmake }}
+          cmake-version: 3.19.x
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.config.py }}
+          python-version: ${{ matrix.py }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -1,0 +1,129 @@
+name: Arbor
+
+on:
+  push:
+    branches: [ master, ciwheel ]
+    tags:
+      - v*
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name:  "Linux Max GCC",
+            os:    "ubuntu-20.04",
+            cc:    "gcc-10",
+            cxx:   "g++-10",
+            py:    "3.9",
+            cmake: "3.19.x",
+            mpi:   "ON",
+            simd:  "OFF"
+          }
+        - {
+            name:  "MacOS Max",
+            os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
+            cc:    "clang",
+            cxx:   "clang++",
+            py:    "3.9",
+            cmake: "3.19.x",
+            mpi:   "ON",
+            simd:  "OFF"
+          }
+
+    env:
+        CC:         ${{ matrix.config.cc }}
+        CXX:        ${{ matrix.config.cxx }}
+        # We set PYTHONPATH instead of installing arbor to avoid distribution/OS specific behaviour.
+        PYTHONPATH: ${{ github.workspace }}/build/python
+        # This is a workaround for the unfortunate interaction of MacOS and OpenMPI 4
+        # See https://github.com/open-mpi/ompi/issues/6518
+        OMPI_MCA_btl: "self,tcp"
+
+    steps:
+      ## system setup
+      - name: Set up cmake
+        uses: jwlawson/actions-setup-cmake@v1.7
+        with:
+          cmake-version: ${{ matrix.config.cmake }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.config.py }}
+      - name: OpenMPI cache
+        uses: actions/cache@v2
+        id:   cache-ompi
+        with:
+          path: ~/openmpi-4.0.2
+          key:  ${{ matrix.config.os }}-openmpi-4.0.2-${{ matrix.config.cxx }}
+      - name: Build OpenMPI
+        if: ${{ steps.cache-ompi.outputs.cache-hit != 'true' }}
+        run: |
+           echo cache-hit='${{ steps.cache-ompi.outputs.cache-hit }}'
+           cd ~
+           wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.2.tar.gz
+           tar -xvf ./openmpi-4.0.2.tar.gz
+           cd openmpi-4.0.2
+           ./configure --disable-mpi-fortran
+           make -j4
+      - name: Install OpenMPI
+        run: |
+           echo "Going to install ompi"
+           cd ~
+           cd openmpi-4.0.2
+           sudo make install
+           cd -
+      - name: Update shared library cache
+        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+        run: sudo ldconfig
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Check config
+        run: |
+          $CC --version
+          $CXX --version
+          python --version
+          mpic++ --show
+          mpicc --show
+          echo $PYTHONPATH
+
+      ##cibuildwheel setup
+      - name: Build wheels Linux
+        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+        uses: joerick/cibuildwheel@v1.9.0
+        with:
+          output-dir: dist
+        env:
+          CIBW_BEFORE_BUILD: pip install numpy setuptools
+          CIBW_BUILD: "cp3?-macosx_x86_64"
+          CIBW_SKIP: "cp35-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+
+      - name: Build wheels macos
+        if: ${{ startsWith(matrix.config.os, 'macos') }}
+        uses: joerick/cibuildwheel@v1.9.0
+        with:
+          output-dir: dist
+        env:
+          CIBW_BEFORE_BUILD: pip install numpy setuptools
+          CIBW_BUILD: "cp3?-macosx_x86_64"
+          CIBW_SKIP: "cp35-*"
+
+        run: |
+          pip install cibuildwheel
+          cibuildwheel --output-dir dist
+
+      - name: Publish distribution 📦 to Test PyPI
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pip install twine
+          twine upload -r testpypi dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.ciwheeltest }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -8,24 +8,22 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        py: ["3.6","3.7","3.8","3.9"]
-        # config:
-        # - {
-        #     name:  "Linux Max GCC",
-        #     os:    "ubuntu-20.04",
-        #     cc:    "gcc-10",
-        #     cxx:   "g++-10",
-        #     py:    ["3.6","3.7","3.8","3.9"],
-        #     cmake: "3.19.x",
-        #     mpi:   "ON",
-        #     simd:  "OFF"
-        #   }
+        config:
+        - {
+            name:  "Linux Max GCC",
+            os:    "ubuntu-20.04",
+            cc:    "gcc-10",
+            cxx:   "g++-10",
+            py:    "3.9",
+            cmake: "3.19.x",
+            mpi:   "ON",
+            simd:  "OFF"
+          }
         # - {
         #     name:  "MacOS Max",
         #     os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
@@ -38,48 +36,25 @@ jobs:
         #   }
 
     env:
-        CC: "gcc-10"
-        CXX: "g++-10"
+        CC:         ${{ matrix.config.cc }}
+        CXX:        ${{ matrix.config.cxx }}
 
     steps:
       ## system setup
-      - name: Set up cmake
-        uses: jwlawson/actions-setup-cmake@v1.7
-        with:
-          cmake-version: 3.19.x
       - name: Set up Python
         uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.py }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: recursive
-      - name: Check config
-        run: |
-          $CC --version
-          $CXX --version
-          python --version
-          echo $PYTHONPATH
-
-      - name: Install pip deps
-        run: |
-          python -m pip install wheel numpy
-      - name: Build the wheel
-        run: |
-          python setup.py build_ext bdist_wheel
 
       ##cibuildwheel setup
-      # - name: Build wheels Linux
-      #   if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
-      #   uses: joerick/cibuildwheel@v1.9.0
-      #   with:
-      #     output-dir: dist
-      #   env:
-      #     CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
-      #     CIBW_BUILD: "cp3?-manylinux_x86_64"
-      #     CIBW_SKIP: "cp35-*"
-      #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      - name: Build wheels Linux
+        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+        uses: joerick/cibuildwheel@v1.9.0
+        with:
+          output-dir: dist
+        env:
+          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
+          CIBW_BUILD: "cp3?-manylinux_x86_64"
+          CIBW_SKIP: "cp35-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
       # - name: Build wheels macos
       #   if: ${{ startsWith(matrix.config.os, 'macos') }}
@@ -91,9 +66,13 @@ jobs:
       #     CIBW_BUILD: "cp3?-macosx_x86_64"
       #     CIBW_SKIP: "cp35-*"
 
+      - name: auditwheel
+        run: |
+          pip install auditwheel
+          auditwheel repair dist/*.whl
+
       - uses: actions/upload-artifact@v2
         with:
-          name: wheels
           path: dist/*.whl
 
       - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -87,23 +87,23 @@ jobs:
         with:
           path: dist/*.whl
 
-  upload:
-    name: upload to pypi
-    runs-on: "ubuntu-20.04"
-    depends-on: "build_wheels"
-      - uses: actions/download-artifact@v2
-        with:
-          name: my-artifact
-          path: path/to/artifact
+  # upload:
+  #   name: upload to pypi
+  #   runs-on: "ubuntu-20.04"
+  #   depends-on: "build_wheels"
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: my-artifact
+  #         path: path/to/artifact
 
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: path/to/artifact
-      - name: Publish distribution 📦 to Test PyPI
-        if: github.ref == 'refs/heads/master'
-        run: |
-          pip install twine
-          twine upload -r testpypi wheelhouse/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
+  #     - name: Display structure of downloaded files
+  #       run: ls -R
+  #       working-directory: path/to/artifact
+  #     - name: Publish distribution 📦 to Test PyPI
+  #       if: github.ref == 'refs/heads/master'
+  #       run: |
+  #         pip install twine
+  #         twine upload -r testpypi wheelhouse/*
+  #       env:
+  #         TWINE_USERNAME: __token__
+  #         TWINE_PASSWORD: ${{ secrets.ciwheeltest }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -19,7 +19,7 @@ jobs:
             os:    "ubuntu-20.04",
             cc:    "gcc-10",
             cxx:   "g++-10",
-            py:    "3.9",
+            py:    ["3.6","3.7","3.8","3.9"],
             cmake: "3.19.x",
             mpi:   "ON",
             simd:  "OFF"

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -2,7 +2,6 @@ name: Arbor on Wheels
 
 on:
   push:
-    branches: [ master, ciwheel ]
     tags:
       - v*
 

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -81,29 +81,31 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
+          name: wheelhouse
           path: wheelhouse/*.whl
 
       - uses: actions/upload-artifact@v2
         with:
+          name: dist
           path: dist/*.whl
 
-  # upload:
-  #   name: upload to pypi
-  #   runs-on: "ubuntu-20.04"
-  #   depends-on: "build_wheels"
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: my-artifact
-  #         path: path/to/artifact
+  upload:
+    name: upload to pypi
+    runs-on: "ubuntu-20.04"
+    needs: [sdist, wheels]
+      - uses: actions/download-artifact@v2
+        # with:
+        #   name: build_wheels
+        #   path: path/to/artifact
 
-  #     - name: Display structure of downloaded files
-  #       run: ls -R
-  #       working-directory: path/to/artifact
-  #     - name: Publish distribution 📦 to Test PyPI
-  #       if: github.ref == 'refs/heads/master'
-  #       run: |
-  #         pip install twine
-  #         twine upload -r testpypi wheelhouse/*
-  #       env:
-  #         TWINE_USERNAME: __token__
-  #         TWINE_PASSWORD: ${{ secrets.ciwheeltest }}
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: path/to/artifact
+      - name: Publish distribution 📦 to Test PyPI
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pip install twine
+          twine upload -r testpypi wheelhouse/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.ciwheeltest }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -24,16 +24,16 @@ jobs:
             mpi:   "ON",
             simd:  "OFF"
           }
-        # - {
-        #     name:  "MacOS Max",
-        #     os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
-        #     cc:    "clang",
-        #     cxx:   "clang++",
-        #     py:    "3.9",
-        #     cmake: "3.19.x",
-        #     mpi:   "ON",
-        #     simd:  "OFF"
-        #   }
+        - {
+            name:  "MacOS Max",
+            os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
+            cc:    "clang",
+            cxx:   "clang++",
+            py:    "3.9",
+            cmake: "3.19.x",
+            mpi:   "ON",
+            simd:  "OFF"
+          }
 
     env:
         CC:         ${{ matrix.config.cc }}
@@ -62,30 +62,48 @@ jobs:
           CIBW_SKIP: "cp35-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
-      # - name: Build wheels macos
-      #   if: ${{ startsWith(matrix.config.os, 'macos') }}
-      #   uses: joerick/cibuildwheel@v1.9.0
-      #   with:
-      #     output-dir: dist
-      #   env:
-      #     CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
-      #     CIBW_BUILD: "cp3?-macosx_x86_64"
-      #     CIBW_SKIP: "cp35-*"
+      - name: Build wheels macos
+        if: ${{ startsWith(matrix.config.os, 'macos') }}
+        uses: joerick/cibuildwheel@v1.9.0
+        with:
+          output-dir: dist
+        env:
+          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
+          CIBW_BUILD: "cp3?-macosx_x86_64"
+          CIBW_SKIP: "cp35-*"
 
       - name: auditwheel
         run: |
           pip install auditwheel
-          auditwheel repair dist/*.whl
+          for whl in ./dist/*.whl; do
+              auditwheel repair "$whl"
+          done
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: wheelhouse/*.whl
 
       - uses: actions/upload-artifact@v2
         with:
           path: dist/*.whl
 
+  upload:
+    name: upload to pypi
+    runs-on: "ubuntu-20.04"
+    depends-on: "build_wheels"
+      - uses: actions/download-artifact@v2
+        with:
+          name: my-artifact
+          path: path/to/artifact
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: path/to/artifact
       - name: Publish distribution 📦 to Test PyPI
         if: github.ref == 'refs/heads/master'
         run: |
           pip install twine
-          twine upload -r testpypi dist/*
+          twine upload -r testpypi wheelhouse/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.ciwheeltest }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
 
+      ## get arbor
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
       ##cibuildwheel setup
       - name: Build wheels Linux
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -7,44 +7,16 @@ on:
       - v*
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.config.os }}
-    runs-on: ${{ matrix.config.os }}
+  build_binary_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        config:
-        # - {
-        #     name:  "Linux Max GCC",
-        #     os:    "ubuntu-20.04",
-        #     cc:    "gcc-10",
-        #     cxx:   "g++-10",
-        #     py:    "3.9",
-        #     cmake: "3.19.x",
-        #     mpi:   "OFF",
-        #     simd:  "OFF"
-        #   }
-        - {
-            name:  "MacOS Max",
-            os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
-            cc:    "clang",
-            cxx:   "clang++",
-            py:    "3.9",
-            cmake: "3.19.x",
-            mpi:   "OFF",
-            simd:  "OFF"
-          }
-
-    env:
-        CC:         ${{ matrix.config.cc }}
-        CXX:        ${{ matrix.config.cxx }}
+        os: [ubuntu-latest, macos-latest]
 
     steps:
-      ## system setup
       - name: Set up Python
         uses: actions/setup-python@v2
-
-      ## get arbor
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -52,7 +24,7 @@ jobs:
 
       ##cibuildwheel setup. produces wheels already manylinux, so no auditwheel needed.
       - name: Build wheels Linux
-        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         uses: joerick/cibuildwheel@v1.9.0
         with:
           output-dir: dist
@@ -64,12 +36,12 @@ jobs:
           # CIBW_TEST_COMMAND: TODO
 
       - name: Build wheels macos
-        if: ${{ startsWith(matrix.config.os, 'macos') }}
+        if: ${{ startsWith(matrix.os, 'macos') }}
         uses: joerick/cibuildwheel@v1.9.0
         with:
           output-dir: dist
         env:
-          MACOSX_DEPLOYMENT_TARGET: "10.15"
+          MACOSX_DEPLOYMENT_TARGET: "10.15" #needed to undo some CIBW settings
           CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
@@ -85,10 +57,28 @@ jobs:
           name: dist
           path: dist/*.whl
 
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Make sdist
+        run:  python setup.py sdist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/*.tar.gz
+
   upload_test_pypi:
     name: upload to test pypi
     runs-on: ubuntu-latest
-    needs: [build_wheels]
+    needs: [build_wheels, build_sdist]
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -108,7 +98,7 @@ jobs:
   upload_pypi:
     name: upload to pypi
     runs-on: ubuntu-latest
-    needs: [build_wheels]
+    needs: [build_wheels, build_sdist]
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -2,6 +2,7 @@ name: Arbor on Wheels
 
 on:
   push:
+    branches: [ ciwheel ]
     tags:
       - v*
 
@@ -14,8 +15,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v2
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -44,7 +43,6 @@ jobs:
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_BUILD_VERBOSITY: 3
           # CIBW_TEST_COMMAND: TODO
 
       # this action runs auditwheel automatically with the following args:

--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -1,6 +1,8 @@
 name: Mirror to Ebrains
 
-on: push
+on:
+  push:
+    branches: [ master ]
 
 jobs:
   to_ebrains:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,11 @@ endif()
 if(ARB_WITH_PYTHON)
     cmake_dependent_option(ARB_USE_BUNDLED_PYBIND11 "Use bundled pybind11" ON "ARB_WITH_PYTHON;ARB_USE_BUNDLED_LIBS" OFF)
 
-    find_package(Python3 ${arb_py_version} COMPONENTS Interpreter Development.Module REQUIRED)
+    if(CIBUILDWHEEL)
+        find_package(Python3 ${arb_py_version} COMPONENTS Interpreter Development.Module REQUIRED)
+    else()
+        find_package(Python3 ${arb_py_version} COMPONENTS Interpreter Development REQUIRED)
+    endif()
 
     # Required to link the dynamic libraries for python modules.
     # Effectively adds '-fpic' flag to CXX_FLAGS.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ endif()
 if(ARB_WITH_PYTHON)
     cmake_dependent_option(ARB_USE_BUNDLED_PYBIND11 "Use bundled pybind11" ON "ARB_WITH_PYTHON;ARB_USE_BUNDLED_LIBS" OFF)
 
-    if(CIBUILDWHEEL)
+    if(DEFINED ENV{CIBUILDWHEEL})
         find_package(Python3 ${arb_py_version} COMPONENTS Interpreter Development.Module REQUIRED)
     else()
         find_package(Python3 ${arb_py_version} COMPONENTS Interpreter Development REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ endif()
 if(ARB_WITH_PYTHON)
     cmake_dependent_option(ARB_USE_BUNDLED_PYBIND11 "Use bundled pybind11" ON "ARB_WITH_PYTHON;ARB_USE_BUNDLED_LIBS" OFF)
 
-    find_package(Python3 ${arb_py_version} COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python3 ${arb_py_version} COMPONENTS Interpreter Development.Module REQUIRED)
 
     # Required to link the dynamic libraries for python modules.
     # Effectively adds '-fpic' flag to CXX_FLAGS.

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -359,6 +359,9 @@ to implement these kernels. Arbor currently has vectorization support for x86 ar
 with AVX, AVX2 or AVX512 ISA extensions; and for AArch64 ARM architectures with NEON and SVE
 (first available on ARMv8-A).
 
+.. note::
+  Note that on x86-64 platforms compilation will fail if you enable vectorization, but the CPU or ``-DARB_ARCH`` does not support any form of AVX.
+
 .. _install-gpu:
 
 GPU backend

--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -21,9 +21,9 @@ Every point release of Arbor is pushed to the Python Package Index. The easiest 
 .. note::
     You will need to have some development packages installed in order to build Arbor this way.
 
-    * Ubuntu/Debian: `sudo apt install git build-essential python3-dev python3-pip`
-    * Fedora/CentOS/Red Hat: `sudo yum install git @development-tools python3-devel python3-pip`
-    * macOS: get `brew` `here <https://brew.sh>`_ and run `brew install cmake clang python3`
+    * Ubuntu/Debian: `sudo apt install git build-essential python3-dev python3-pip libxml2-dev`
+    * Fedora/CentOS/Red Hat: `sudo yum install git @development-tools python3-devel python3-pip libxml2-devel`
+    * macOS: get `brew` `here <https://brew.sh>`_ and run `brew install cmake clang python3 libxml2`
     * Windows: the simplest way is to use `WSL <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and then follow the instructions for Ubuntu.
 
 If you wish to get the latest Arbor straight from
@@ -73,7 +73,7 @@ be used to configure the installation:
 * ``--mpi``: Enable MPI support (requires MPI library).
 * ``--gpu``: Enable GPU support for NVIDIA GPUs with nvcc using ``cuda``, or with clang using ``cuda-clang`` (both require cudaruntime).
   Enable GPU support for AMD GPUs with hipcc using ``hip``. By default set to ``none``, which disables gpu support.
-* ``--vec``: Enable vectorization. This might require choosing an appropriate architecture using ``--arch``.
+* ``--vec``: Enable vectorization. This might require choosing an appropriate architecture using ``--arch``. Note that on x86-64 platforms compilation will fail if you enable vectorization, but the CPU or ``--arch`` does not support any form of AVX.
 * ``--arch``: CPU micro-architecture to target. By default this is set to ``native``.
 
 If calling ``setup.py`` the flags must come after ``install`` on the command line,

--- a/python/setup.py
+++ b/python/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     name='arbor',
     packages=['arbor'],
     version=version_,
-    author='CSCS and FSJ',
+    author='CSCS and FZJ',
     url='https://github.com/arbor-sim/arbor',
     description='High performance simulation of networks of multicompartment neurons.',
     long_description='',

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: C++',
     ],
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,14 @@ import pathlib
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
-from wheel.bdist_wheel import bdist_wheel
 import subprocess
+try:
+    from wheel.bdist_wheel import bdist_wheel
+    WHEEL_INSTALLED = True
+except:
+    #wheel package not installed.
+    WHEEL_INSTALLED = False
+    pass
 
 # Singleton class that holds the settings configured using command line
 # options. This information has to be stored in a singleton so that it
@@ -91,48 +97,48 @@ class install_command(install):
 
         install.run(self)
 
-#https://wheel.readthedocs.io/en/stable/
-class bdist_wheel_command(bdist_wheel):
-    user_options = bdist_wheel.user_options + [
-        ('mpi',   None, 'enable mpi support (requires MPI library)'),
-        ('gpu=',  None, 'enable nvidia cuda support (requires cudaruntime and nvcc) or amd hip support. Supported values: '
-                        'none, cuda, cuda-clang, hip'),
-        ('vec',   None, 'enable vectorization'),
-        ('arch=', None, 'cpu architecture, e.g. haswell, skylake, armv8.2-a+sve, znver2 (default native).'),
-        ('neuroml', None, 'enable parsing neuroml morphologies in Arbor (requires libxml)'),
-        ('sysdeps', None, 'don\'t use bundled 3rd party C++ dependencies (pybind11 and json). This flag forces use of dependencies installed on the system.')
-    ]
+if not WHEEL_INSTALLED:
+    class bdist_wheel_command(bdist_wheel):
+        user_options = bdist_wheel.user_options + [
+            ('mpi',   None, 'enable mpi support (requires MPI library)'),
+            ('gpu=',  None, 'enable nvidia cuda support (requires cudaruntime and nvcc) or amd hip support. Supported values: '
+                            'none, cuda, cuda-clang, hip'),
+            ('vec',   None, 'enable vectorization'),
+            ('arch=', None, 'cpu architecture, e.g. haswell, skylake, armv8.2-a+sve, znver2 (default native).'),
+            ('neuroml', None, 'enable parsing neuroml morphologies in Arbor (requires libxml)'),
+            ('sysdeps', None, 'don\'t use bundled 3rd party C++ dependencies (pybind11 and json). This flag forces use of dependencies installed on the system.')
+        ]
 
-    def initialize_options(self):
-        bdist_wheel.initialize_options(self)
-        self.mpi  = None
-        self.gpu  = None
-        self.arch = None
-        self.vec  = None
-        self.neuroml = None
-        self.sysdeps = None
+        def initialize_options(self):
+            bdist_wheel.initialize_options(self)
+            self.mpi  = None
+            self.gpu  = None
+            self.arch = None
+            self.vec  = None
+            self.neuroml = None
+            self.sysdeps = None
 
-    def finalize_options(self):
-        bdist_wheel.finalize_options(self)
+        def finalize_options(self):
+            bdist_wheel.finalize_options(self)
 
-    def run(self):
-        # The options are stored in global variables:
-        opt = cl_opt()
-        #   mpi  : build with MPI support (boolean).
-        opt['mpi']  = self.mpi is not None
-        #   gpu  : compile for AMD/NVIDIA GPUs and choose compiler (string).
-        opt['gpu']  = "none" if self.gpu is None else self.gpu
-        #   vec  : generate SIMD vectorized kernels for CPU micro-architecture (boolean).
-        opt['vec']  = self.vec is not None
-        #   arch : target CPU micro-architecture (string).
-        opt['arch'] = "native" if self.arch is None else self.arch
-        #   neuroml : compile with neuroml support for morphologies.
-        opt['neuroml'] = self.neuroml is not None
-        #   bundled : use bundled/git-submoduled 3rd party libraries.
-        #             By default use bundled libs.
-        opt['bundled'] = self.sysdeps is None
+        def run(self):
+            # The options are stored in global variables:
+            opt = cl_opt()
+            #   mpi  : build with MPI support (boolean).
+            opt['mpi']  = self.mpi is not None
+            #   gpu  : compile for AMD/NVIDIA GPUs and choose compiler (string).
+            opt['gpu']  = "none" if self.gpu is None else self.gpu
+            #   vec  : generate SIMD vectorized kernels for CPU micro-architecture (boolean).
+            opt['vec']  = self.vec is not None
+            #   arch : target CPU micro-architecture (string).
+            opt['arch'] = "native" if self.arch is None else self.arch
+            #   neuroml : compile with neuroml support for morphologies.
+            opt['neuroml'] = self.neuroml is not None
+            #   bundled : use bundled/git-submoduled 3rd party libraries.
+            #             By default use bundled libs.
+            opt['bundled'] = self.sysdeps is None
 
-        bdist_wheel.run(self)
+            bdist_wheel.run(self)
 
 class cmake_extension(Extension):
     def __init__(self, name):
@@ -210,6 +216,9 @@ setuptools.setup(
         'build_ext':   cmake_build,
         'install':     install_command,
         'bdist_wheel': bdist_wheel_command,
+    } if WHEEL_INSTALLED else {
+        'build_ext':   cmake_build,
+        'install':     install_command,
     },
 
     author='The Arbor dev team.',

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,10 @@ import subprocess
 try:
     from wheel.bdist_wheel import bdist_wheel
     WHEEL_INSTALLED = True
-    cmdclasses_ = {
-        'build_ext':   cmake_build,
-        'install':     install_command,
-        'bdist_wheel': bdist_wheel_command,
-    }
 except:
     #wheel package not installed.
     WHEEL_INSTALLED = False
-    cmdclasses_ = {
-        'build_ext':   cmake_build,
-        'install':     install_command,
-    }
+    pass
 
 # Singleton class that holds the settings configured using command line
 # options. This information has to be stored in a singleton so that it
@@ -215,7 +207,14 @@ setuptools.setup(
     setup_requires=[],
     zip_safe=False,
     ext_modules=[cmake_extension('arbor')],
-    cmdclass=cmdclasses_,
+    cmdclass={
+        'build_ext':   cmake_build,
+        'install':     install_command,
+        'bdist_wheel': bdist_wheel_command,
+    } if WHEEL_INSTALLED else {
+        'build_ext':   cmake_build,
+        'install':     install_command,
+    },
 
     author='The Arbor dev team.',
     url='https://github.com/arbor-sim/arbor',

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ class install_command(install):
 
         install.run(self)
 
-if not WHEEL_INSTALLED:
+if WHEEL_INSTALLED:
     class bdist_wheel_command(bdist_wheel):
         user_options = bdist_wheel.user_options + [
             ('mpi',   None, 'enable mpi support (requires MPI library)'),

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import pathlib
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
+from wheel.bdist_wheel import bdist_wheel
 import subprocess
 
 # Singleton class that holds the settings configured using command line
@@ -19,7 +20,7 @@ class CL_opt:
                                'gpu': 'none',
                                'vec': False,
                                'arch': 'native',
-                               'neuroml': False,
+                               'neuroml': True,
                                'bundled': True}
 
     def settings(self):
@@ -89,6 +90,49 @@ class install_command(install):
         opt['bundled'] = self.sysdeps is None
 
         install.run(self)
+
+#https://wheel.readthedocs.io/en/stable/
+class bdist_wheel_command(bdist_wheel):
+    user_options = bdist_wheel.user_options + [
+        ('mpi',   None, 'enable mpi support (requires MPI library)'),
+        ('gpu=',  None, 'enable nvidia cuda support (requires cudaruntime and nvcc) or amd hip support. Supported values: '
+                        'none, cuda, cuda-clang, hip'),
+        ('vec',   None, 'enable vectorization'),
+        ('arch=', None, 'cpu architecture, e.g. haswell, skylake, armv8.2-a+sve, znver2 (default native).'),
+        ('neuroml', None, 'enable parsing neuroml morphologies in Arbor (requires libxml)'),
+        ('sysdeps', None, 'don\'t use bundled 3rd party C++ dependencies (pybind11 and json). This flag forces use of dependencies installed on the system.')
+    ]
+
+    def initialize_options(self):
+        bdist_wheel.initialize_options(self)
+        self.mpi  = None
+        self.gpu  = None
+        self.arch = None
+        self.vec  = None
+        self.neuroml = None
+        self.sysdeps = None
+
+    def finalize_options(self):
+        bdist_wheel.finalize_options(self)
+
+    def run(self):
+        # The options are stored in global variables:
+        opt = cl_opt()
+        #   mpi  : build with MPI support (boolean).
+        opt['mpi']  = self.mpi is not None
+        #   gpu  : compile for AMD/NVIDIA GPUs and choose compiler (string).
+        opt['gpu']  = "none" if self.gpu is None else self.gpu
+        #   vec  : generate SIMD vectorized kernels for CPU micro-architecture (boolean).
+        opt['vec']  = self.vec is not None
+        #   arch : target CPU micro-architecture (string).
+        opt['arch'] = "native" if self.arch is None else self.arch
+        #   neuroml : compile with neuroml support for morphologies.
+        opt['neuroml'] = self.neuroml is not None
+        #   bundled : use bundled/git-submoduled 3rd party libraries.
+        #             By default use bundled libs.
+        opt['bundled'] = self.sysdeps is None
+
+        bdist_wheel.run(self)
 
 class cmake_extension(Extension):
     def __init__(self, name):
@@ -163,8 +207,9 @@ setuptools.setup(
     zip_safe=False,
     ext_modules=[cmake_extension('arbor')],
     cmdclass={
-        'build_ext': cmake_build,
-        'install':   install_command,
+        'build_ext':   cmake_build,
+        'install':     install_command,
+        'bdist_wheel': bdist_wheel_command,
     },
 
     author='The Arbor dev team.',


### PR DESCRIPTION
## Changes

* Auto-generate binary wheels, triggered by git tags 'v*'.
  * Wheels are generated for Python versions 3.6-3.9, for Linux using the [PyPA manylinux-2014 image](https://github.com/pypa/manylinux) and MacOS using macos-latest (10.15 at time of writing).
  * The Action generates `sdist` for any other platforms.
  * The cibuildwheel action automatically prepares the wheels using [auditwheel](https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command), which means bundling of external deps (e.g. libxml2 for NeuroML).
  * The output is all that's needed for publication of a new version to (Test)PyPI.
* `setup.py` defaults `neuroml` to on.
* A small change to `CMakeLists.txt` was required to build the wheels: based on this [Pybind hint](https://pybind11.readthedocs.io/en/stable/compiling.html#findpython-mode) `Development.Module`is now required, and not `Development` when CMake searches for Python. I confirm this change is needed to make Arbor build in the manylinux docker images, but I do not understand what the change implies, other than that we now don't link to `libpython`.
* (Unrelated to the above) Only run the `ebrains.yml` action on commits to master.

## Not changed

* Vectorization is off
  * Arbor's vectorization requires AVX (on x86-64), but that might be too much of a demand on all users (Intel CPUs >2010, AMD CPUs >2013 come with AVX), so I've left it `off` right now.
  * Reference for archs: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
    * Building Arbor with vectorization on but an arch without AVX support fails.

## Example

Example output (scroll down): https://github.com/brenthuisman/arbor/actions/runs/614579564
The artifacts can be download from the Github Action run, and you'll be just a `twine` away from uploading a new version.  

Fixes #1326