### PR TITLE
Bug/multiplicity

### DIFF
--- a/arbor/backends/gpu/mechanism.cpp
+++ b/arbor/backends/gpu/mechanism.cpp
@@ -152,17 +152,13 @@ void mechanism::instantiate(unsigned id,
 
     auto base_ptr = indices_.data();
 
-    auto append_chunk = [&](const auto& input, auto& base_ptr, auto& output) {
+    auto append_chunk = [&](const auto& input, auto& output) {
         memory::copy(make_const_view(input), device_view(base_ptr, width_));
         output = base_ptr;
         base_ptr += width_padded_;
     };
 
-    append_chunk(pos_data.cv, base_ptr, pp->node_index);
-
-    // memory::copy(make_const_view(pos_data.cv), device_view(base_ptr, width_));
-    // pp->node_index_ = base_ptr;
-    // base_ptr += width_padded_;
+    append_chunk(pos_data.cv, pp->node_index);
 
     auto ion_index_tbl = ion_index_table();
     arb_assert(num_ions_==ion_index_tbl.size());
@@ -181,15 +177,11 @@ void mechanism::instantiate(unsigned id,
         std::vector<index_type> mech_ion_index(indices.begin(), indices.end());
 
         // Take reference to derived (generated) mechanism ion index pointer.
-        memory::copy(make_const_view(mech_ion_index), device_view(base_ptr, width_));
-        *ion_ptr = base_ptr;
-        base_ptr += width_padded_;
+        append_chunk(mech_ion_index, *ion_ptr);
     }
 
     if (mult_in_place_) {
-        memory::copy(make_const_view(pos_data.multiplicity), device_view(base_ptr, width_));
-        pp->multiplicity_ = base_ptr;
-        base_ptr += width_padded_; // Theoretically redundant, but for consistency
+        append_chunk(pos_data.multiplicity, pp->multiplicity);
     }
 }
 

--- a/arbor/backends/gpu/mechanism.cpp
+++ b/arbor/backends/gpu/mechanism.cpp
@@ -158,7 +158,7 @@ void mechanism::instantiate(unsigned id,
         base_ptr += width_padded_;
     };
 
-    append_chunk(pos_data.cv, pp->node_index);
+    append_chunk(pos_data.cv, pp->node_index_);
 
     auto ion_index_tbl = ion_index_table();
     arb_assert(num_ions_==ion_index_tbl.size());
@@ -181,7 +181,7 @@ void mechanism::instantiate(unsigned id,
     }
 
     if (mult_in_place_) {
-        append_chunk(pos_data.multiplicity, pp->multiplicity);
+        append_chunk(pos_data.multiplicity, pp->multiplicity_);
     }
 }
 

--- a/arbor/backends/gpu/mechanism.cpp
+++ b/arbor/backends/gpu/mechanism.cpp
@@ -152,9 +152,17 @@ void mechanism::instantiate(unsigned id,
 
     auto base_ptr = indices_.data();
 
-    memory::copy(make_const_view(pos_data.cv), device_view(base_ptr, width_));
-    pp->node_index_ = base_ptr;
-    base_ptr += width_padded_;
+    auto append_chunk = [](const auto& input, auto& base_ptr, auto& output) {
+        memory::copy(make_const_view(input), device_view(base_ptr, width_));
+        output = base_ptr;
+        base_ptr += width_padded_;
+    };
+
+    append_chunk(pos_data.cv, base_ptr, pp->node_index);
+
+    // memory::copy(make_const_view(pos_data.cv), device_view(base_ptr, width_));
+    // pp->node_index_ = base_ptr;
+    // base_ptr += width_padded_;
 
     auto ion_index_tbl = ion_index_table();
     arb_assert(num_ions_==ion_index_tbl.size());

--- a/arbor/backends/gpu/mechanism.cpp
+++ b/arbor/backends/gpu/mechanism.cpp
@@ -152,8 +152,8 @@ void mechanism::instantiate(unsigned id,
 
     auto base_ptr = indices_.data();
 
+    memory::copy(make_const_view(pos_data.cv), device_view(base_ptr, width_));
     pp->node_index_ = base_ptr;
-    memory::copy(make_const_view(pos_data.cv), device_view(pp->node_index_, width_));
     base_ptr += width_padded_;
 
     auto ion_index_tbl = ion_index_table();
@@ -173,14 +173,14 @@ void mechanism::instantiate(unsigned id,
         std::vector<index_type> mech_ion_index(indices.begin(), indices.end());
 
         // Take reference to derived (generated) mechanism ion index pointer.
+        memory::copy(make_const_view(mech_ion_index), device_view(base_ptr, width_));
         *ion_ptr = base_ptr;
-        memory::copy(make_const_view(mech_ion_index), device_view(*ion_ptr, width_));
         base_ptr += width_padded_;
     }
 
     if (mult_in_place_) {
+        memory::copy(make_const_view(pos_data.multiplicity), device_view(base_ptr, width_));
         pp->multiplicity_ = base_ptr;
-        memory::copy(make_const_view(pos_data.multiplicity), device_view(pp->multiplicity_, width_));
         base_ptr += width_padded_; // Theoretically redundant, but for consistency
     }
 }

--- a/arbor/backends/gpu/mechanism.cpp
+++ b/arbor/backends/gpu/mechanism.cpp
@@ -152,7 +152,7 @@ void mechanism::instantiate(unsigned id,
 
     auto base_ptr = indices_.data();
 
-    auto append_chunk = [](const auto& input, auto& base_ptr, auto& output) {
+    auto append_chunk = [&](const auto& input, auto& base_ptr, auto& output) {
         memory::copy(make_const_view(input), device_view(base_ptr, width_));
         output = base_ptr;
         base_ptr += width_padded_;

--- a/arbor/backends/gpu/mechanism.cpp
+++ b/arbor/backends/gpu/mechanism.cpp
@@ -177,7 +177,7 @@ void mechanism::instantiate(unsigned id,
     }
 
     if (mult_in_place_) {
-        memory::copy(make_const_view(pos_data.multiplicity), device_view(indices_.data() + width_padded_, width_));
+        memory::copy(make_const_view(pos_data.multiplicity), device_view(indices_.data() + (num_ions_ + 1)*width_padded_, width_));
         pp->multiplicity_ = indices_.data() + (num_ions_ + 1)*width_padded_;
     }
 }


### PR DESCRIPTION
Fix a bug in GPU mechanism init that would have overwritten ion indices if in-place multiplication was enabled.
Also refactor the surrounding code to avoid similar bugs in the future.