### PR TITLE
 Fix linking issues caused by nvcc host compiler. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,11 @@ if(ARB_GPU STREQUAL "cuda")
         set(CMAKE_CUDA_ARCHITECTURES 60 70 80)
     endif()
 
+    # This fixes nvcc picking up a wrong host compiler for linking, causing issues
+    # with outdated libraries, eg libstdc++ and std::filesystem. Must happend before
+    # all calls to enable_language(CUDA)
+    set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
+
     enable_language(CUDA)
 
     # Despite native CUDA support, the CUDA package is still required to export


### PR DESCRIPTION
Update: confirmed. ~This is WIP until we can confirm it fixes the issue.~

Here's a brief description what happened on the user's system
- the system g++ alias was g++-7 (not g++-8)
- CMAKE_CXX_COMPILER was g++8
- but nvcc picks up the system's g++ for linking (shown by running `nvcc --verbose` on an empty kernel)
- which causes CMake to determine that it should link the gcc/stdlib/7

The ad-hoc fix is to `update-alternatives` g++ -> g++-8 (debian/ubuntu).

This patch aims at a more general solution, but I doubt this particular pattern
will happen very often.
