### PR TITLE
Fix Issues yaml, now all templates should show up

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,8 @@ name: Bug report
 about: Create a report to help us improve. If you need help setting up your simulation
   with Arbor, please start a new topic in Discussions.
 title: ''
-labels: 'bug'
+labels:
+- 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.md
@@ -2,7 +2,9 @@
 name: Arbor Enhancement Proposal
 about: 'An outline and rationale for a new feature or major change to Arbor. '
 title: 'AEP: [PROPOSAL]'
-labels: 'AEP', 'enhancement'
+labels:
+- 'AEP'
+- 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,9 @@
 name: Feature request
 about: 'Suggest an idea for Arbor. Add a clear and concise description of what the problem is and what you want to happen instead. '
 title: ''
-labels: 'enhancement', 'help wanted'
+labels:
+- 'enhancement'
+- 'help wanted'
 assignees: ''
 
 ---


### PR DESCRIPTION
Turns out some templates are hidden due to malformed yaml.
