### PR TITLE
🚧 lif_cell example 🚧

### DIFF
--- a/arbor/include/arbor/lif_cell.hpp
+++ b/arbor/include/arbor/lif_cell.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sstream>
+
 namespace arb {
 
 // Model parameteres of leaky integrate and fire neuron model.
@@ -13,5 +15,19 @@ struct lif_cell {
     double V_reset = E_L; // Reset potential [mV].
     double t_ref = 2;     // Refractory period [ms].
 };
+
+inline std::ostream& operator<<(std::ostream& o, const lif_cell& v) {
+    return
+        o << "<arbor.lif_cell:"
+          << " tau_m " << v.tau_m
+          << ", V_th " << v.V_th
+          << ", C_m " << v.C_m
+          << ", E_L " << v.E_L
+          << ", V_m " << v.V_m
+          << ", V_reset " << v.V_reset
+          << ", t_ref " << v.t_ref
+          << "; at " << &v
+          << ">";
+}
 
 } // namespace arb

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -111,12 +111,6 @@ std::optional<arb::mechanism_desc> maybe_method(pybind11::object method) {
 // string printers
 //
 
-std::string lif_str(const arb::lif_cell& c){
-    return util::pprintf(
-        "<arbor.lif_cell: tau_m {}, V_th {}, C_m {}, E_L {}, V_m {}, t_ref {}, V_reset {}>",
-        c.tau_m, c.V_th, c.C_m, c.E_L, c.V_m, c.t_ref, c.V_reset);
-}
-
 
 std::string mechanism_desc_str(const arb::mechanism_desc& md) {
     return util::pprintf("mechanism('{}', {})",
@@ -197,8 +191,12 @@ void register_cells(pybind11::module& m) {
             "Refractory period [ms].")
         .def_readwrite("V_reset", &arb::lif_cell::V_reset,
             "Reset potential [mV].")
-        .def("__repr__", &lif_str)
-        .def("__str__",  &lif_str);
+        .def("__repr__", [](const arb::lif_cell &c){util::pprintf("{}",c);})
+        .def("__str__",  [](const arb::lif_cell &c){
+                std::stringstream stream;
+                stream << c;
+                return stream.str();
+            });
 
     // arb::label_dict
 


### PR DESCRIPTION
Example of unifying printing `lif_cell`.

* I'd like to use libfmt for `operator<<`.
* Is it the right location for defining `operator<<`?
* Calling `__repr__` results in error, know why?