### PR TITLE
Check validity of event_generator targets in recipe

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -38,7 +38,8 @@ bad_connection_source_gid::bad_connection_source_gid(cell_gid_type gid, cell_gid
 {}
 
 bad_connection_source_lid::bad_connection_source_lid(cell_gid_type gid, cell_lid_type src_lid, cell_size_type num_sources):
-    arbor_exception(pprintf("Model building error on cell {}: connection source index {} is out of range. Cell {} has {} sources, in the range [{}:{}].", gid, src_lid, gid, num_sources, 0, num_sources-1)),
+    arbor_exception(pprintf("Model building error on cell {}: connection source index {} is out of range. Cell {} has {} sources", gid, src_lid, gid, num_sources) +
+                    (num_sources? pprintf(", in the range [{}:{}].",  0, num_sources-1) : ".")),
     gid(gid), src_lid(src_lid), num_sources(num_sources)
 {}
 
@@ -48,7 +49,19 @@ bad_connection_target_gid::bad_connection_target_gid(cell_gid_type gid, cell_gid
 {}
 
 bad_connection_target_lid::bad_connection_target_lid(cell_gid_type gid, cell_lid_type tgt_lid, cell_size_type num_targets):
-    arbor_exception(pprintf("Model building error on cell {}: connection target index {} is out of range. Cell {} has {} targets, in the range [{}:{}].", gid, tgt_lid, gid, num_targets, 0, num_targets-1)),
+    arbor_exception(pprintf("Model building error on cell {}: connection target index {} is out of range. Cell {} has {} targets", gid, tgt_lid, gid, num_targets) +
+                    (num_targets ? pprintf(", in the range [{}:{}].", 0, num_targets-1) : ".")),
+    gid(gid), tgt_lid(tgt_lid), num_targets(num_targets)
+{}
+
+bad_event_generator_target_gid::bad_event_generator_target_gid(cell_gid_type gid, cell_gid_type tgt_gid):
+    arbor_exception(pprintf("Model building error on cell {}: event_generator target gid {} has to match cell gid {}].", gid, tgt_gid, gid)),
+    gid(gid), tgt_gid(tgt_gid)
+{}
+
+bad_event_generator_target_lid::bad_event_generator_target_lid(cell_gid_type gid, cell_lid_type tgt_lid, cell_size_type num_targets):
+    arbor_exception(pprintf("Model building error on cell {}: event_generator target index {} is out of range. Cell {} has {} targets", gid, tgt_lid, gid, num_targets) +
+                    (num_targets ? pprintf(", in the range [{}:{}].", 0, num_targets-1) : ".")),
     gid(gid), tgt_lid(tgt_lid), num_targets(num_targets)
 {}
 

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -79,6 +79,18 @@ struct bad_connection_target_lid: arbor_exception {
     cell_size_type num_targets;
 };
 
+struct bad_event_generator_target_gid: arbor_exception {
+    bad_event_generator_target_gid(cell_gid_type gid, cell_gid_type tgt_gid);
+    cell_gid_type gid, tgt_gid;
+};
+
+struct bad_event_generator_target_lid: arbor_exception {
+    bad_event_generator_target_lid(cell_gid_type gid, cell_lid_type tgt_lid, cell_size_type num_targets);
+    cell_gid_type gid;
+    cell_lid_type tgt_lid;
+    cell_size_type num_targets;
+};
+
 struct bad_global_property: arbor_exception {
     explicit bad_global_property(cell_kind kind);
     cell_kind kind;

--- a/arbor/include/arbor/event_generator.hpp
+++ b/arbor/include/arbor/event_generator.hpp
@@ -64,6 +64,9 @@ struct empty_generator {
     event_seq events(time_type, time_type) {
         return {nullptr, nullptr};
     }
+    std::vector<cell_member_type> targets() {
+        return {};
+    };
 };
 
 class event_generator {
@@ -95,10 +98,15 @@ public:
         return impl_->events(t0, t1);
     }
 
+    std::vector<cell_member_type> targets() const {
+        return impl_->targets();
+    }
+
 private:
     struct interface {
         virtual void reset() = 0;
         virtual event_seq events(time_type, time_type) = 0;
+        virtual std::vector<cell_member_type> targets() = 0;
         virtual std::unique_ptr<interface> clone() = 0;
         virtual ~interface() {}
     };
@@ -112,6 +120,10 @@ private:
 
         event_seq events(time_type t0, time_type t1) override {
             return wrapped.events(t0, t1);
+        }
+
+        std::vector<cell_member_type> targets() override {
+            return wrapped.targets();
         }
 
         void reset() override {
@@ -151,6 +163,10 @@ struct schedule_generator {
         }
 
         return {events_.data(), events_.data()+events_.size()};
+    }
+
+    std::vector<cell_member_type> targets() {
+        return {target_};
     }
 
 private:
@@ -215,6 +231,12 @@ struct explicit_generator {
 
         start_index_ = ub-events_.data();
         return {lb, ub};
+    }
+
+    std::vector<cell_member_type> targets() {
+        std::vector<cell_member_type> tgts;
+        std::transform(events_.begin(), events_.end(), std::back_inserter(tgts), [](auto&& e){ return e.target;});
+        return tgts;
     }
 
 private:

--- a/arbor/include/arbor/event_generator.hpp
+++ b/arbor/include/arbor/event_generator.hpp
@@ -16,12 +16,12 @@ namespace arb {
 
 // An `event_generator` generates a sequence of events to be delivered to a cell.
 // The sequence of events is always in ascending order, i.e. each event will be
-// greater than the event that proceded it, where events are ordered by:
+// greater than the event that proceeded it, where events are ordered by:
 //  - delivery time;
 //  - then target id for events with the same delivery time;
 //  - then weight for events with the same delivery time and target.
 //
-// An `event_generator` supports two operations:
+// An `event_generator` supports three operations:
 //
 // `void event_generator::reset()`
 //
@@ -31,6 +31,10 @@ namespace arb {
 //
 //     Provide a non-owning view on to the events in the time interval
 //     [to, from).
+//
+// `std::vector<cell_member_type> targets()`
+//
+//     Return a vector of all the targets of the generator.
 //
 // The `event_seq` type is a pair of `spike_event` pointers that
 // provide a view onto an internally-maintained contiguous sequence

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -159,8 +159,23 @@ simulation_state::simulation_state(
             // Store mapping of gid to local cell index.
             gid_to_local_[gid] = gid_local_info{lidx, grpidx};
 
+            // Check validity of event_generator targets
+            auto event_gens = rec.event_generators(gid);
+            auto num_targets = rec.num_targets(gid);
+            for (const auto& g: event_gens) {
+                for (const auto& t: g.targets()) {
+                    if (t.gid != gid) {
+                        throw arb::bad_event_generator_target_gid(gid,  t.gid);
+                    }
+                    if (t.index >= num_targets) {
+                        throw arb::bad_event_generator_target_lid(gid, t.index, num_targets);
+                    }
+                }
+            }
+
             // Set up the event generators for cell gid.
-            event_generators_[lidx] = rec.event_generators(gid);
+            event_generators_[lidx] = event_gens;
+
             ++lidx;
         }
         ++grpidx;

--- a/python/example/single_cell_stdp.py
+++ b/python/example/single_cell_stdp.py
@@ -22,6 +22,9 @@ class single_recipe(arbor.recipe):
     def num_sources(self, gid):
         return 1
 
+    def num_targets(self, gid):
+        return 2
+
     def cell_kind(self, gid):
         return arbor.cell_kind.cable
 


### PR DESCRIPTION
- Add a method to `event_generator` that returns all of its targets. 
- When the simulation is constructed, check the targets of each event generator, and throw an exception if an the `gid` or `lid` is invalid.
- Add unit test.

Fixes #1435 