### PR TITLE
fix bug attaching branches to the soma in ASCII file descriptions

### DIFF
--- a/arborio/neurolucida.cpp
+++ b/arborio/neurolucida.cpp
@@ -648,7 +648,7 @@ asc_morphology parse_asc_string(const char* input) {
 
             if (!branch.samples.empty()) { // Skip empty branches, which are permitted
                 auto it = branch.samples.begin();
-                // Don't conect the first sample to the distal end of the parent
+                // Don't connect the first sample to the distal end of the parent
                 // branch if the parent is the soma center.
                 if (parent==arb::mnpos) {
                     prox_sample = *it;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -216,7 +216,7 @@ if(${CMAKE_POSITION_INDEPENDENT_CODE})
     MECHS dummy
     ARBOR "${PROJECT_SOURCE_DIR}"
     STANDALONE ON
-    VERBOSE ON)
+    VERBOSE OFF)
   target_compile_definitions(unit PRIVATE USE_DYNAMIC_CATALOGUES)
   add_dependencies(unit dummy-catalogue)
 endif()


### PR DESCRIPTION
Fix bug attaching branches to the soma in ASCII file descriptions.

Branches in an ASCII description attached to the soma were incorrectly creating a segment
from the center of the soma to the first point in the branch.