### PR TITLE
orient ASC soma cylinders along y axis

### DIFF
--- a/arborio/neurolucida.cpp
+++ b/arborio/neurolucida.cpp
@@ -591,15 +591,6 @@ asc_morphology parse_asc_string(const char* input) {
 
     arb::segment_tree stree;
 
-/*
-
-
-
-
-
-
-
-*/
     // Form a soma composed of two cylinders, extended along the negative then positive
     // y axis from the center of the soma.
     //

--- a/doc/fileformat/asc.rst
+++ b/doc/fileformat/asc.rst
@@ -36,18 +36,18 @@ and locsets from the meta data.
 Soma / CellBody
 """"""""""""""""
 
-The soma, or CellBody, is described in one of three different methods (that we are aware of) in
-an ASCII file.
+The soma, or CellBody, is described in one of three different methods in an ASCII file:
 
   1. As a CellBody statement containing a single location and radius, which models **a sphere**.
   2. As a CellBody statement containing an unbranched sequence of locations that define **a single contour**.
   3. As multiple CellBody statements, each defining a contour, that describe the soma as **a stack of contours**.
 
-Arbor supports description methods 1 and 2, and support for method 3 can be added on request
-(open an issue).
+Arbor supports description methods 1 and 2 following the `neuromporpho policies <http://neuromorpho.org/SomaFormat.html>`_.
+Currently multiple contours in method 3 are not supported, and if you need support make
+the request with an `issue <https://github.com/arbor-sim/arbor/issues>`_.
 
 In each case, the soma is modeled as a cylinder with diameter equal to it's length, centred
-at the centre of the soma, and oriented along the z axis.
+at the centre of the soma, and oriented along the y axis.
 
 For a **spherical** soma, the centre and diameter are that of the sphere. For
 a **contour**, the centre is the centroid of the locations that define the contour,

--- a/test/unit/test_asc.cpp
+++ b/test/unit/test_asc.cpp
@@ -62,12 +62,12 @@ TEST(asc, only_cell_body) {
         auto& segs1 = m.morphology.branch_segments(0);
         EXPECT_EQ(segs1.size(), 1u);
         EXPECT_EQ(segs1[0].prox, (arb::mpoint{0., 0., 1., 2.}));
-        EXPECT_EQ(segs1[0].dist, (arb::mpoint{0., 0., -1., 2.}));
+        EXPECT_EQ(segs1[0].dist, (arb::mpoint{0.,-2., 1., 2.}));
 
         auto& segs2 = m.morphology.branch_segments(1);
         EXPECT_EQ(segs2.size(), 1u);
         EXPECT_EQ(segs2[0].prox, (arb::mpoint{0., 0., 1., 2.}));
-        EXPECT_EQ(segs2[0].dist, (arb::mpoint{0., 0., 3., 2.}));
+        EXPECT_EQ(segs2[0].dist, (arb::mpoint{0., 2., 1., 2.}));
     }
 
 
@@ -81,12 +81,12 @@ TEST(asc, only_cell_body) {
         auto& segs1 = m.morphology.branch_segments(0);
         EXPECT_EQ(segs1.size(), 1u);
         EXPECT_EQ(segs1[0].prox, (arb::mpoint{0., 0., 1., 2.}));
-        EXPECT_EQ(segs1[0].dist, (arb::mpoint{0., 0., -1., 2.}));
+        EXPECT_EQ(segs1[0].dist, (arb::mpoint{0.,-2., 1., 2.}));
 
         auto& segs2 = m.morphology.branch_segments(1);
         EXPECT_EQ(segs2.size(), 1u);
         EXPECT_EQ(segs2[0].prox, (arb::mpoint{0., 0., 1., 2.}));
-        EXPECT_EQ(segs2[0].dist, (arb::mpoint{0., 0., 3., 2.}));
+        EXPECT_EQ(segs2[0].dist, (arb::mpoint{0., 2., 1., 2.}));
     }
 
     { // Cell with two CellBodys: unsupported feature ATM.
@@ -257,9 +257,9 @@ TEST(asc, soma_connection) {
         EXPECT_EQ(m.num_branches(), 5u);
         // Test soma
         EXPECT_EQ(m.branch_segments(0)[0].prox, (arb::mpoint{0, 0, 0, 2}));
-        EXPECT_EQ(m.branch_segments(0)[0].dist, (arb::mpoint{0, 0,-2, 2}));
+        EXPECT_EQ(m.branch_segments(0)[0].dist, (arb::mpoint{0,-2, 0, 2}));
         EXPECT_EQ(m.branch_segments(1)[0].prox, (arb::mpoint{0, 0, 0, 2}));
-        EXPECT_EQ(m.branch_segments(1)[0].dist, (arb::mpoint{0, 0, 2, 2}));
+        EXPECT_EQ(m.branch_segments(1)[0].dist, (arb::mpoint{0, 2, 0, 2}));
         // Test dendrite proximal ends
         EXPECT_EQ(m.branch_segments(2)[0].prox, (arb::mpoint{0, 2, 0, 1}));
         EXPECT_EQ(m.branch_segments(3)[0].prox, (arb::mpoint{0, 5, 0, 1}));
@@ -271,9 +271,9 @@ TEST(asc, soma_connection) {
         EXPECT_EQ(m.num_branches(), 7u);
         // Test soma
         EXPECT_EQ(m.branch_segments(0)[0].prox, (arb::mpoint{0, 0, 0, 2}));
-        EXPECT_EQ(m.branch_segments(0)[0].dist, (arb::mpoint{0, 0,-2, 2}));
+        EXPECT_EQ(m.branch_segments(0)[0].dist, (arb::mpoint{0,-2, 0, 2}));
         EXPECT_EQ(m.branch_segments(1)[0].prox, (arb::mpoint{0, 0, 0, 2}));
-        EXPECT_EQ(m.branch_segments(1)[0].dist, (arb::mpoint{0, 0, 2, 2}));
+        EXPECT_EQ(m.branch_segments(1)[0].dist, (arb::mpoint{0, 2, 0, 2}));
         // Test dendrite proximal ends
         EXPECT_EQ(m.branch_segments(2)[0].prox, (arb::mpoint{ 0, 2, 0, 1}));
         EXPECT_EQ(m.branch_segments(3)[0].prox, (arb::mpoint{ 0, 5, 0, 1}));
@@ -287,9 +287,9 @@ TEST(asc, soma_connection) {
         EXPECT_EQ(m.num_branches(), 8u);
         // Test soma
         EXPECT_EQ(m.branch_segments(0)[0].prox, (arb::mpoint{0, 0, 0, 2}));
-        EXPECT_EQ(m.branch_segments(0)[0].dist, (arb::mpoint{0, 0,-2, 2}));
+        EXPECT_EQ(m.branch_segments(0)[0].dist, (arb::mpoint{0,-2, 0, 2}));
         EXPECT_EQ(m.branch_segments(1)[0].prox, (arb::mpoint{0, 0, 0, 2}));
-        EXPECT_EQ(m.branch_segments(1)[0].dist, (arb::mpoint{0, 0, 2, 2}));
+        EXPECT_EQ(m.branch_segments(1)[0].dist, (arb::mpoint{0, 2, 0, 2}));
         // Test dendrite proximal ends
         EXPECT_EQ(m.branch_segments(2)[0].prox, (arb::mpoint{0, 2, 0, 1}));
         EXPECT_EQ(m.branch_segments(3)[0].prox, (arb::mpoint{0, 5, 0, 1}));


### PR DESCRIPTION
Fix orientation of ASC somas from along z axis to along the y axis.

As per the rules followed by Arbor's SWC parsers, and prescribed in:
http://neuromorpho.org/SomaFormat.html

Addresses #1445