### PR TITLE
Add optional spherical root for NeuroML.

### DIFF
--- a/arbor/morph/place_pwlin.cpp
+++ b/arbor/morph/place_pwlin.cpp
@@ -62,7 +62,16 @@ std::vector<mpoint> place_pwlin::all_at(mlocation loc) const {
     double pos = is_degenerate(pw_index)? 0: loc.pos;
 
     for (auto [bounds, index]: util::make_range(pw_index.equal_range(pos))) {
-        result.push_back(interpolate_segment(bounds, data_->segments.at(index), pos));
+        auto seg = data_->segments.at(index);
+
+        // Add both ends of zero length segment, if they differ.
+        if (bounds.first==bounds.second && seg.prox!=seg.dist) {
+            result.push_back(seg.prox);
+            result.push_back(seg.dist);
+        }
+        else {
+            result.push_back(interpolate_segment(bounds, seg, pos));
+        }
     }
     return result;
 }

--- a/arborio/include/arborio/neuroml.hpp
+++ b/arborio/include/arborio/neuroml.hpp
@@ -90,7 +90,19 @@ struct nml_morphology_data {
 
 struct neuroml_impl;
 
+// TODO: C++20, replace with enum class and deploy using enum as appropriate.
+namespace neuroml_options {
+    enum values {
+        none = 0,
+        allow_spherical_root = 1
+    };
+}
+
 struct neuroml {
+    // Correct interpretation of zero-length segments is currently a bit unclear
+    // in NeuroML 2.0, hence these options. For further options, use flags in powers of two
+    // so that we can bitwise combine and test them.
+
     neuroml();
     explicit neuroml(std::string nml_document);
 
@@ -108,8 +120,8 @@ struct neuroml {
     // Parse and retrieve top-level morphology or morphology associated with a cell.
     // Return nullopt if not found.
 
-    std::optional<nml_morphology_data> morphology(const std::string& morph_id) const;
-    std::optional<nml_morphology_data> cell_morphology(const std::string& cell_id) const;
+    std::optional<nml_morphology_data> morphology(const std::string& morph_id, enum neuroml_options::values = neuroml_options::none) const;
+    std::optional<nml_morphology_data> cell_morphology(const std::string& cell_id, enum neuroml_options::values = neuroml_options::none) const;
 
     ~neuroml();
 

--- a/arborio/neuroml.cpp
+++ b/arborio/neuroml.cpp
@@ -116,15 +116,15 @@ std::vector<std::string> neuroml::morphology_ids() const {
     return result;
 }
 
-optional<nml_morphology_data> neuroml::morphology(const std::string& morph_id) const {
+optional<nml_morphology_data> neuroml::morphology(const std::string& morph_id, enum neuroml_options::values options) const {
     xml_error_scope err;
     auto ctx = impl_->make_context();
     auto matches = ctx.query("//nml:neuroml/nml:morphology[@id="+xpath_escape(morph_id)+"]");
 
-    return matches.empty()? nullopt: optional(nml_parse_morphology_element(ctx, matches[0]));
+    return matches.empty()? nullopt: optional(nml_parse_morphology_element(ctx, matches[0], options));
 }
 
-optional<nml_morphology_data> neuroml::cell_morphology(const std::string& cell_id) const {
+optional<nml_morphology_data> neuroml::cell_morphology(const std::string& cell_id, enum neuroml_options::values options) const {
     xml_error_scope err;
     auto ctx = impl_->make_context();
     auto matches = ctx.query(
@@ -133,7 +133,7 @@ optional<nml_morphology_data> neuroml::cell_morphology(const std::string& cell_i
 
     if (matches.empty()) return nullopt;
 
-    nml_morphology_data M = nml_parse_morphology_element(ctx, matches[0]);
+    nml_morphology_data M = nml_parse_morphology_element(ctx, matches[0], options);
     M.cell_id = cell_id;
     return M;
 }

--- a/arborio/nml_parse_morphology.hpp
+++ b/arborio/nml_parse_morphology.hpp
@@ -5,6 +5,6 @@
 
 namespace arborio {
 
-nml_morphology_data nml_parse_morphology_element(xmlwrap::xml_xpathctx ctx, xmlwrap::xml_node morph);
+nml_morphology_data nml_parse_morphology_element(xmlwrap::xml_xpathctx ctx, xmlwrap::xml_node morph, enum neuroml_options::values);
 
 } // namespace arborio

--- a/doc/cpp/morphology.rst
+++ b/doc/cpp/morphology.rst
@@ -482,7 +482,6 @@ Unhandleable exceptions from ``libxml2`` are forwarded via an exception
 
 NeuroML2 morphology support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 NeuroML documents are represented by the ``arborio::neuroml`` class,
 which in turn provides methods for the identification and translation
 of morphology data. ``neuroml`` objects are moveable and move-assignable,
@@ -495,6 +494,9 @@ those which can be represented by an ``unsigned long long`` value.
 the underlying libxml2 library reports a problem that cannot be handled by the ``arborio``
 library. Otherwise, exceptions derived from ``aborio::neuroml_exception`` can be thrown
 when encountering problems interpreting the NeuroML document (see :ref:`cppneuromlexceptions` below).
+
+Special parsing behaviour can be invoked through the use of an enum value in the `neuroml_options`
+namespace.
 
 .. cpp:class:: neuroml
 
@@ -510,15 +512,29 @@ when encountering problems interpreting the NeuroML document (see :ref:`cppneuro
 
    Return the id of each top-level ``<morphology>`` element defined in the NeuroML document.
 
-   .. cpp:function:: std::optional<nml_morphology_data> morphology(const std::string&) const
+   .. cpp:function:: std::optional<nml_morphology_data> morphology(const std::string&, enum neuroml_options::value = neuroml_options::none) const
 
    Return a representation of the top-level morphology with the supplied identifier, or
    ``std::nullopt`` if no such morphology could be found.
 
-   .. cpp:function:: std::optional<nml_morphology_data> cell_morphology(const std::string&) const
+   .. cpp:function:: std::optional<nml_morphology_data> cell_morphology(const std::string&, enum neuroml_options::value = neuroml_options::none) const
 
    Return a representation of the morphology associated with the cell with the supplied identifier,
    or ``std::nullopt`` if the cell or its morphology could not be found.
+
+.. cpp:enum:: neuroml_options::value
+
+   .. cpp:enumerator:: none
+
+   Perform no special parsing.
+
+   .. cpp:enumerator:: allow_spherical_root
+
+   Replace a zero-length root segment of constant radius with a Y-axis aligned
+   cylindrical segment of the same radius and with length twice the radius. This
+   cylinder will have the equivalent surface area to a sphere of the given radius.
+
+   All child segments will connect to the centre of this cylinder, no matter the value of any ``fractionAlong`` attribute.
 
 The morphology representation contains the corresponding Arbor ``arb::morphology`` object,
 label dictionaries for regions corresponding to its segments and segment groups by name

--- a/doc/python/morphology.rst
+++ b/doc/python/morphology.rst
@@ -613,6 +613,10 @@ constitute part of the CV boundary point set.
     An implementation limitation restricts valid segment id values to those which can be represented by an
     unsigned long long value.
 
+    The ``allow_spherical_root`` optional parameter below, if set to true, will instruct the parser to
+    interpret a zero-length constant radius root segment as denoting a spherical segment, and this will
+    in turn be represented in the resultant morphology by a cylinder of equivalent surface area.
+
    .. py:method:: neuroml(filename)
 
       Build a NeuroML document representation from the supplied file contents.
@@ -631,20 +635,22 @@ constitute part of the CV boundary point set.
 
       :rtype: list[str]
 
-   .. py:method:: morphology(morph_id)
+   .. py:method:: morphology(morph_id, allow_spherical_root=false)
 
       Returns a representation of the top-level morphology with the supplied morph_id if it could be found.
       Parse errors or an inconsistent representation will raise an exception.
 
       :param str morph_id: ID of the top-level morphology.
+      :param bool allow_spherical_root: Treat zero length root segments especially.
       :rtype: optional(neuroml_morph_data)
 
-   .. py:method:: cell_morphology(cell_id)
+   .. py:method:: cell_morphology(cell_id, allow_spherical_root=false)
 
       Returns a representation of the morphology associated with the cell with the supplied cell_id if it
       could be found. Parse errors or an inconsistent representation will raise an exception.
 
       :param str morph_id: ID of the cell.
+      :param bool allow_spherical_root: Treat zero length root segments especially.
       :rtype: optional(neuroml_morph_data)
 
 .. _pyasc:

--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -413,10 +413,10 @@ void register_morphology(py::module& m) {
             [](const arborio::nml_morphology_data& md) {return label_dict_proxy(md.segments);},
             "Label dictionary containing one region expression for each segment id.")
         .def("named_segments",
-             [](const arborio::nml_morphology_data& md) {return label_dict_proxy(md.named_segments);},
+            [](const arborio::nml_morphology_data& md) {return label_dict_proxy(md.named_segments);},
             "Label dictionary containing one region expression for each name applied to one or more segments.")
         .def("groups",
-             [](const arborio::nml_morphology_data& md) {return label_dict_proxy(md.groups);},
+            [](const arborio::nml_morphology_data& md) {return label_dict_proxy(md.groups);},
             "Label dictionary containing one region expression for each segmentGroup id.")
         .def_readonly("group_segments",
             &arborio::nml_morphology_data::group_segments,
@@ -427,59 +427,64 @@ void register_morphology(py::module& m) {
     neuroml
         // constructors
         .def(py::init(
-            [](std::string fname){
-              std::ifstream fid{fname};
-              if (!fid.good()) {
-                  throw pyarb_error(util::pprintf("can't open file '{}'", fname));
-              }
-              try {
-                  std::string string_data((std::istreambuf_iterator<char>(fid)),
-                                           std::istreambuf_iterator<char>());
-                  return arborio::neuroml(string_data);
-              }
-              catch (arborio::neuroml_exception& e) {
-                  // Try to produce helpful error messages for NeuroML parsing errors.
-                  throw pyarb_error(
-                      util::pprintf("NeuroML error processing file {}: ", fname, e.what()));
-              }
+            [](std::string fname) {
+                std::ifstream fid{fname};
+                if (!fid.good()) {
+                    throw pyarb_error(util::pprintf("can't open file '{}'", fname));
+                }
+                try {
+                    std::string string_data((std::istreambuf_iterator<char>(fid)),
+                                             std::istreambuf_iterator<char>());
+                    return arborio::neuroml(string_data);
+                }
+                catch (arborio::neuroml_exception& e) {
+                    // Try to produce helpful error messages for NeuroML parsing errors.
+                    throw pyarb_error(util::pprintf("NeuroML error processing file {}: {}", fname, e.what()));
+                }
             }))
         .def("cell_ids",
-             [](const arborio::neuroml& nml) {
+            [](const arborio::neuroml& nml) {
                 try {
                     return nml.cell_ids();
                 }
                 catch (arborio::neuroml_exception& e) {
                     throw util::pprintf("NeuroML error: {}", e.what());
                 }
-             },"Query top-level cells.")
+            },
+            "Query top-level cells.")
         .def("morphology_ids",
-             [](const arborio::neuroml& nml) {
+            [](const arborio::neuroml& nml) {
                 try {
                     return nml.morphology_ids();
                 }
                 catch (arborio::neuroml_exception& e) {
                     throw util::pprintf("NeuroML error: {}", e.what());
                 }
-             },"Query top-level standalone morphologies.")
+            },
+            "Query top-level standalone morphologies.")
         .def("morphology",
-             [](const arborio::neuroml& nml, const std::string& morph_id) {
+            [](const arborio::neuroml& nml, const std::string& morph_id, bool spherical) {
                 try {
-                    return nml.morphology(morph_id);
+                    using namespace arborio::neuroml_options;
+                    return nml.morphology(morph_id, spherical? allow_spherical_root: none);
                 }
                 catch (arborio::neuroml_exception& e) {
                     throw util::pprintf("NeuroML error: {}", e.what());
                 }
-             },"morph_id"_a,"Retrieve top-level nml_morph_data associated with morph_id.")
+            }, "morph_id"_a, "allow_spherical_root"_a=false,
+            "Retrieve top-level nml_morph_data associated with morph_id.")
         .def("cell_morphology",
-             [](const arborio::neuroml& nml, const std::string& cell_id) {
-               try {
-                   return nml.cell_morphology(cell_id);
-               }
-               catch (arborio::neuroml_exception& e) {
-                   throw util::pprintf("NeuroML error: {}", e.what());
-               }
-             },"morph_id"_a,"Retrieve nml_morph_data associated with cell_id.");
-#endif
+            [](const arborio::neuroml& nml, const std::string& cell_id, bool spherical) {
+                try {
+                    using namespace arborio::neuroml_options;
+                    return nml.cell_morphology(cell_id, spherical? allow_spherical_root: none);
+                }
+                catch (arborio::neuroml_exception& e) {
+                    throw util::pprintf("NeuroML error: {}", e.what());
+                }
+            }, "cell_id"_a, "allow_spherical_root"_a=false,
+            "Retrieve nml_morph_data associated with cell_id.");
+#endif // def ARB_NEUROML_ENABLED
 }
 
 } // namespace pyarb

--- a/test/unit/morph_pred.hpp
+++ b/test/unit/morph_pred.hpp
@@ -10,6 +10,7 @@
 #include <arbor/morph/region.hpp>
 
 #include "util/span.hpp"
+#include "common.hpp"
 
 namespace testing {
 
@@ -85,6 +86,19 @@ inline ::testing::AssertionResult locset_eq(const arb::mprovider& p, arb::locset
     return mlocationlist_eq(thingify(a, p), thingify(b, p));
 }
 
+inline ::testing::AssertionResult point_almost_eq(arb::mpoint p, arb::mpoint q) {
+    // Compare almost equal in single precision.
+    auto result = almost_eq<float>(p.x, q.x);
+    if (!result) return result;
+
+    result = almost_eq<float>(p.y, q.y);
+    if (!result) return result;
+
+    result = almost_eq<float>(p.z, q.z);
+    if (!result) return result;
+
+    return almost_eq<float>(p.radius, q.radius);
+}
 
 } // namespace testing
 

--- a/test/unit/test_morph_place.cpp
+++ b/test/unit/test_morph_place.cpp
@@ -385,6 +385,35 @@ TEST(place_pwlin, all_at) {
         EXPECT_TRUE(mpoint_almost_eq(p1d, points_end_b0[1]));
         EXPECT_TRUE(mpoint_almost_eq(p2d, points_end_b0[2]));
     }
+
+    // Zero length branch comprising single zero-length segment with differing radius.
+    // (Please don't do this either.)
+    {
+        mpoint p0p{2, 3, 4, 5};
+        mpoint p0d{2, 3, 4, 8};
+
+        segment_tree tree;
+        (void)tree.append(mnpos, p0p, p0d, 0);
+
+        morphology m(tree);
+        mprovider p(m, label_dict{});
+        place_pwlin place(m);
+
+        auto points_begin_b0 = place.all_at(mlocation{0, 0});
+        ASSERT_EQ(2u, points_begin_b0.size());
+        EXPECT_TRUE(mpoint_almost_eq(p0p, points_begin_b0[0]));
+        EXPECT_TRUE(mpoint_almost_eq(p0d, points_begin_b0[1]));
+
+        auto points_mid_b0 = place.all_at(mlocation{0, 0.5});
+        ASSERT_EQ(2u, points_begin_b0.size());
+        EXPECT_TRUE(mpoint_almost_eq(p0p, points_begin_b0[0]));
+        EXPECT_TRUE(mpoint_almost_eq(p0d, points_begin_b0[1]));
+
+        auto points_end_b0 = place.all_at(mlocation{0, 1});
+        ASSERT_EQ(2u, points_begin_b0.size());
+        EXPECT_TRUE(mpoint_almost_eq(p0p, points_begin_b0[0]));
+        EXPECT_TRUE(mpoint_almost_eq(p0d, points_begin_b0[1]));
+    }
 }
 
 TEST(place_pwlin, segments) {


### PR DESCRIPTION
* Adds a `neuroml_options` namespace with enum for use with `neuroml::morphology(...)` and `neuroml::cell_morphology(...)`.
* Add support for a 'spherical' root segment with option `neuroml_options;:allow_spherical_root`; a zero-length root segment with identical proximal and distal radius will then be converted into an area-equivalent cylinder in the resultant morphology.
* Amend `place_pwlin::all_at` so that locations on a zero-length segment with different radii at the endpoint will give an mpoint for either end.
* Add `allow_spherical_root` boolean optional parameter to Python NeuroML morphology methods.
* Update docs; C++ unit tests.

Fixes #1439.