### PR TITLE
Expose `assign` from `sve.hpp`

### DIFF
--- a/arbor/include/arbor/simd/sve.hpp
+++ b/arbor/include/arbor/simd/sve.hpp
@@ -894,7 +894,7 @@ struct simd_cast_impl {
 };
 }  // namespace detail
 
-template <typename T, typename Other>
+template <typename T, typename Other, typename = std::enable_if_t<detail::is_sve<T>::value>>
 void assign(T& a, const Other& b) {
     a = detail::simd_cast_impl<T>::cast(b);
 }

--- a/arbor/include/arbor/simd/sve.hpp
+++ b/arbor/include/arbor/simd/sve.hpp
@@ -800,10 +800,12 @@ void compound_indexed_add(
     }
 }
 
+[[maybe_unused]]
 static int width(const svfloat64_t& v) {
     return svlen_f64(v);
 };
 
+[[maybe_unused]]
 static int width(const svint64_t& v) {
     return svlen_s64(v);
 };
@@ -890,13 +892,13 @@ struct simd_cast_impl {
         return r;
     }
 };
+}  // namespace detail
 
 template <typename T, typename Other>
 void assign(T& a, const Other& b) {
     a = detail::simd_cast_impl<T>::cast(b);
 }
 
-}  // namespace detail
 }  // namespace simd
 }  // namespace arb
 

--- a/arbor/include/arbor/simd/sve.hpp
+++ b/arbor/include/arbor/simd/sve.hpp
@@ -894,8 +894,8 @@ struct simd_cast_impl {
 };
 }  // namespace detail
 
-template <typename T, typename Other, typename = std::enable_if_t<detail::is_sve<T>::value>>
-void assign(T& a, const Other& b) {
+template <typename T, typename Other>
+void assign(T& a, const Other& b, typename std::enable_if_t<detail::is_sve<T>::value>* = 0) {
     a = detail::simd_cast_impl<T>::cast(b);
 }
 


### PR DESCRIPTION
Move the `assign` function out of the `detail` namespace. 