### PR TITLE
Make proper aggregates for C++20

### DIFF
--- a/arbor/include/arbor/cable_cell_param.hpp
+++ b/arbor/include/arbor/cable_cell_param.hpp
@@ -89,41 +89,34 @@ struct gap_junction_site {};
 // cell-wide default:
 
 struct init_membrane_potential {
-    init_membrane_potential() = delete;
-    double value; // [mV]
+    double value = NAN; // [mV]
 };
 
 struct temperature_K {
-    temperature_K() = delete;
-    double value; // [K]
+    double value = NAN; // [K]
 };
 
 struct axial_resistivity {
-    axial_resistivity() = delete;
-    double value; // [Ω·cm]
+    double value = NAN; // [Ω·cm]
 };
 
 struct membrane_capacitance {
-    membrane_capacitance() = delete;
-    double value; // [F/m²]
+    double value = NAN; // [F/m²]
 };
 
 struct init_int_concentration {
-    init_int_concentration() = delete;
-    std::string ion;
-    double value; // [mM]
+    std::string ion = "";
+    double value = NAN; // [mM]
 };
 
 struct init_ext_concentration {
-    init_ext_concentration() = delete;
-    std::string ion;
-    double value; // [mM]
+    std::string ion = "";
+    double value = NAN; // [mM]
 };
 
 struct init_reversal_potential {
-    init_reversal_potential() = delete;
-    std::string ion;
-    double value; // [mV]
+    std::string ion = "";
+    double value = NAN; // [mV]
 };
 
 // Mechanism description, viz. mechanism name and


### PR DESCRIPTION
This removes the deletion of default constructors in arbor's `cable_cell_parameter`'s strong typedefs. When compiling with a C++20 compiler (as done in the GUI) this idiom prevents aggregate initialisation like this
```
arb::membrane_capacitance cm{42.0}; // OK in 17, fails in 20
```
Instead, values are set to `NAN`.

These are the only occurences of this idiom.
See here for the change in C++ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1008r1.pdf