### PR TITLE
Docs markup improvements

### DIFF
--- a/doc/concepts/decor.rst
+++ b/doc/concepts/decor.rst
@@ -28,8 +28,8 @@ The choice of region or locset is reflected in the two broad classes of dynamics
 
 Decorations are described by a **decor** object in Arbor. It provides facilities for
 
-  * setting properties defined over the whole cell;
-  * descriptions of dynamics applied to regions and locsets.
+* setting properties defined over the whole cell;
+* descriptions of dynamics applied to regions and locsets.
 
 .. _cablecell-paint:
 

--- a/doc/concepts/domdec.rst
+++ b/doc/concepts/domdec.rst
@@ -6,8 +6,8 @@ Domain decomposition
 A *domain decomposition* describes the distribution of the model over the available computational resources.
 The description partitions the cells in the model as follows:
 
-    * group the cells into cell groups of the same :ref:`kind <modelcellkind>` of cell;
-    * assign each cell group to either a CPU core or GPU on a specific MPI rank.
+* group the cells into cell groups of the same :ref:`kind <modelcellkind>` of cell;
+* assign each cell group to either a CPU core or GPU on a specific MPI rank.
 
 The number of cells in each cell group depends on different factors, including the type of the cell, and whether the
 cell group will run on a CPU core or the GPU. The domain decomposition is solely responsible for describing the distribution

--- a/doc/concepts/morphology.rst
+++ b/doc/concepts/morphology.rst
@@ -607,7 +607,7 @@ because it has two children: the dendrites attached to its distal end.
 Supported file formats
 ----------------------
 
-See the main menu under the "file formats" caption, or have a look in the ``doc/fileformat`` directory.
+See the supported :ref:`file formats <format-overview>`.
 
 .. _morph-cv-policies:
 

--- a/doc/concepts/morphology.rst
+++ b/doc/concepts/morphology.rst
@@ -607,17 +607,7 @@ because it has two children: the dendrites attached to its distal end.
 Supported file formats
 ----------------------
 
-Arbor supports morphologies described using the SWC file format and the NeuroML file format.
-
-SWC
-~~~
-
-See :ref:`formatswc`
-
-NeuroML
-~~~~~~~
-
-See :ref:`formatneuroml`
+See the main menu under the "file formats" caption, or have a look in the ``doc/fileformat`` directory.
 
 .. _morph-cv-policies:
 

--- a/doc/concepts/recipe.rst
+++ b/doc/concepts/recipe.rst
@@ -6,16 +6,16 @@ Recipes
 An Arbor *recipe* is a description of a model. The recipe is queried during the model
 building phase to provide information about individual cells in the model, such as:
 
-  * The **number of cells** in the model.
-  * The **kind** of each cell.
-  * The **description** of each cell, e.g. with morphology, dynamics, synapses, detectors,
-    stimuli etc.
-  * The number of **spike targets** on each cell.
-  * The number of **spike sources** on each cell.
-  * The number of **gap junction sites** on each cell.
-  * Incoming **network connections** from other cells terminating on a cell.
-  * **Gap junction connections** on each cell.
-  * **Probes** on each cell.
+* The **number of cells** in the model.
+* The **kind** of each cell.
+* The **description** of each cell, e.g. with morphology, dynamics, synapses, detectors,
+  stimuli etc.
+* The number of **spike targets** on each cell.
+* The number of **spike sources** on each cell.
+* The number of **gap junction sites** on each cell.
+* Incoming **network connections** from other cells terminating on a cell.
+* **Gap junction connections** on each cell.
+* **Probes** on each cell.
 
 Recipes are structured to provide a consistent interface for describing each cell in the
 network using their global identifier (`gid`).
@@ -26,31 +26,31 @@ which helps make Arbor fast and easily distributable over many nodes.
 To better illustrate the content of a recipe, let's consider the following network of
 three cells:
 
--  | ``Cell 0``: Is a single soma, with ``hh`` (Hodgkin-huxley) dynamics. In the middle
-     of the soma, a spike detector is attached, it generates a spiking event when the
-     voltage goes above 10 mV. In the same spot on the soma, a current clamp is also
-     attached, with the intention of triggering some spikes. All of the preceding info:
-     the morphology, dynamics, spike detector and current clamp are what is referred to in
-     Arbor as the **description** of the cell.
-   | ``Cell 0`` should be modelled as a :ref:`cable cell<modelcablecell>`,
-     (because cable cells allow complex dynamics such as ``hh``). This is referred to as
-     the **kind** of the cell.
-   | It's quite expensive to build cable cells, so we don't want to do this too often.
-     But when the simulation is first set up, it needs to know how cells interact with
-     one another in order to distribute the simulation over the available computational
-     resources. This is why the number of **targets**, **sources** and **gap junction sites**
-     is needed separately from the cell description: with them, the simulation can tell
-     that ``cell 0`` has 1 **spike source** (the detector), 0 **spike targets**, and 0
-     **gap junction sites**, without having to build the cell.
--  | ``Cell 1``: Is a soma and a single dendrite, with ``passive`` dynamics everywhere.
-     It has a single synapse at the end of the dendrite and a gap junction site in the
-     middle of the soma. This is the **description** of the cell.
-     It's also a cable cell, which is its **cell kind**. It has 0 **spike sources**, 1
-     **spike target** (the synapse) and 1 **gap junction site**.
--  | ``Cell 2``: Is a soma and a single dendrite, with ``passive`` dynamics everywhere.
-     It has a gap junction site in the middle of the soma. This is the **description**
-     of the cell. It's also a cable cell, which is its **cell kind**. It has 0
-     **spike sources**, 0 **spike targets** and 1 **gap junction site**.
+- ``Cell 0``: Is a single soma, with ``hh`` (Hodgkin-huxley) dynamics. In the middle
+  of the soma, a spike detector is attached, it generates a spiking event when the
+  voltage goes above 10 mV. In the same spot on the soma, a current clamp is also
+  attached, with the intention of triggering some spikes. All of the preceding info:
+  the morphology, dynamics, spike detector and current clamp are what is referred to in
+  Arbor as the **description** of the cell.
+  ``Cell 0`` should be modelled as a :ref:`cable cell<modelcablecell>`,
+  (because cable cells allow complex dynamics such as ``hh``). This is referred to as
+  the **kind** of the cell.
+  It's quite expensive to build cable cells, so we don't want to do this too often.
+  But when the simulation is first set up, it needs to know how cells interact with
+  one another in order to distribute the simulation over the available computational
+  resources. This is why the number of **targets**, **sources** and **gap junction sites**
+  is needed separately from the cell description: with them, the simulation can tell
+  that ``cell 0`` has 1 **spike source** (the detector), 0 **spike targets**, and 0
+  **gap junction sites**, without having to build the cell.
+- ``Cell 1``: Is a soma and a single dendrite, with ``passive`` dynamics everywhere.
+  It has a single synapse at the end of the dendrite and a gap junction site in the
+  middle of the soma. This is the **description** of the cell.
+  It's also a cable cell, which is its **cell kind**. It has 0 **spike sources**, 1
+  **spike target** (the synapse) and 1 **gap junction site**.
+- ``Cell 2``: Is a soma and a single dendrite, with ``passive`` dynamics everywhere.
+  It has a gap junction site in the middle of the soma. This is the **description**
+  of the cell. It's also a cable cell, which is its **cell kind**. It has 0
+  **spike sources**, 0 **spike targets** and 1 **gap junction site**.
 
 The total **number of cells** in the model is 3. The **kind**, **description** and
 number of **spike sources**, **spike targets** and **gap junction sites** on each cell
@@ -89,10 +89,10 @@ Why recipes?
 
 The interface and design of Arbor recipes was motivated by the following aims:
 
-    * Building a simulation from a recipe description must be possible in a
-      distributed system efficiently with minimal communication.
-    * Minimising the amount of memory used in model building, making it
-      possible to build and run simulations in one run.
+* Building a simulation from a recipe description must be possible in a
+  distributed system efficiently with minimal communication.
+* Minimising the amount of memory used in model building, making it
+  possible to build and run simulations in one run.
 
 Recipe descriptions are cell-oriented, in order that the building phase can
 be efficiently distributed and that the model can be built independently of any
@@ -153,8 +153,8 @@ General best practices
     information only when requested.
     This has multiple benefits, including:
 
-        * thread safety;
-        * minimising the memory footprint of the recipe.
+    * thread safety;
+    * minimising the memory footprint of the recipe.
 
 .. topic:: Be reproducible
 

--- a/doc/concepts/simulation.rst
+++ b/doc/concepts/simulation.rst
@@ -11,21 +11,21 @@ From recipe to simulation
 
 To build a simulation the following are needed:
 
-    * A :ref:`recipe <modelrecipe>` that describes the cells and connections in the model.
-    * A :ref:`domain decomposition <modeldomdec>` that describes the distribution of the
-      model over the local and distributed :ref:`hardware resources <modelhardware>`.
-    * An :ref:`execution context <modelcontext>` used to execute the simulation.
+* A :ref:`recipe <modelrecipe>` that describes the cells and connections in the model.
+* A :ref:`domain decomposition <modeldomdec>` that describes the distribution of the
+  model over the local and distributed :ref:`hardware resources <modelhardware>`.
+* An :ref:`execution context <modelcontext>` used to execute the simulation.
 
 Simulation execution and interaction
 ------------------------------------
 
 Simulations provide an interface for executing and interacting with the model:
 
-    * The simulation is executed/*run* by advancing the model state from the current simulation time to another
-      with maximum time step size.
-    * The model state can be *reset* to its initial state before the simulation was started.
-    * *Sampling* of the simulation state can be performed during execution with samplers and probes
-      and spike output with the total number of spikes generated since either construction or reset.
+* The simulation is executed/*run* by advancing the model state from the current simulation time to another
+  with maximum time step size.
+* The model state can be *reset* to its initial state before the simulation was started.
+* *Sampling* of the simulation state can be performed during execution with samplers and probes
+  and spike output with the total number of spikes generated since either construction or reset.
 
 API
 ---

--- a/doc/fileformat/asc.rst
+++ b/doc/fileformat/asc.rst
@@ -1,7 +1,7 @@
 .. _formatasc:
 
-Neurlucida ASCII format
-~~~~~~~~~~~~~~~~~~~~~~~
+Neurolucida ASCII
+~~~~~~~~~~~~~~~~~
 
 Arbor has support for reading cable cell morphologies described using the
 `Neurlucida ASCII file format <https://www.mbfbioscience.com/help/pdf/NL9.pdf>`_

--- a/doc/fileformat/asc.rst
+++ b/doc/fileformat/asc.rst
@@ -3,9 +3,13 @@
 Neurolucida ASCII
 ~~~~~~~~~~~~~~~~~
 
+.. csv-table::
+   :header: "Name", "File extension", "Read", "Write"
+
+   "Neurolucida", "``asc``", "✓", "✗"
+
 Arbor has support for reading cable cell morphologies described using the
-`Neurlucida ASCII file format <https://www.mbfbioscience.com/help/pdf/NL9.pdf>`_
-or ``.asc`` file format.
+`Neurolucida ASCII file format <https://www.mbfbioscience.com/help/pdf/NL9.pdf>`_.
 
 Because ASCII files contain both a morphology description and meta data, the
 loader returns both a morphology, and a label dictionary that describes regions

--- a/doc/fileformat/cable_cell.rst
+++ b/doc/fileformat/cable_cell.rst
@@ -1,7 +1,7 @@
 .. _formatcablecell:
 
-Arbor Cable Cell format (ACC)
-=============================
+Arbor Cable Cell
+================
 
 We define an s-expression format for describing :ref:`cable cells <cablecell>`.
 Cable cells are constructed from three components: a :ref:`label dictionary <labels>`,

--- a/doc/fileformat/cable_cell.rst
+++ b/doc/fileformat/cable_cell.rst
@@ -3,6 +3,11 @@
 Arbor Cable Cell
 ================
 
+.. csv-table::
+   :header: "Name", "File extension", "Read", "Write"
+
+   "Arbor Cable Cell", "``acc``", "✓", "✓"
+
 We define an s-expression format for describing :ref:`cable cells <cablecell>`.
 Cable cells are constructed from three components: a :ref:`label dictionary <labels>`,
 a :ref:`decoration object <cablecell-decoration>` and a :ref:`morphology <morph>`.

--- a/doc/fileformat/index.rst
+++ b/doc/fileformat/index.rst
@@ -1,0 +1,22 @@
+.. _format-overview:
+
+File formats
+============
+
+.. csv-table::
+   :header: "Name", "File extension", "Read", "Write"
+
+   "Arbor Cable Cell", "``acc``", "✓", "✓"
+   "SWC", "``swc``", "✓", "✗"
+   "NMODL", "``mod``", "✓", "✗"
+   "NeuroML2", "``nml``", "✓", "✗"
+   "Neurolucida", "``asc``", "✓", "✗"
+
+.. toctree::
+   :maxdepth: 2
+
+   cable_cell
+   asc
+   neuroml
+   nmodl
+   swc

--- a/doc/fileformat/neuroml.rst
+++ b/doc/fileformat/neuroml.rst
@@ -3,6 +3,11 @@
 NeuroML2
 --------
 
+.. csv-table::
+   :header: "Name", "File extension", "Read", "Write"
+
+   "NeuroML2", "``nml``", "✓", "✗"
+
 Arbor offers limited support for models described in `NeuroML version 2 <https://neuroml.org/neuromlv2>`_.
 This is not built by default (see :ref:`NeuroML support <install-neuroml>` for instructions on how
 to build Arbor with NeuroML).

--- a/doc/fileformat/nmodl.rst
+++ b/doc/fileformat/nmodl.rst
@@ -1,7 +1,12 @@
 .. _formatnmodl:
 
 NMODL
-======
+=====
+
+.. csv-table::
+   :header: "Name", "File extension", "Read", "Write"
+
+   "NMODL", "``mod``", "✓", "✗"
 
 *NMODL* is a `DSL <https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/mechanisms/nmodl.html>`_
 for describing ion channel and synapse dynamics that is used by NEURON,

--- a/doc/fileformat/swc.rst
+++ b/doc/fileformat/swc.rst
@@ -3,6 +3,11 @@
 SWC
 ~~~
 
+.. csv-table::
+   :header: "Name", "File extension", "Read", "Write"
+
+   "SWC", "``swc``", "✓", "✗"
+
 Arbor supports reading morphologies described using the
 `SWC <http://www.neuronland.org/NLMorphologyConverter/MorphologyFormats/SWC/Spec.html>`_ file format.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -162,3 +162,6 @@ A full list of our software attributions can be found `here <https://github.com/
    contrib/doc
    contrib/example
    contrib/test
+
+.. meta::
+   :google-site-verification: KbkW8d9MLsBFZz8Ry0tfcQRkHsgxzkECCahcyRSjWDo

--- a/doc/python/domdec.rst
+++ b/doc/python/domdec.rst
@@ -163,18 +163,18 @@ Therefore, the following data structures are used to describe domain decompositi
 
     Return the indexes of a set of cells of the same kind that are grouped together in a cell group in an :class:`arbor.simulation`.
 
-        .. function:: group_description(kind, gids, backend)
+    .. function:: group_description(kind, gids, backend)
 
-            Construct a group description with parameters :attr:`kind`, :attr:`gids` and :attr:`backend`.
+        Construct a group description with parameters :attr:`kind`, :attr:`gids` and :attr:`backend`.
 
-        .. attribute:: kind
+    .. attribute:: kind
 
-            The kind of cell in the group.
+        The kind of cell in the group.
 
-        .. attribute:: gids
+    .. attribute:: gids
 
-            The list of gids of the cells in the cell group.
+        The list of gids of the cells in the cell group.
 
-        .. attribute:: backend
+    .. attribute:: backend
 
-            The hardware :class:`backend` on which the cell group will run.
+        The hardware :class:`backend` on which the cell group will run.

--- a/doc/python/hardware.rst
+++ b/doc/python/hardware.rst
@@ -19,10 +19,10 @@ Helper functions for checking cmake or environment variables, as well as configu
 
     Returns a dictionary to check which options the Arbor library was configured with at compile time:
 
-      * ``ARB_MPI_ENABLED``
-      * ``ARB_WITH_MPI4PY``
-      * ``ARB_GPU_ENABLED``
-      * ``ARB_VERSION``
+    * ``ARB_MPI_ENABLED``
+    * ``ARB_WITH_MPI4PY``
+    * ``ARB_GPU_ENABLED``
+    * ``ARB_VERSION``
 
     .. container:: example-code
 

--- a/doc/python/simulation.rst
+++ b/doc/python/simulation.rst
@@ -8,8 +8,8 @@ From recipe to simulation
 
 To build a simulation the following concepts are needed:
 
-    * an :py:class:`arbor.recipe` that describes the cells and connections in the model;
-    * an :py:class:`arbor.context` used to execute the simulation.
+* an :py:class:`arbor.recipe` that describes the cells and connections in the model;
+* an :py:class:`arbor.context` used to execute the simulation.
 
 The workflow to build a simulation is to first generate an
 :class:`arbor.domain_decomposition` based on the :py:class:`arbor.recipe` and :py:class:`arbor.context` describing the distribution of the model
@@ -50,16 +50,16 @@ over the local and distributed hardware resources (see :ref:`pydomdec`). Then, t
 
     The **constructor** takes
 
-        * an :py:class:`arbor.recipe` that describes the model;
-        * an :py:class:`arbor.domain_decomposition` that describes how the cells in the model are assigned to hardware resources;
-        * an :py:class:`arbor.context` which is used to execute the simulation.
+    * an :py:class:`arbor.recipe` that describes the model;
+    * an :py:class:`arbor.domain_decomposition` that describes how the cells in the model are assigned to hardware resources;
+    * an :py:class:`arbor.context` which is used to execute the simulation.
 
     Simulations provide an interface for executing and interacting with the model:
 
-        * Specify what data (spikes, probe results) to record.
-        * **Advance the model state** by running the simulation up to some time point.
-        * Retrieve recorded data.
-        * Reset simulator state back to initial conditions.
+    * Specify what data (spikes, probe results) to record.
+    * **Advance the model state** by running the simulation up to some time point.
+    * Retrieve recorded data.
+    * Reset simulator state back to initial conditions.
 
     **Constructor:**
 
@@ -286,60 +286,61 @@ Definitions
 Procedure
 *********
 
-    There are three parts to the process of recording cell data over a simulation.
+There are three parts to the process of recording cell data over a simulation.
 
-    1. Describing what to measure.
+1. Describing what to measure.
 
-       The recipe object must provide a method :py:func:`recipe.get_probes` that returns a list of
-       probe addresses for the cell with a given ``gid``. The kth element of the list corresponds
-       to the :term:`probe id` ``(gid, k)``.
+   The recipe object must provide a method :py:func:`recipe.get_probes` that returns a list of
+   probe addresses for the cell with a given ``gid``. The kth element of the list corresponds
+   to the :term:`probe id` ``(gid, k)``.
 
-       Each probe address is an opaque object describing what to measure and where, and each cell kind
-       will have its own set of functions for generating valid address specifications. Possible cable
-       cell probes are described in the cable cell documentation: :ref:`pycablecell-probesample`.
+   Each probe address is an opaque object describing what to measure and where, and each cell kind
+   will have its own set of functions for generating valid address specifications. Possible cable
+   cell probes are described in the cable cell documentation: :ref:`pycablecell-probesample`.
 
-    2. Instructing the simulator to record data.
+2. Instructing the simulator to record data.
 
-       Recording is set up with the method :py:func:`simulation.sample`
-       as described above. It returns a handle that is used to retrieve the recorded data after
-       simulation.
+   Recording is set up with the method :py:func:`simulation.sample`
+   as described above. It returns a handle that is used to retrieve the recorded data after
+   simulation.
 
-    3. Retrieve recorded data.
+3. Retrieve recorded data.
 
-       The method :py:func:`simulation.samples` takes a handle and returns the recorded data as a list,
-       with one entry for each probe associated with the :term:`probe id` that was used in step 2 above. Each
-       entry will be a tuple ``(data, meta)`` where ``meta`` is the metadata associated with the
-       probe, and ``data`` contains all the data sampled on that probe over the course of the
-       simulation.
+   The method :py:func:`simulation.samples` takes a handle and returns the recorded data as a list,
+   with one entry for each probe associated with the :term:`probe id` that was used in step 2 above. Each
+   entry will be a tuple ``(data, meta)`` where ``meta`` is the metadata associated with the
+   probe, and ``data`` contains all the data sampled on that probe over the course of the
+   simulation.
 
-       The contents of ``data`` will depend upon the specifics of the probe, but note:
+   The contents of ``data`` will depend upon the specifics of the probe, but note:
 
-       i. The object type and structure of ``data`` is fully determined by the metadata.
+   i. The object type and structure of ``data`` is fully determined by the metadata.
 
-       ii. All currently implemented probes return data that is a NumPy array, with one
-           row per sample, first column being sample time, and the remaining columns containing
-           the corresponding data.
+   ii. All currently implemented probes return data that is a NumPy array, with one
+       row per sample, first column being sample time, and the remaining columns containing
+       the corresponding data.
 
-.. container:: example-code
+Example
+*******
 
-    .. code-block:: python
+.. code-block:: python
 
-        import arbor
+    import arbor
 
-        # [... define recipe, decomposition, context ... ]
-        # Initialize simulation:
+    # [... define recipe, decomposition, context ... ]
+    # Initialize simulation:
 
-        sim = arbor.simulation(recipe, decomp, context)
+    sim = arbor.simulation(recipe, decomp, context)
 
-        # Sample probe id (0, 0) (first probe id on cell 0) every 0.1 ms with exact sample timing:
+    # Sample probe id (0, 0) (first probe id on cell 0) every 0.1 ms with exact sample timing:
 
-        handle = sim.sample((0, 0), arbor.regular_schedule(0.1), arbor.sampling_policy.exact)
+    handle = sim.sample((0, 0), arbor.regular_schedule(0.1), arbor.sampling_policy.exact)
 
-        # Run simulation and retrieve sample data from the first probe associated with the handle.
+    # Run simulation and retrieve sample data from the first probe associated with the handle.
 
-        sim.run(tfinal=3, dt=0.1)
-        data, meta = sim.samples(handle)[0]
-        print(data)
+    sim.run(tfinal=3, dt=0.1)
+    data, meta = sim.samples(handle)[0]
+    print(data)
 
 >>> [[  0.         -50.        ]
 >>>  [  0.1        -55.14412111]

--- a/doc/python/single_cell_model.rst
+++ b/doc/python/single_cell_model.rst
@@ -14,39 +14,39 @@ Single cell model
    cable cells.
    The simulation can not be distributed over several machines.
 
-    .. method:: single_cell_model(cable_cell)
+   .. method:: single_cell_model(cable_cell)
 
-       Construct a :class:`single_cell_model` from a :class:`cable_cell`
+      Construct a :class:`single_cell_model` from a :class:`cable_cell`
 
-    .. method:: run(tfinal, dt)
+   .. method:: run(tfinal, dt)
 
-       Run the model from time t= ``0`` to t= ``tflinal`` with a dt= ``dt``.
+      Run the model from time t= ``0`` to t= ``tflinal`` with a dt= ``dt``.
 
-    .. method:: probe(what, where, frequency)
+   .. method:: probe(what, where, frequency)
 
-       Sample a variable on the cell:
+      Sample a variable on the cell:
 
-       :param what: Name of the variable to record (currently only 'voltage').
-       :param where: :class:`location` at which to sample the variable.
-       :param frequency: The frequency at which to sample [kHz].
+      :param what: Name of the variable to record (currently only 'voltage').
+      :param where: :class:`location` at which to sample the variable.
+      :param frequency: The frequency at which to sample [kHz].
 
-    .. method:: spikes()
+   .. method:: spikes()
 
-       Returns a list spike times [ms] after a call to :class:`single_cell_model.run`.
+      Returns a list spike times [ms] after a call to :class:`single_cell_model.run`.
 
-    .. method:: traces()
+   .. method:: traces()
 
-       Returns a list of :class:`trace` after a call to  :class:`single_cell_model.run`.
-       Each element in the list holds the trace of one of the probes added via
-       :class:`single_cell_model.probe`.
+      Returns a list of :class:`trace` after a call to  :class:`single_cell_model.run`.
+      Each element in the list holds the trace of one of the probes added via
+      :class:`single_cell_model.probe`.
 
-    .. attribute:: properties
+   .. attribute:: properties
 
-       The :class:`cable_global_properties` of the model.
+      The :class:`cable_global_properties` of the model.
 
-    .. attribute:: catalogue
+   .. attribute:: catalogue
 
-       The :class:`mechanism_catalogue` of the model.
+      The :class:`mechanism_catalogue` of the model.
 
 .. py:class:: trace
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=2.4.0
 svgwrite
+docutils >= 0.17

--- a/doc/scripts/divio_docs_theme/static/css/divio.css
+++ b/doc/scripts/divio_docs_theme/static/css/divio.css
@@ -250,13 +250,13 @@ big, small {
     max-width: 100% !important; }
   @page {
     margin: 0.5cm; }
-  p, h2, .rst-content .toctree-wrapper p.caption, h3 {
+  p, h2, .rst-content .toctree-wrapper caption, h3 {
     orphans: 3;
     widows: 3; }
-  h2, .rst-content .toctree-wrapper p.caption, h3 {
+  h2, .rst-content .toctree-wrapper caption, h3 {
     page-break-after: avoid; } }
 
-.fa:before, .wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li.on a span.toctree-expand:before, .wy-menu-vertical li.current > a span.toctree-expand:before, .rst-content .admonition-title:before, .rst-content h1 .headerlink:before, .rst-content h2 .headerlink:before, .rst-content h3 .headerlink:before, .rst-content h4 .headerlink:before, .rst-content h5 .headerlink:before, .rst-content h6 .headerlink:before, .rst-content dl dt .headerlink:before, .rst-content p.caption .headerlink:before, .rst-content tt.download span:first-child:before, .rst-content code.download span:first-child:before, .icon:before, .wy-dropdown .caret:before, .wy-inline-validate.wy-inline-validate-success .wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .wy-input-context:before, .wy-alert, .rst-content .note, .rst-content .attention, .rst-content .caution, .rst-content .danger, .rst-content .error, .rst-content .hint, .rst-content .important, .rst-content .tip, .rst-content .warning, .rst-content .seealso, .rst-content .admonition-todo, .rst-content .admonition, .btn, input[type="text"], input[type="password"], input[type="email"], input[type="url"], input[type="date"], input[type="month"], input[type="time"], input[type="datetime"], input[type="datetime-local"], input[type="week"], input[type="number"], input[type="search"], input[type="tel"], input[type="color"], select, textarea, .wy-menu-vertical li.on a, .wy-menu-vertical li.current > a, .wy-side-nav-search > a, .wy-side-nav-search .wy-dropdown > a, .wy-nav-top a {
+.fa:before, .wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li.on a span.toctree-expand:before, .wy-menu-vertical li.current > a span.toctree-expand:before, .rst-content .admonition-title:before, .rst-content h1 .headerlink:before, .rst-content h2 .headerlink:before, .rst-content h3 .headerlink:before, .rst-content h4 .headerlink:before, .rst-content h5 .headerlink:before, .rst-content h6 .headerlink:before, .rst-content dl dt .headerlink:before, .rst-content caption .headerlink:before, .rst-content tt.download span:first-child:before, .rst-content code.download span:first-child:before, .icon:before, .wy-dropdown .caret:before, .wy-inline-validate.wy-inline-validate-success .wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .wy-input-context:before, .wy-alert, .rst-content .note, .rst-content .attention, .rst-content .caution, .rst-content .danger, .rst-content .error, .rst-content .hint, .rst-content .important, .rst-content .tip, .rst-content .warning, .rst-content .seealso, .rst-content .admonition-todo, .rst-content .admonition, .btn, input[type="text"], input[type="password"], input[type="email"], input[type="url"], input[type="date"], input[type="month"], input[type="time"], input[type="datetime"], input[type="datetime-local"], input[type="week"], input[type="number"], input[type="search"], input[type="tel"], input[type="color"], select, textarea, .wy-menu-vertical li.on a, .wy-menu-vertical li.current > a, .wy-side-nav-search > a, .wy-side-nav-search .wy-dropdown > a, .wy-nav-top a {
   -webkit-font-smoothing: antialiased; }
 
 .clearfix {
@@ -281,7 +281,7 @@ big, small {
   font-weight: normal;
   font-style: normal; }
 
-.fa, .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand, .rst-content .admonition-title, .rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content p.caption .headerlink, .rst-content tt.download span:first-child, .rst-content code.download span:first-child, .icon {
+.fa, .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand, .rst-content .admonition-title, .rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content caption .headerlink, .rst-content tt.download span:first-child, .rst-content code.download span:first-child, .icon {
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome;
   font-size: inherit;
@@ -340,10 +340,10 @@ big, small {
 .fa-pull-right {
   float: right; }
 
-.fa.fa-pull-left, .wy-menu-vertical li span.fa-pull-left.toctree-expand, .wy-menu-vertical li.on a span.fa-pull-left.toctree-expand, .wy-menu-vertical li.current > a span.fa-pull-left.toctree-expand, .rst-content .fa-pull-left.admonition-title, .rst-content h1 .fa-pull-left.headerlink, .rst-content h2 .fa-pull-left.headerlink, .rst-content h3 .fa-pull-left.headerlink, .rst-content h4 .fa-pull-left.headerlink, .rst-content h5 .fa-pull-left.headerlink, .rst-content h6 .fa-pull-left.headerlink, .rst-content dl dt .fa-pull-left.headerlink, .rst-content p.caption .fa-pull-left.headerlink, .rst-content tt.download span.fa-pull-left:first-child, .rst-content code.download span.fa-pull-left:first-child, .fa-pull-left.icon {
+.fa.fa-pull-left, .wy-menu-vertical li span.fa-pull-left.toctree-expand, .wy-menu-vertical li.on a span.fa-pull-left.toctree-expand, .wy-menu-vertical li.current > a span.fa-pull-left.toctree-expand, .rst-content .fa-pull-left.admonition-title, .rst-content h1 .fa-pull-left.headerlink, .rst-content h2 .fa-pull-left.headerlink, .rst-content h3 .fa-pull-left.headerlink, .rst-content h4 .fa-pull-left.headerlink, .rst-content h5 .fa-pull-left.headerlink, .rst-content h6 .fa-pull-left.headerlink, .rst-content dl dt .fa-pull-left.headerlink, .rst-content caption .fa-pull-left.headerlink, .rst-content tt.download span.fa-pull-left:first-child, .rst-content code.download span.fa-pull-left:first-child, .fa-pull-left.icon {
   margin-right: .3em; }
 
-.fa.fa-pull-right, .wy-menu-vertical li span.fa-pull-right.toctree-expand, .wy-menu-vertical li.on a span.fa-pull-right.toctree-expand, .wy-menu-vertical li.current > a span.fa-pull-right.toctree-expand, .rst-content .fa-pull-right.admonition-title, .rst-content h1 .fa-pull-right.headerlink, .rst-content h2 .fa-pull-right.headerlink, .rst-content h3 .fa-pull-right.headerlink, .rst-content h4 .fa-pull-right.headerlink, .rst-content h5 .fa-pull-right.headerlink, .rst-content h6 .fa-pull-right.headerlink, .rst-content dl dt .fa-pull-right.headerlink, .rst-content p.caption .fa-pull-right.headerlink, .rst-content tt.download span.fa-pull-right:first-child, .rst-content code.download span.fa-pull-right:first-child, .fa-pull-right.icon {
+.fa.fa-pull-right, .wy-menu-vertical li span.fa-pull-right.toctree-expand, .wy-menu-vertical li.on a span.fa-pull-right.toctree-expand, .wy-menu-vertical li.current > a span.fa-pull-right.toctree-expand, .rst-content .fa-pull-right.admonition-title, .rst-content h1 .fa-pull-right.headerlink, .rst-content h2 .fa-pull-right.headerlink, .rst-content h3 .fa-pull-right.headerlink, .rst-content h4 .fa-pull-right.headerlink, .rst-content h5 .fa-pull-right.headerlink, .rst-content h6 .fa-pull-right.headerlink, .rst-content dl dt .fa-pull-right.headerlink, .rst-content caption .fa-pull-right.headerlink, .rst-content tt.download span.fa-pull-right:first-child, .rst-content code.download span.fa-pull-right:first-child, .fa-pull-right.icon {
   margin-left: .3em; }
 
 /* Deprecated as of 4.4.0 */
@@ -353,10 +353,10 @@ big, small {
 .pull-left {
   float: left; }
 
-.fa.pull-left, .wy-menu-vertical li span.pull-left.toctree-expand, .wy-menu-vertical li.on a span.pull-left.toctree-expand, .wy-menu-vertical li.current > a span.pull-left.toctree-expand, .rst-content .pull-left.admonition-title, .rst-content h1 .pull-left.headerlink, .rst-content h2 .pull-left.headerlink, .rst-content h3 .pull-left.headerlink, .rst-content h4 .pull-left.headerlink, .rst-content h5 .pull-left.headerlink, .rst-content h6 .pull-left.headerlink, .rst-content dl dt .pull-left.headerlink, .rst-content p.caption .pull-left.headerlink, .rst-content tt.download span.pull-left:first-child, .rst-content code.download span.pull-left:first-child, .pull-left.icon {
+.fa.pull-left, .wy-menu-vertical li span.pull-left.toctree-expand, .wy-menu-vertical li.on a span.pull-left.toctree-expand, .wy-menu-vertical li.current > a span.pull-left.toctree-expand, .rst-content .pull-left.admonition-title, .rst-content h1 .pull-left.headerlink, .rst-content h2 .pull-left.headerlink, .rst-content h3 .pull-left.headerlink, .rst-content h4 .pull-left.headerlink, .rst-content h5 .pull-left.headerlink, .rst-content h6 .pull-left.headerlink, .rst-content dl dt .pull-left.headerlink, .rst-content caption .pull-left.headerlink, .rst-content tt.download span.pull-left:first-child, .rst-content code.download span.pull-left:first-child, .pull-left.icon {
   margin-right: .3em; }
 
-.fa.pull-right, .wy-menu-vertical li span.pull-right.toctree-expand, .wy-menu-vertical li.on a span.pull-right.toctree-expand, .wy-menu-vertical li.current > a span.pull-right.toctree-expand, .rst-content .pull-right.admonition-title, .rst-content h1 .pull-right.headerlink, .rst-content h2 .pull-right.headerlink, .rst-content h3 .pull-right.headerlink, .rst-content h4 .pull-right.headerlink, .rst-content h5 .pull-right.headerlink, .rst-content h6 .pull-right.headerlink, .rst-content dl dt .pull-right.headerlink, .rst-content p.caption .pull-right.headerlink, .rst-content tt.download span.pull-right:first-child, .rst-content code.download span.pull-right:first-child, .pull-right.icon {
+.fa.pull-right, .wy-menu-vertical li span.pull-right.toctree-expand, .wy-menu-vertical li.on a span.pull-right.toctree-expand, .wy-menu-vertical li.current > a span.pull-right.toctree-expand, .rst-content .pull-right.admonition-title, .rst-content h1 .pull-right.headerlink, .rst-content h2 .pull-right.headerlink, .rst-content h3 .pull-right.headerlink, .rst-content h4 .pull-right.headerlink, .rst-content h5 .pull-right.headerlink, .rst-content h6 .pull-right.headerlink, .rst-content dl dt .pull-right.headerlink, .rst-content caption .pull-right.headerlink, .rst-content tt.download span.pull-right:first-child, .rst-content code.download span.pull-right:first-child, .pull-right.icon {
   margin-left: .3em; }
 
 .fa-spin {
@@ -2603,10 +2603,10 @@ big, small {
   overflow: visible;
   clip: auto; }
 
-.fa, .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand, .rst-content .admonition-title, .rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content p.caption .headerlink, .rst-content tt.download span:first-child, .rst-content code.download span:first-child, .icon, .wy-dropdown .caret, .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-info .wy-input-context {
+.fa, .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand, .rst-content .admonition-title, .rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content caption .headerlink, .rst-content tt.download span:first-child, .rst-content code.download span:first-child, .icon, .wy-dropdown .caret, .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-info .wy-input-context {
   font-family: inherit; }
 
-.fa:before, .wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li.on a span.toctree-expand:before, .wy-menu-vertical li.current > a span.toctree-expand:before, .rst-content .admonition-title:before, .rst-content h1 .headerlink:before, .rst-content h2 .headerlink:before, .rst-content h3 .headerlink:before, .rst-content h4 .headerlink:before, .rst-content h5 .headerlink:before, .rst-content h6 .headerlink:before, .rst-content dl dt .headerlink:before, .rst-content p.caption .headerlink:before, .rst-content tt.download span:first-child:before, .rst-content code.download span:first-child:before, .icon:before, .wy-dropdown .caret:before, .wy-inline-validate.wy-inline-validate-success .wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .wy-input-context:before {
+.fa:before, .wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li.on a span.toctree-expand:before, .wy-menu-vertical li.current > a span.toctree-expand:before, .rst-content .admonition-title:before, .rst-content h1 .headerlink:before, .rst-content h2 .headerlink:before, .rst-content h3 .headerlink:before, .rst-content h4 .headerlink:before, .rst-content h5 .headerlink:before, .rst-content h6 .headerlink:before, .rst-content dl dt .headerlink:before, .rst-content caption .headerlink:before, .rst-content tt.download span:first-child:before, .rst-content code.download span:first-child:before, .icon:before, .wy-dropdown .caret:before, .wy-inline-validate.wy-inline-validate-success .wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .wy-input-context:before {
   font-family: "FontAwesome";
   display: inline-block;
   font-style: normal;
@@ -2614,29 +2614,29 @@ big, small {
   line-height: 1;
   text-decoration: inherit; }
 
-a .fa, a .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li a span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand, a .rst-content .admonition-title, .rst-content a .admonition-title, a .rst-content h1 .headerlink, .rst-content h1 a .headerlink, a .rst-content h2 .headerlink, .rst-content h2 a .headerlink, a .rst-content h3 .headerlink, .rst-content h3 a .headerlink, a .rst-content h4 .headerlink, .rst-content h4 a .headerlink, a .rst-content h5 .headerlink, .rst-content h5 a .headerlink, a .rst-content h6 .headerlink, .rst-content h6 a .headerlink, a .rst-content dl dt .headerlink, .rst-content dl dt a .headerlink, a .rst-content p.caption .headerlink, .rst-content p.caption a .headerlink, a .rst-content tt.download span:first-child, .rst-content tt.download a span:first-child, a .rst-content code.download span:first-child, .rst-content code.download a span:first-child, a .icon {
+a .fa, a .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li a span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand, a .rst-content .admonition-title, .rst-content a .admonition-title, a .rst-content h1 .headerlink, .rst-content h1 a .headerlink, a .rst-content h2 .headerlink, .rst-content h2 a .headerlink, a .rst-content h3 .headerlink, .rst-content h3 a .headerlink, a .rst-content h4 .headerlink, .rst-content h4 a .headerlink, a .rst-content h5 .headerlink, .rst-content h5 a .headerlink, a .rst-content h6 .headerlink, .rst-content h6 a .headerlink, a .rst-content dl dt .headerlink, .rst-content dl dt a .headerlink, a .rst-content caption .headerlink, .rst-content caption a .headerlink, a .rst-content tt.download span:first-child, .rst-content tt.download a span:first-child, a .rst-content code.download span:first-child, .rst-content code.download a span:first-child, a .icon {
   display: inline-block;
   text-decoration: inherit; }
 
-.btn .fa, .btn .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li .btn span.toctree-expand, .btn .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.on a .btn span.toctree-expand, .btn .wy-menu-vertical li.current > a span.toctree-expand, .wy-menu-vertical li.current > a .btn span.toctree-expand, .btn .rst-content .admonition-title, .rst-content .btn .admonition-title, .btn .rst-content h1 .headerlink, .rst-content h1 .btn .headerlink, .btn .rst-content h2 .headerlink, .rst-content h2 .btn .headerlink, .btn .rst-content h3 .headerlink, .rst-content h3 .btn .headerlink, .btn .rst-content h4 .headerlink, .rst-content h4 .btn .headerlink, .btn .rst-content h5 .headerlink, .rst-content h5 .btn .headerlink, .btn .rst-content h6 .headerlink, .rst-content h6 .btn .headerlink, .btn .rst-content dl dt .headerlink, .rst-content dl dt .btn .headerlink, .btn .rst-content p.caption .headerlink, .rst-content p.caption .btn .headerlink, .btn .rst-content tt.download span:first-child, .rst-content tt.download .btn span:first-child, .btn .rst-content code.download span:first-child, .rst-content code.download .btn span:first-child, .btn .icon, .nav .fa, .nav .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li .nav span.toctree-expand, .nav .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.on a .nav span.toctree-expand, .nav .wy-menu-vertical li.current > a span.toctree-expand, .wy-menu-vertical li.current > a .nav span.toctree-expand, .nav .rst-content .admonition-title, .rst-content .nav .admonition-title, .nav .rst-content h1 .headerlink, .rst-content h1 .nav .headerlink, .nav .rst-content h2 .headerlink, .rst-content h2 .nav .headerlink, .nav .rst-content h3 .headerlink, .rst-content h3 .nav .headerlink, .nav .rst-content h4 .headerlink, .rst-content h4 .nav .headerlink, .nav .rst-content h5 .headerlink, .rst-content h5 .nav .headerlink, .nav .rst-content h6 .headerlink, .rst-content h6 .nav .headerlink, .nav .rst-content dl dt .headerlink, .rst-content dl dt .nav .headerlink, .nav .rst-content p.caption .headerlink, .rst-content p.caption .nav .headerlink, .nav .rst-content tt.download span:first-child, .rst-content tt.download .nav span:first-child, .nav .rst-content code.download span:first-child, .rst-content code.download .nav span:first-child, .nav .icon {
+.btn .fa, .btn .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li .btn span.toctree-expand, .btn .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.on a .btn span.toctree-expand, .btn .wy-menu-vertical li.current > a span.toctree-expand, .wy-menu-vertical li.current > a .btn span.toctree-expand, .btn .rst-content .admonition-title, .rst-content .btn .admonition-title, .btn .rst-content h1 .headerlink, .rst-content h1 .btn .headerlink, .btn .rst-content h2 .headerlink, .rst-content h2 .btn .headerlink, .btn .rst-content h3 .headerlink, .rst-content h3 .btn .headerlink, .btn .rst-content h4 .headerlink, .rst-content h4 .btn .headerlink, .btn .rst-content h5 .headerlink, .rst-content h5 .btn .headerlink, .btn .rst-content h6 .headerlink, .rst-content h6 .btn .headerlink, .btn .rst-content dl dt .headerlink, .rst-content dl dt .btn .headerlink, .btn .rst-content caption .headerlink, .rst-content caption .btn .headerlink, .btn .rst-content tt.download span:first-child, .rst-content tt.download .btn span:first-child, .btn .rst-content code.download span:first-child, .rst-content code.download .btn span:first-child, .btn .icon, .nav .fa, .nav .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li .nav span.toctree-expand, .nav .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.on a .nav span.toctree-expand, .nav .wy-menu-vertical li.current > a span.toctree-expand, .wy-menu-vertical li.current > a .nav span.toctree-expand, .nav .rst-content .admonition-title, .rst-content .nav .admonition-title, .nav .rst-content h1 .headerlink, .rst-content h1 .nav .headerlink, .nav .rst-content h2 .headerlink, .rst-content h2 .nav .headerlink, .nav .rst-content h3 .headerlink, .rst-content h3 .nav .headerlink, .nav .rst-content h4 .headerlink, .rst-content h4 .nav .headerlink, .nav .rst-content h5 .headerlink, .rst-content h5 .nav .headerlink, .nav .rst-content h6 .headerlink, .rst-content h6 .nav .headerlink, .nav .rst-content dl dt .headerlink, .rst-content dl dt .nav .headerlink, .nav .rst-content caption .headerlink, .rst-content caption .nav .headerlink, .nav .rst-content tt.download span:first-child, .rst-content tt.download .nav span:first-child, .nav .rst-content code.download span:first-child, .rst-content code.download .nav span:first-child, .nav .icon {
   display: inline; }
 
-.btn .fa.fa-large, .btn .wy-menu-vertical li span.fa-large.toctree-expand, .wy-menu-vertical li .btn span.fa-large.toctree-expand, .btn .rst-content .fa-large.admonition-title, .rst-content .btn .fa-large.admonition-title, .btn .rst-content h1 .fa-large.headerlink, .rst-content h1 .btn .fa-large.headerlink, .btn .rst-content h2 .fa-large.headerlink, .rst-content h2 .btn .fa-large.headerlink, .btn .rst-content h3 .fa-large.headerlink, .rst-content h3 .btn .fa-large.headerlink, .btn .rst-content h4 .fa-large.headerlink, .rst-content h4 .btn .fa-large.headerlink, .btn .rst-content h5 .fa-large.headerlink, .rst-content h5 .btn .fa-large.headerlink, .btn .rst-content h6 .fa-large.headerlink, .rst-content h6 .btn .fa-large.headerlink, .btn .rst-content dl dt .fa-large.headerlink, .rst-content dl dt .btn .fa-large.headerlink, .btn .rst-content p.caption .fa-large.headerlink, .rst-content p.caption .btn .fa-large.headerlink, .btn .rst-content tt.download span.fa-large:first-child, .rst-content tt.download .btn span.fa-large:first-child, .btn .rst-content code.download span.fa-large:first-child, .rst-content code.download .btn span.fa-large:first-child, .btn .fa-large.icon, .nav .fa.fa-large, .nav .wy-menu-vertical li span.fa-large.toctree-expand, .wy-menu-vertical li .nav span.fa-large.toctree-expand, .nav .rst-content .fa-large.admonition-title, .rst-content .nav .fa-large.admonition-title, .nav .rst-content h1 .fa-large.headerlink, .rst-content h1 .nav .fa-large.headerlink, .nav .rst-content h2 .fa-large.headerlink, .rst-content h2 .nav .fa-large.headerlink, .nav .rst-content h3 .fa-large.headerlink, .rst-content h3 .nav .fa-large.headerlink, .nav .rst-content h4 .fa-large.headerlink, .rst-content h4 .nav .fa-large.headerlink, .nav .rst-content h5 .fa-large.headerlink, .rst-content h5 .nav .fa-large.headerlink, .nav .rst-content h6 .fa-large.headerlink, .rst-content h6 .nav .fa-large.headerlink, .nav .rst-content dl dt .fa-large.headerlink, .rst-content dl dt .nav .fa-large.headerlink, .nav .rst-content p.caption .fa-large.headerlink, .rst-content p.caption .nav .fa-large.headerlink, .nav .rst-content tt.download span.fa-large:first-child, .rst-content tt.download .nav span.fa-large:first-child, .nav .rst-content code.download span.fa-large:first-child, .rst-content code.download .nav span.fa-large:first-child, .nav .fa-large.icon {
+.btn .fa.fa-large, .btn .wy-menu-vertical li span.fa-large.toctree-expand, .wy-menu-vertical li .btn span.fa-large.toctree-expand, .btn .rst-content .fa-large.admonition-title, .rst-content .btn .fa-large.admonition-title, .btn .rst-content h1 .fa-large.headerlink, .rst-content h1 .btn .fa-large.headerlink, .btn .rst-content h2 .fa-large.headerlink, .rst-content h2 .btn .fa-large.headerlink, .btn .rst-content h3 .fa-large.headerlink, .rst-content h3 .btn .fa-large.headerlink, .btn .rst-content h4 .fa-large.headerlink, .rst-content h4 .btn .fa-large.headerlink, .btn .rst-content h5 .fa-large.headerlink, .rst-content h5 .btn .fa-large.headerlink, .btn .rst-content h6 .fa-large.headerlink, .rst-content h6 .btn .fa-large.headerlink, .btn .rst-content dl dt .fa-large.headerlink, .rst-content dl dt .btn .fa-large.headerlink, .btn .rst-content caption .fa-large.headerlink, .rst-content caption .btn .fa-large.headerlink, .btn .rst-content tt.download span.fa-large:first-child, .rst-content tt.download .btn span.fa-large:first-child, .btn .rst-content code.download span.fa-large:first-child, .rst-content code.download .btn span.fa-large:first-child, .btn .fa-large.icon, .nav .fa.fa-large, .nav .wy-menu-vertical li span.fa-large.toctree-expand, .wy-menu-vertical li .nav span.fa-large.toctree-expand, .nav .rst-content .fa-large.admonition-title, .rst-content .nav .fa-large.admonition-title, .nav .rst-content h1 .fa-large.headerlink, .rst-content h1 .nav .fa-large.headerlink, .nav .rst-content h2 .fa-large.headerlink, .rst-content h2 .nav .fa-large.headerlink, .nav .rst-content h3 .fa-large.headerlink, .rst-content h3 .nav .fa-large.headerlink, .nav .rst-content h4 .fa-large.headerlink, .rst-content h4 .nav .fa-large.headerlink, .nav .rst-content h5 .fa-large.headerlink, .rst-content h5 .nav .fa-large.headerlink, .nav .rst-content h6 .fa-large.headerlink, .rst-content h6 .nav .fa-large.headerlink, .nav .rst-content dl dt .fa-large.headerlink, .rst-content dl dt .nav .fa-large.headerlink, .nav .rst-content caption .fa-large.headerlink, .rst-content caption .nav .fa-large.headerlink, .nav .rst-content tt.download span.fa-large:first-child, .rst-content tt.download .nav span.fa-large:first-child, .nav .rst-content code.download span.fa-large:first-child, .rst-content code.download .nav span.fa-large:first-child, .nav .fa-large.icon {
   line-height: 0.9em; }
 
-.btn .fa.fa-spin, .btn .wy-menu-vertical li span.fa-spin.toctree-expand, .wy-menu-vertical li .btn span.fa-spin.toctree-expand, .btn .rst-content .fa-spin.admonition-title, .rst-content .btn .fa-spin.admonition-title, .btn .rst-content h1 .fa-spin.headerlink, .rst-content h1 .btn .fa-spin.headerlink, .btn .rst-content h2 .fa-spin.headerlink, .rst-content h2 .btn .fa-spin.headerlink, .btn .rst-content h3 .fa-spin.headerlink, .rst-content h3 .btn .fa-spin.headerlink, .btn .rst-content h4 .fa-spin.headerlink, .rst-content h4 .btn .fa-spin.headerlink, .btn .rst-content h5 .fa-spin.headerlink, .rst-content h5 .btn .fa-spin.headerlink, .btn .rst-content h6 .fa-spin.headerlink, .rst-content h6 .btn .fa-spin.headerlink, .btn .rst-content dl dt .fa-spin.headerlink, .rst-content dl dt .btn .fa-spin.headerlink, .btn .rst-content p.caption .fa-spin.headerlink, .rst-content p.caption .btn .fa-spin.headerlink, .btn .rst-content tt.download span.fa-spin:first-child, .rst-content tt.download .btn span.fa-spin:first-child, .btn .rst-content code.download span.fa-spin:first-child, .rst-content code.download .btn span.fa-spin:first-child, .btn .fa-spin.icon, .nav .fa.fa-spin, .nav .wy-menu-vertical li span.fa-spin.toctree-expand, .wy-menu-vertical li .nav span.fa-spin.toctree-expand, .nav .rst-content .fa-spin.admonition-title, .rst-content .nav .fa-spin.admonition-title, .nav .rst-content h1 .fa-spin.headerlink, .rst-content h1 .nav .fa-spin.headerlink, .nav .rst-content h2 .fa-spin.headerlink, .rst-content h2 .nav .fa-spin.headerlink, .nav .rst-content h3 .fa-spin.headerlink, .rst-content h3 .nav .fa-spin.headerlink, .nav .rst-content h4 .fa-spin.headerlink, .rst-content h4 .nav .fa-spin.headerlink, .nav .rst-content h5 .fa-spin.headerlink, .rst-content h5 .nav .fa-spin.headerlink, .nav .rst-content h6 .fa-spin.headerlink, .rst-content h6 .nav .fa-spin.headerlink, .nav .rst-content dl dt .fa-spin.headerlink, .rst-content dl dt .nav .fa-spin.headerlink, .nav .rst-content p.caption .fa-spin.headerlink, .rst-content p.caption .nav .fa-spin.headerlink, .nav .rst-content tt.download span.fa-spin:first-child, .rst-content tt.download .nav span.fa-spin:first-child, .nav .rst-content code.download span.fa-spin:first-child, .rst-content code.download .nav span.fa-spin:first-child, .nav .fa-spin.icon {
+.btn .fa.fa-spin, .btn .wy-menu-vertical li span.fa-spin.toctree-expand, .wy-menu-vertical li .btn span.fa-spin.toctree-expand, .btn .rst-content .fa-spin.admonition-title, .rst-content .btn .fa-spin.admonition-title, .btn .rst-content h1 .fa-spin.headerlink, .rst-content h1 .btn .fa-spin.headerlink, .btn .rst-content h2 .fa-spin.headerlink, .rst-content h2 .btn .fa-spin.headerlink, .btn .rst-content h3 .fa-spin.headerlink, .rst-content h3 .btn .fa-spin.headerlink, .btn .rst-content h4 .fa-spin.headerlink, .rst-content h4 .btn .fa-spin.headerlink, .btn .rst-content h5 .fa-spin.headerlink, .rst-content h5 .btn .fa-spin.headerlink, .btn .rst-content h6 .fa-spin.headerlink, .rst-content h6 .btn .fa-spin.headerlink, .btn .rst-content dl dt .fa-spin.headerlink, .rst-content dl dt .btn .fa-spin.headerlink, .btn .rst-content caption .fa-spin.headerlink, .rst-content caption .btn .fa-spin.headerlink, .btn .rst-content tt.download span.fa-spin:first-child, .rst-content tt.download .btn span.fa-spin:first-child, .btn .rst-content code.download span.fa-spin:first-child, .rst-content code.download .btn span.fa-spin:first-child, .btn .fa-spin.icon, .nav .fa.fa-spin, .nav .wy-menu-vertical li span.fa-spin.toctree-expand, .wy-menu-vertical li .nav span.fa-spin.toctree-expand, .nav .rst-content .fa-spin.admonition-title, .rst-content .nav .fa-spin.admonition-title, .nav .rst-content h1 .fa-spin.headerlink, .rst-content h1 .nav .fa-spin.headerlink, .nav .rst-content h2 .fa-spin.headerlink, .rst-content h2 .nav .fa-spin.headerlink, .nav .rst-content h3 .fa-spin.headerlink, .rst-content h3 .nav .fa-spin.headerlink, .nav .rst-content h4 .fa-spin.headerlink, .rst-content h4 .nav .fa-spin.headerlink, .nav .rst-content h5 .fa-spin.headerlink, .rst-content h5 .nav .fa-spin.headerlink, .nav .rst-content h6 .fa-spin.headerlink, .rst-content h6 .nav .fa-spin.headerlink, .nav .rst-content dl dt .fa-spin.headerlink, .rst-content dl dt .nav .fa-spin.headerlink, .nav .rst-content caption .fa-spin.headerlink, .rst-content caption .nav .fa-spin.headerlink, .nav .rst-content tt.download span.fa-spin:first-child, .rst-content tt.download .nav span.fa-spin:first-child, .nav .rst-content code.download span.fa-spin:first-child, .rst-content code.download .nav span.fa-spin:first-child, .nav .fa-spin.icon {
   display: inline-block; }
 
-.btn.fa:before, .wy-menu-vertical li span.btn.toctree-expand:before, .rst-content .btn.admonition-title:before, .rst-content h1 .btn.headerlink:before, .rst-content h2 .btn.headerlink:before, .rst-content h3 .btn.headerlink:before, .rst-content h4 .btn.headerlink:before, .rst-content h5 .btn.headerlink:before, .rst-content h6 .btn.headerlink:before, .rst-content dl dt .btn.headerlink:before, .rst-content p.caption .btn.headerlink:before, .rst-content tt.download span.btn:first-child:before, .rst-content code.download span.btn:first-child:before, .btn.icon:before {
+.btn.fa:before, .wy-menu-vertical li span.btn.toctree-expand:before, .rst-content .btn.admonition-title:before, .rst-content h1 .btn.headerlink:before, .rst-content h2 .btn.headerlink:before, .rst-content h3 .btn.headerlink:before, .rst-content h4 .btn.headerlink:before, .rst-content h5 .btn.headerlink:before, .rst-content h6 .btn.headerlink:before, .rst-content dl dt .btn.headerlink:before, .rst-content caption .btn.headerlink:before, .rst-content tt.download span.btn:first-child:before, .rst-content code.download span.btn:first-child:before, .btn.icon:before {
   opacity: 0.5;
   -webkit-transition: opacity 0.05s ease-in;
   -moz-transition: opacity 0.05s ease-in;
   transition: opacity 0.05s ease-in; }
 
-.btn.fa:hover:before, .wy-menu-vertical li span.btn.toctree-expand:hover:before, .rst-content .btn.admonition-title:hover:before, .rst-content h1 .btn.headerlink:hover:before, .rst-content h2 .btn.headerlink:hover:before, .rst-content h3 .btn.headerlink:hover:before, .rst-content h4 .btn.headerlink:hover:before, .rst-content h5 .btn.headerlink:hover:before, .rst-content h6 .btn.headerlink:hover:before, .rst-content dl dt .btn.headerlink:hover:before, .rst-content p.caption .btn.headerlink:hover:before, .rst-content tt.download span.btn:first-child:hover:before, .rst-content code.download span.btn:first-child:hover:before, .btn.icon:hover:before {
+.btn.fa:hover:before, .wy-menu-vertical li span.btn.toctree-expand:hover:before, .rst-content .btn.admonition-title:hover:before, .rst-content h1 .btn.headerlink:hover:before, .rst-content h2 .btn.headerlink:hover:before, .rst-content h3 .btn.headerlink:hover:before, .rst-content h4 .btn.headerlink:hover:before, .rst-content h5 .btn.headerlink:hover:before, .rst-content h6 .btn.headerlink:hover:before, .rst-content dl dt .btn.headerlink:hover:before, .rst-content caption .btn.headerlink:hover:before, .rst-content tt.download span.btn:first-child:hover:before, .rst-content code.download span.btn:first-child:hover:before, .btn.icon:hover:before {
   opacity: 1; }
 
-.btn-mini .fa:before, .btn-mini .wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li .btn-mini span.toctree-expand:before, .btn-mini .rst-content .admonition-title:before, .rst-content .btn-mini .admonition-title:before, .btn-mini .rst-content h1 .headerlink:before, .rst-content h1 .btn-mini .headerlink:before, .btn-mini .rst-content h2 .headerlink:before, .rst-content h2 .btn-mini .headerlink:before, .btn-mini .rst-content h3 .headerlink:before, .rst-content h3 .btn-mini .headerlink:before, .btn-mini .rst-content h4 .headerlink:before, .rst-content h4 .btn-mini .headerlink:before, .btn-mini .rst-content h5 .headerlink:before, .rst-content h5 .btn-mini .headerlink:before, .btn-mini .rst-content h6 .headerlink:before, .rst-content h6 .btn-mini .headerlink:before, .btn-mini .rst-content dl dt .headerlink:before, .rst-content dl dt .btn-mini .headerlink:before, .btn-mini .rst-content p.caption .headerlink:before, .rst-content p.caption .btn-mini .headerlink:before, .btn-mini .rst-content tt.download span:first-child:before, .rst-content tt.download .btn-mini span:first-child:before, .btn-mini .rst-content code.download span:first-child:before, .rst-content code.download .btn-mini span:first-child:before, .btn-mini .icon:before {
+.btn-mini .fa:before, .btn-mini .wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li .btn-mini span.toctree-expand:before, .btn-mini .rst-content .admonition-title:before, .rst-content .btn-mini .admonition-title:before, .btn-mini .rst-content h1 .headerlink:before, .rst-content h1 .btn-mini .headerlink:before, .btn-mini .rst-content h2 .headerlink:before, .rst-content h2 .btn-mini .headerlink:before, .btn-mini .rst-content h3 .headerlink:before, .rst-content h3 .btn-mini .headerlink:before, .btn-mini .rst-content h4 .headerlink:before, .rst-content h4 .btn-mini .headerlink:before, .btn-mini .rst-content h5 .headerlink:before, .rst-content h5 .btn-mini .headerlink:before, .btn-mini .rst-content h6 .headerlink:before, .rst-content h6 .btn-mini .headerlink:before, .btn-mini .rst-content dl dt .headerlink:before, .rst-content dl dt .btn-mini .headerlink:before, .btn-mini .rst-content caption .headerlink:before, .rst-content caption .btn-mini .headerlink:before, .btn-mini .rst-content tt.download span:first-child:before, .rst-content tt.download .btn-mini span:first-child:before, .btn-mini .rst-content code.download span:first-child:before, .rst-content code.download .btn-mini span:first-child:before, .btn-mini .icon:before {
   font-size: 14px;
   vertical-align: -15%; }
 
@@ -3666,7 +3666,7 @@ a.wy-text-danger:hover {
 a.wy-text-neutral:hover {
   color: #595959 !important; }
 
-h1, h2, .rst-content .toctree-wrapper p.caption, h3, h4, h5, h6, legend {
+h1, h2, .rst-content .toctree-wrapper caption, h3, h4, h5, h6, legend {
   margin-top: 0;
   font-weight: 700;
   font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", "Noto Sans", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
@@ -3680,7 +3680,7 @@ p {
 h1 {
   font-size: 36px; }
 
-h2, .rst-content .toctree-wrapper p.caption {
+h2, .rst-content .toctree-wrapper caption {
   font-size: 28px; }
 
 h3 {
@@ -3717,46 +3717,46 @@ code, .rst-content tt, .rst-content code {
 code.code-large, .rst-content tt.code-large {
   font-size: 90%; }
 
-.wy-plain-list-disc, .rst-content .section ul, .rst-content .toctree-wrapper ul, article ul {
+.wy-plain-list-disc, .rst-content section ul, .rst-content .toctree-wrapper ul, article ul {
   list-style: disc;
   line-height: 24px;
   margin-bottom: 24px; }
 
-.wy-plain-list-disc li, .rst-content .section ul li, .rst-content .toctree-wrapper ul li, article ul li {
+.wy-plain-list-disc li, .rst-content section ul li, .rst-content .toctree-wrapper ul li, article ul li {
   list-style: disc;
   margin-left: 24px; }
 
-.wy-plain-list-disc li p:last-child, .rst-content .section ul li p:last-child, .rst-content .toctree-wrapper ul li p:last-child, article ul li p:last-child {
+.wy-plain-list-disc li p:last-child, .rst-content section ul li p:last-child, .rst-content .toctree-wrapper ul li p:last-child, article ul li p:last-child {
   margin-bottom: 0; }
 
-.wy-plain-list-disc li ul, .rst-content .section ul li ul, .rst-content .toctree-wrapper ul li ul, article ul li ul {
+.wy-plain-list-disc li ul, .rst-content section ul li ul, .rst-content .toctree-wrapper ul li ul, article ul li ul {
   margin-bottom: 0; }
 
-.wy-plain-list-disc li li, .rst-content .section ul li li, .rst-content .toctree-wrapper ul li li, article ul li li {
+.wy-plain-list-disc li li, .rst-content section ul li li, .rst-content .toctree-wrapper ul li li, article ul li li {
   list-style: circle; }
 
-.wy-plain-list-disc li li li, .rst-content .section ul li li li, .rst-content .toctree-wrapper ul li li li, article ul li li li {
+.wy-plain-list-disc li li li, .rst-content section ul li li li, .rst-content .toctree-wrapper ul li li li, article ul li li li {
   list-style: square; }
 
-.wy-plain-list-disc li ol li, .rst-content .section ul li ol li, .rst-content .toctree-wrapper ul li ol li, article ul li ol li {
+.wy-plain-list-disc li ol li, .rst-content section ul li ol li, .rst-content .toctree-wrapper ul li ol li, article ul li ol li {
   list-style: decimal; }
 
-.wy-plain-list-decimal, .rst-content .section ol, .rst-content ol.arabic, article ol {
+.wy-plain-list-decimal, .rst-content section ol, .rst-content ol.arabic, article ol {
   list-style: decimal;
   line-height: 24px;
   margin-bottom: 24px; }
 
-.wy-plain-list-decimal li, .rst-content .section ol li, .rst-content ol.arabic li, article ol li {
+.wy-plain-list-decimal li, .rst-content section ol li, .rst-content ol.arabic li, article ol li {
   list-style: decimal;
   margin-left: 24px; }
 
-.wy-plain-list-decimal li p:last-child, .rst-content .section ol li p:last-child, .rst-content ol.arabic li p:last-child, article ol li p:last-child {
+.wy-plain-list-decimal li p:last-child, .rst-content section ol li p:last-child, .rst-content ol.arabic li p:last-child, article ol li p:last-child {
   margin-bottom: 0; }
 
-.wy-plain-list-decimal li ul, .rst-content .section ol li ul, .rst-content ol.arabic li ul, article ol li ul {
+.wy-plain-list-decimal li ul, .rst-content section ol li ul, .rst-content ol.arabic li ul, article ol li ul {
   margin-bottom: 0; }
 
-.wy-plain-list-decimal li ul li, .rst-content .section ol li ul li, .rst-content ol.arabic li ul li, article ol li ul li {
+.wy-plain-list-decimal li ul li, .rst-content section ol li ul li, .rst-content ol.arabic li ul li, article ol li ul li {
   list-style: disc; }
 
 .codeblock-example {
@@ -4103,7 +4103,7 @@ div[class^='highlight'] pre {
 .wy-menu-vertical {
   width: 300px; }
 
-.wy-menu-vertical header, .wy-menu-vertical p.caption, .wy-menu-vertical p {
+.wy-menu-vertical header, .wy-menu-vertical caption, .wy-menu-vertical p {
   height: 32px;
   display: inline-block;
   line-height: 32px;
@@ -4544,7 +4544,7 @@ footer span.commit code, footer span.commit .rst-content tt, .rst-content footer
   .rst-versions .rst-current-version .fa {
     font-size: 12px; }
 
-.rst-versions .rst-current-version .fa, .rst-versions .rst-current-version .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li .rst-versions .rst-current-version span.toctree-expand, .rst-versions .rst-current-version .rst-content .admonition-title, .rst-content .rst-versions .rst-current-version .admonition-title, .rst-versions .rst-current-version .rst-content h1 .headerlink, .rst-content h1 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h2 .headerlink, .rst-content h2 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h3 .headerlink, .rst-content h3 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h4 .headerlink, .rst-content h4 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h5 .headerlink, .rst-content h5 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h6 .headerlink, .rst-content h6 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content dl dt .headerlink, .rst-content dl dt .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content p.caption .headerlink, .rst-content p.caption .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content tt.download span:first-child, .rst-content tt.download .rst-versions .rst-current-version span:first-child, .rst-versions .rst-current-version .rst-content code.download span:first-child, .rst-content code.download .rst-versions .rst-current-version span:first-child, .rst-versions .rst-current-version .icon {
+.rst-versions .rst-current-version .fa, .rst-versions .rst-current-version .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li .rst-versions .rst-current-version span.toctree-expand, .rst-versions .rst-current-version .rst-content .admonition-title, .rst-content .rst-versions .rst-current-version .admonition-title, .rst-versions .rst-current-version .rst-content h1 .headerlink, .rst-content h1 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h2 .headerlink, .rst-content h2 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h3 .headerlink, .rst-content h3 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h4 .headerlink, .rst-content h4 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h5 .headerlink, .rst-content h5 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h6 .headerlink, .rst-content h6 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content dl dt .headerlink, .rst-content dl dt .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content caption .headerlink, .rst-content caption .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content tt.download span:first-child, .rst-content tt.download .rst-versions .rst-current-version span:first-child, .rst-versions .rst-current-version .rst-content code.download span:first-child, .rst-content code.download .rst-versions .rst-current-version span:first-child, .rst-versions .rst-current-version .icon {
   color: black; }
 
 .rst-versions .rst-current-version.rst-out-of-date {
@@ -4602,16 +4602,16 @@ footer span.commit code, footer span.commit .rst-content tt, .rst-content footer
   max-width: 100%;
   height: auto !important; }
 
-.rst-content div.figure {
+.rst-content figure {
   margin-bottom: 24px; }
 
-.rst-content div.figure p.caption {
+.rst-content figure figcaption {
   font-style: italic; }
 
-.rst-content div.figure.align-center {
+.rst-content figure.align-center {
   text-align: center; }
 
-.rst-content .section > img, .rst-content .section > a > img {
+.rst-content section > img, .rst-content section > a > img {
   margin-bottom: 24px; }
 
 .rst-content blockquote {
@@ -4633,13 +4633,13 @@ footer span.commit code, footer span.commit .rst-content tt, .rst-content footer
   background: transparent !important;
   border-color: rgba(0, 0, 0, 0.1) !important; }
 
-.rst-content .section ol.loweralpha, .rst-content .section ol.loweralpha li {
+.rst-content section ol.loweralpha, .rst-content section ol.loweralpha li {
   list-style: lower-alpha; }
 
-.rst-content .section ol.upperalpha, .rst-content .section ol.upperalpha li {
+.rst-content section ol.upperalpha, .rst-content section ol.upperalpha li {
   list-style: upper-alpha; }
 
-.rst-content .section ol p, .rst-content .section ul p {
+.rst-content section ol p, .rst-content section ul p {
   margin-bottom: 12px; }
 
 .rst-content .line-block {
@@ -4664,18 +4664,18 @@ footer span.commit code, footer span.commit .rst-content tt, .rst-content footer
   margin: auto;
   display: block; }
 
-.rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content .toctree-wrapper p.caption .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content p.caption .headerlink {
+.rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content .toctree-wrapper caption .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content caption .headerlink {
   display: none;
   visibility: hidden;
   font-size: 14px; }
 
-.rst-content h1 .headerlink:after, .rst-content h2 .headerlink:after, .rst-content .toctree-wrapper p.caption .headerlink:after, .rst-content h3 .headerlink:after, .rst-content h4 .headerlink:after, .rst-content h5 .headerlink:after, .rst-content h6 .headerlink:after, .rst-content dl dt .headerlink:after, .rst-content p.caption .headerlink:after {
+.rst-content h1 .headerlink:after, .rst-content h2 .headerlink:after, .rst-content .toctree-wrapper caption .headerlink:after, .rst-content h3 .headerlink:after, .rst-content h4 .headerlink:after, .rst-content h5 .headerlink:after, .rst-content h6 .headerlink:after, .rst-content dl dt .headerlink:after, .rst-content caption .headerlink:after {
   visibility: visible;
   content: "";
   font-family: FontAwesome;
   display: inline-block; }
 
-.rst-content h1:hover .headerlink, .rst-content h2:hover .headerlink, .rst-content .toctree-wrapper p.caption:hover .headerlink, .rst-content h3:hover .headerlink, .rst-content h4:hover .headerlink, .rst-content h5:hover .headerlink, .rst-content h6:hover .headerlink, .rst-content dl dt:hover .headerlink, .rst-content p.caption:hover .headerlink {
+.rst-content h1:hover .headerlink, .rst-content h2:hover .headerlink, .rst-content .toctree-wrapper caption:hover .headerlink, .rst-content h3:hover .headerlink, .rst-content h4:hover .headerlink, .rst-content h5:hover .headerlink, .rst-content h6:hover .headerlink, .rst-content dl dt:hover .headerlink, .rst-content caption:hover .headerlink {
   display: inline-block; }
 
 .rst-content .centered {

--- a/doc/scripts/divio_docs_theme/static/css/divio.css
+++ b/doc/scripts/divio_docs_theme/static/css/divio.css
@@ -4838,6 +4838,9 @@ footer span.commit code, footer span.commit .rst-content tt, .rst-content footer
   display: inline-block;
   padding-right: 8px; }
 
+.rst-content dl:not(.docutils) span.pre~code.sig-name.descname, .rst-content dl:not(.docutils) .pre~em {
+  padding-left: 8px; }
+
 .rst-content .viewcode-link, .rst-content .viewcode-back {
   display: inline-block;
   color: #27AE60;


### PR DESCRIPTION
* Adapt CSS for the HTML5 transition in docutils 0.17, see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
   * e.g. `<div class=figure>` was changed to `<figure>`; the css is updated to match these sorts of changes.
* Fix some markup errors
* Add meta-tag to enable indexation control at Google (current indexation appears at least a year old).