### PR TITLE
fix current-clamp generation

### DIFF
--- a/arborio/cableio.cpp
+++ b/arborio/cableio.cpp
@@ -60,8 +60,7 @@ s_expr mksexp(const i_clamp& c) {
     std::vector<s_expr> evlps;
     std::transform(c.envelope.begin(), c.envelope.end(), std::back_inserter(evlps),
         [](const auto& x){return slist(x.t, x.amplitude);});
-    auto envelope = s_expr{"envelope"_symbol, slist_range(evlps)};
-    return slist("current-clamp"_symbol, envelope, c.frequency, c.phase);
+    return slist("current-clamp"_symbol, s_expr{"envelope"_symbol, slist_range(evlps)}, c.frequency, c.phase);
 }
 s_expr mksexp(const threshold_detector& d) {
     return slist("threshold-detector"_symbol, d.threshold);

--- a/arborio/cableio.cpp
+++ b/arborio/cableio.cpp
@@ -60,7 +60,7 @@ s_expr mksexp(const i_clamp& c) {
     std::vector<s_expr> evlps;
     std::transform(c.envelope.begin(), c.envelope.end(), std::back_inserter(evlps),
         [](const auto& x){return slist(x.t, x.amplitude);});
-    auto envelope = slist("envelope"_symbol, slist_range(evlps));
+    auto envelope = s_expr{"envelope"_symbol, slist_range(evlps)};
     return slist("current-clamp"_symbol, envelope, c.frequency, c.phase);
 }
 s_expr mksexp(const threshold_detector& d) {

--- a/test/unit/test_s_expr.cpp
+++ b/test/unit/test_s_expr.cpp
@@ -600,6 +600,9 @@ TEST(decor, round_tripping) {
                                 "      (ion-internal-concentration \"ca\" 0.500000))\n"
                                 "    (place \n"
                                 "      (location 0 0)\n"
+                                "      (gap-junction-site))\n"
+                                "    (place \n"
+                                "      (location 0 0)\n"
                                 "      (threshold-detector 10.000000))\n"
                                 "    (place \n"
                                 "      (location 0 0.5)\n"
@@ -803,10 +806,16 @@ TEST(cable_cell, round_tripping) {
                                 "        (mechanism \"pas\"))\n"
                                 "      (paint \n"
                                 "        (region \"soma\")\n"
-                                "        (mechanism \"hh\"))\n"
+                                "        (mechanism \"hh\" \n"
+                                "          (\"el\" 0.500000)))\n"
                                 "      (place \n"
                                 "        (location 0 1)\n"
-                                "        (mechanism \"exp2syn\")))))";
+                                "        (current-clamp \n"
+                                "          (envelope \n"
+                                "            (10.000000 0.500000)\n"
+                                "            (110.000000 0.500000)\n"
+                                "            (110.000000 0.000000))\n"
+                                "          0.000000 0.000000)))))";
 
     EXPECT_EQ(component_str, round_trip_component(component_str.c_str()));
 


### PR DESCRIPTION
Fixes incorrect `current-clamp` generated s-expression. 
Adds unit test.

Fixes #1486