### PR TITLE
Remove std::filesystem to workaround OSX features.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ install(TARGETS arbor-config-defs EXPORT arbor-targets)
 # Interface library `arbor-private-deps` collects dependencies, options etc.
 # for the arbor library.
 add_library(arbor-private-deps INTERFACE)
-target_link_libraries(arbor-private-deps INTERFACE arbor-config-defs ext-random123 ${CMAKE_DL_LIBS} arbor-compiler-compat)
+target_link_libraries(arbor-private-deps INTERFACE arbor-config-defs ext-random123 ${CMAKE_DL_LIBS})
 install(TARGETS arbor-private-deps EXPORT arbor-targets)
 
 # Interface library `arborenv-private-deps` collects dependencies, options etc.

--- a/arbor/include/arbor/mechcat.hpp
+++ b/arbor/include/arbor/mechcat.hpp
@@ -128,6 +128,6 @@ const mechanism_catalogue& global_bbp_catalogue();
 
 // Load catalogue from disk.
 
-    const mechanism_catalogue& load_catalogue(const std::string&);
+const mechanism_catalogue& load_catalogue(const std::string&);
 
 } // namespace arb

--- a/arbor/include/arbor/mechcat.hpp
+++ b/arbor/include/arbor/mechcat.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
@@ -129,6 +128,6 @@ const mechanism_catalogue& global_bbp_catalogue();
 
 // Load catalogue from disk.
 
-const mechanism_catalogue& load_catalogue(const std::filesystem::path&);
+    const mechanism_catalogue& load_catalogue(const std::string&);
 
 } // namespace arb

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -587,10 +587,8 @@ static void check_dlerror(const std::string& fn, const std::string& call) {
     if (error) { throw arb::bad_catalogue_error{fn, call}; }
 }
 
-const mechanism_catalogue& load_catalogue(const std::filesystem::path& fn) {
+const mechanism_catalogue& load_catalogue(const std::string& fn) {
     typedef const void* global_catalogue_t();
-
-    if (!std::filesystem::exists(fn)) { throw arb::file_not_found_error{fn}; }
 
     auto plugin = dlopen(fn.c_str(), RTLD_LAZY);
     check_dlerror(fn, "dlopen");

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -20,66 +20,6 @@ if(${ARBDEV_COLOR})
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${colorflags}>")
 endif()
 
-# A library to collect compiler-specific linking adjustments.
-add_library(arbor-compiler-compat INTERFACE)
-
-cmake_push_check_state()
-# Check how to use std::filesystem
-string(CONFIGURE [[
-  #include <cstdio>
-  #include <filesystem>
-  int main() {
-    auto cwd = std::filesystem::current_path();
-    std::printf("%s %d", cwd.c_str(), std::filesystem::exists(cwd));
-  }
-  ]] arb_cxx_fs_test @ONLY)
-
-# Remember some state to avoid constant push/pop
-set(arb_req_libs ${CMAKE_REQUIRED_LIBRARIES})
-
-# Test whether we can run probes
-set(STD_FS_LIB "")
-set(CMAKE_REQUIRED_FLAGS -std=c++17 ${CMAKE_REQUIRED_FLAGS})
-check_cxx_source_runs("${arb_cxx_fs_test}" STD_FS_PLAIN_RUN)
-
-if(NOT STD_FS_PLAIN_RUN)
-  set(STD_FS_LIB -lstdc++fs)
-  set(CMAKE_REQUIRED_LIBRARIES ${arb_req_libs} ${STD_FS_LIB})
-  check_cxx_source_runs("${arb_cxx_fs_test}" STD_FS_STDCXX_RUN)
-
-  if(NOT STD_FS_STDCXX_RUN)
-    set(STD_FS_LIB -lc++fs)
-    set(CMAKE_REQUIRED_LIBRARIES ${arb_req_libs} ${STD_FS_LIB})
-    check_cxx_source_runs("${arb_cxx_fs_test}" STD_FS_CXX_RUN)
-
-    # If running is not ok, we are possibly cross-compiling, so check linking as a fallback
-    if(NOT STD_FS_CXX_RUN)
-      check_cxx_source_compiles("${arb_cxx_fs_test}" STD_FS_PLAIN_LNK)
-
-      if(NOT STD_FS_PLAIN_LNK)
-        set(STD_FS_LIB -lstdc++fs)
-        set(CMAKE_REQUIRED_LIBRARIES ${arb_req_libs} ${STD_FS_LIB})
-        check_cxx_source_compiles("${arb_cxx_fs_test}" STD_FS_STDCXX_LNK)
-
-        if(NOT STD_FS_STDCXX_LNK)
-          set(STD_FS_LIB -lc++fs)
-          set(CMAKE_REQUIRED_LIBRARIES ${arb_req_libs} ${STD_FS_LIB})
-          check_cxx_source_compiles("${arb_cxx_fs_test}" STD_FS_CXX_LNK)
-
-          if(NOT STD_FS_CXX_LNK)
-            message(FATAL_ERROR "Could not enable support for std::filesystem")
-          endif()
-        endif()
-      endif()
-    endif()
-  endif()
-endif()
-cmake_pop_check_state()
-
-target_link_libraries(arbor-compiler-compat INTERFACE ${STD_FS_LIB})
-
-install(TARGETS arbor-compiler-compat EXPORT arbor-targets)
-
 # Warning options: disable specific spurious warnings as required.
 
 set(CXXOPT_WALL

--- a/test/unit/test_mechcat.cpp
+++ b/test/unit/test_mechcat.cpp
@@ -317,7 +317,7 @@ TEST(mechcat, names) {
 
 #ifdef USE_DYNAMIC_CATALOGUES
 TEST(mechcat, loading) {
-    EXPECT_THROW(load_catalogue(LIBDIR "/does-not-exist-catalogue.so"), file_not_found_error);
+    EXPECT_THROW(load_catalogue(LIBDIR "/does-not-exist-catalogue.so"), bad_catalogue_error);
     EXPECT_THROW(load_catalogue(LIBDIR "/libarbor.a"), bad_catalogue_error);
     const mechanism_catalogue* cat = nullptr;
     EXPECT_NO_THROW(cat = &load_catalogue(LIBDIR "/dummy-catalogue.so"));


### PR DESCRIPTION
Replaces use of `std::filesystem::path` with plain old `std::string`.