### PR TITLE
Fix communicator source gid bounds check.

### DIFF
--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -80,11 +80,10 @@ communicator::communicator(const recipe& rec,
     for (const auto& cell: gid_infos) {
         auto num_targets = rec.num_targets(cell.gid);
         for (auto c: cell.conns) {
-            auto num_sources = rec.num_sources(c.source.gid);
             if (c.source.gid >= num_total_cells) {
                 throw arb::bad_connection_source_gid(cell.gid, c.source.gid, num_total_cells);
             }
-            if (c.source.index >= num_sources) {
+            if (auto num_sources = rec.num_sources(c.source.gid); c.source.index >= num_sources) {
                 throw arb::bad_connection_source_lid(cell.gid, c.source.index, num_sources);
             }
             if (c.dest >= num_targets) {

--- a/test/unit/test_recipe.cpp
+++ b/test/unit/test_recipe.cpp
@@ -40,25 +40,25 @@ namespace {
             return num_cells_;
         }
         arb::util::unique_any get_cell_description(cell_gid_type gid) const override {
-            return cells_[gid];
+            return cells_.at(gid);
         }
         cell_kind get_cell_kind(cell_gid_type gid) const override {
             return cell_kind::cable;
         }
         std::vector<gap_junction_connection> gap_junctions_on(cell_gid_type gid) const override {
-            return gap_junctions_[gid];
+            return gap_junctions_.at(gid);
         }
         std::vector<cell_connection> connections_on(cell_gid_type gid) const override {
-            return connections_[gid];
+            return connections_.at(gid);
         }
         cell_size_type num_sources(cell_gid_type gid) const override {
-            return num_sources_[gid];
+            return num_sources_.at(gid);
         }
         cell_size_type num_targets(cell_gid_type gid) const override {
-            return num_targets_[gid];
+            return num_targets_.at(gid);
         }
         std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
-            return event_generators_[gid];
+            return event_generators_.at(gid);
         }
         std::any get_global_properties(cell_kind) const override {
             arb::cable_cell_global_properties a;


### PR DESCRIPTION
* Correct bounds check order in communicator.
* Use `.at()` in test recipe to catch failures in bound checking.

Fixes bug highlighted in PR #1501. 