### PR TITLE
Clarify/rewrite pw_elements zip.

### DIFF
--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -1164,7 +1164,7 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
         const mcable_map<init_reversal_potential>& rvpot_on_cable = initial_rvpot_map[ion];
 
         auto pw_times = [](const pw_elements<double>& a, const pw_elements<double>& b) {
-            return zip(a, b, [](double left, double right, pw_element<double> a, pw_element<double> b) { return a.second*b.second; });
+            return zip(a, b, [](double left, double right, pw_element<double> a, pw_element<double> b) { return a.element*b.element; });
         };
 
         for (auto i: count_along(config.cv)) {

--- a/arbor/fvm_layout.hpp
+++ b/arbor/fvm_layout.hpp
@@ -145,7 +145,7 @@ struct cv_geometry {
         }
 
         index_type cv_base = cell_cv_divs.at(cell_idx);
-        return cv_base+pw_cv_offset[i].second;
+        return cv_base+pw_cv_offset[i].element;
     }
 };
 

--- a/arbor/morph/embed_pwlin.cpp
+++ b/arbor/morph/embed_pwlin.cpp
@@ -93,9 +93,9 @@ mcable_list data_cmp(const branch_pw_ratpoly<1, 0>& f, unsigned bid, double val,
     mcable_list L;
     const auto& pw = f.at(bid);
     for (const auto& piece: pw) {
-        auto extents = piece.first;
-        auto left_val = piece.second(0);
-        auto right_val = piece.second(1);
+        auto extents = piece.interval;
+        auto left_val = piece.element(0);
+        auto right_val = piece.element(1);
 
         if (!op(left_val, val) && !op(right_val, val)) {
             continue;
@@ -275,11 +275,11 @@ embed_pwlin::embed_pwlin(const arb::morphology& m) {
             segment_cables_[seg.id] = mcable{bid, pos0, pos1};
         }
 
-        double length_0 = parent==mnpos? 0: data_->length[parent].back().second[1];
+        double length_0 = parent==mnpos? 0: data_->length[parent].back().element[1];
         data_->length[bid].push_back(0., 1, rat_element<1, 0>(length_0, length_0+branch_length));
 
-        double area_0 = parent==mnpos? 0: data_->area[parent].back().second[2];
-        double ixa_0 = parent==mnpos? 0: data_->ixa[parent].back().second[2];
+        double area_0 = parent==mnpos? 0: data_->area[parent].back().element[2];
+        double ixa_0 = parent==mnpos? 0: data_->ixa[parent].back().element[2];
 
         for (auto i: util::count_along(segments)) {
             auto prox = segments[i].prox;

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -157,6 +157,20 @@ struct pw_elements {
     std::pair<iterator, iterator> equal_range(double x) const {
         auto eq = std::equal_range(vertex_.begin(), vertex_.end(), x);
 
+        // Let n be the number of elements, indexed from 0 to n-1, with
+        // vertices indexed from 0 to n. Observe:
+        // * eq.first points to least vertex v_i ≥ x.
+        // * eq.second points to vertex_.end() if the last vertex v_n ≤ x,
+        //   or else to the least vertex v_k > x.
+        //
+        // Elements then correspond to the index range [b, e), where:
+        // * b=0 if i=0, else b=i-1, as v_i will be the upper vertex for
+        //   the first element whose (closed) support contains x.
+        // * e=k if k<n, since v_k will be the upper vertex for the
+        //   the last element (index k-1) whose support contains x.
+        //   Otherwise, if k==n or eq.second is vertex_.end(), the
+        //   last element (index n-1) contains x, and so e=n.
+
         if (eq.first==vertex_.end()) return {end(), end()};
         if (eq.first>vertex_.begin()) --eq.first;
         if (eq.second==vertex_.end()) --eq.second;
@@ -403,7 +417,7 @@ namespace impl {
     template <typename A, typename B>
     struct piecewise_pairify {
         std::pair<A, B> operator()(
-            double left, double right,
+            double, double,
             const pw_element<A>& a_elem,
             const pw_element<B>& b_elem) const
          {
@@ -414,7 +428,7 @@ namespace impl {
     template <typename X>
     struct piecewise_pairify<X, void> {
         X operator()(
-            double left, double right,
+            double, double,
             const pw_element<X>& a_elem,
             const pw_element<void>& b_elem) const
         {
@@ -425,7 +439,7 @@ namespace impl {
     template <typename X>
     struct piecewise_pairify<void, X> {
         X operator()(
-            double left, double right,
+            double, double,
             const pw_element<void>& a_elem,
             const pw_element<X>& b_elem) const
         {
@@ -436,7 +450,7 @@ namespace impl {
     template <>
     struct piecewise_pairify<void, void> {
         void operator()(
-            double left, double right,
+            double, double,
             const pw_element<void>&,
             const pw_element<void>&) const {}
     };


### PR DESCRIPTION
* Use a struct with meaningful field names instead of a `std::pair` to represent elements in `pw_elements`.
* Describe explicitly the semantics of the zip operation.
* Update implementation and add unit tests to suit.

Fixes #1514.