### PR TITLE
Guard empty ARB_CXXOPT_ARCH, cf. spack package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ if(ARB_ARCH)
     target_compile_options(arborenv-private-deps INTERFACE ${ARB_CXXOPT_ARCH})
     set(MAYBE_EMPTY_ARB_ARCH ${ARB_ARCH})
 else()
-    set(MAYBE_EMPTY_ARB_ARCH "notset")
+    set(MAYBE_EMPTY_ARB_ARCH "ARB_ARCH_not_set")
 endif()
 
 # Profiling and test features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,9 @@ if(ARB_ARCH)
     set_arch_target(ARB_CXXOPT_ARCH "${ARB_ARCH}")
     target_compile_options(arbor-private-deps INTERFACE ${ARB_CXXOPT_ARCH})
     target_compile_options(arborenv-private-deps INTERFACE ${ARB_CXXOPT_ARCH})
+    set(MAYBE_EMPTY_ARB_ARCH ${ARB_ARCH})
+else()
+    set(MAYBE_EMPTY_ARB_ARCH "notset")
 endif()
 
 # Profiling and test features

--- a/arbor/include/CMakeLists.txt
+++ b/arbor/include/CMakeLists.txt
@@ -55,7 +55,8 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" arb_config_str)
 add_custom_command(
     OUTPUT version.hpp-test
     DEPENDS _always_rebuild
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
+
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${MAYBE_EMPTY_ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
 )
 
 set(version_hpp_path arbor/version.hpp)

--- a/mechanisms/BuildModules.cmake
+++ b/mechanisms/BuildModules.cmake
@@ -118,7 +118,7 @@ function("make_catalogue")
   endforeach()
   set(${MK_CAT_OUTPUT} ${catalogue_${MK_CAT_NAME}_source} PARENT_SCOPE)
 
-  if(${ARB_CXXOPT_ARCH})
+  if(DEFINED ARB_CXXOPT_ARCH)
 	set_source_files_properties(${catalogue_${MK_CAT_NAME}_source} COMPILE_FLAGS ${ARB_CXXOPT_ARCH})
   endif()
 

--- a/mechanisms/BuildModules.cmake
+++ b/mechanisms/BuildModules.cmake
@@ -118,7 +118,9 @@ function("make_catalogue")
   endforeach()
   set(${MK_CAT_OUTPUT} ${catalogue_${MK_CAT_NAME}_source} PARENT_SCOPE)
 
-  set_source_files_properties(${catalogue_${MK_CAT_NAME}_source} COMPILE_FLAGS ${ARB_CXXOPT_ARCH})
+  if(${ARB_CXXOPT_ARCH})
+	set_source_files_properties(${catalogue_${MK_CAT_NAME}_source} COMPILE_FLAGS ${ARB_CXXOPT_ARCH})
+  endif()
 
   if(${MK_CAT_STANDALONE})
     add_library(${MK_CAT_NAME}-catalogue SHARED ${catalogue_${MK_CAT_NAME}_source})


### PR DESCRIPTION
If ARB_ARCH is empty, so is ARB_CXXOPT_ARCH. We need to check because COMPILE_FLAGS does not allow for an empty argument.