### PR TITLE
Modcc: Invalid pointer bug

### DIFF
--- a/modcc/functioninliner.cpp
+++ b/modcc/functioninliner.cpp
@@ -180,8 +180,9 @@ void FunctionInliner::visit(AssignmentExpression* e) {
     if (auto rhs = e->rhs()->is_identifier()) {
         if (local_arg_map_.count(rhs->spelling())) {
             e->replace_rhs(local_arg_map_.at(rhs->spelling())->clone());
+            rhs = e->rhs()->is_identifier();
         }
-        if (call_arg_map_.count(rhs->spelling())) {
+        if (rhs && call_arg_map_.count(rhs->spelling())) {
             e->replace_rhs(call_arg_map_.at(rhs->spelling())->clone());
         }
     }


### PR DESCRIPTION
After reviewing the failures in PR #1521, I found and fixed a bug in the modcc function inliner: the `rhs` pointer is potentially changed then the old value is reused. 