### PR TITLE
Revert "Add default hidden visibliity to pyarb shared lib. (#1510)"

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -45,7 +45,6 @@ set(pyarb_source
 # use by both the Python wrapper target (pyarb) and for the
 # unit tests of the C++ components in the Python wrapper.
 add_library(pyarb_obj OBJECT ${pyarb_source})
-set_target_properties(pyarb_obj PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_link_libraries(pyarb_obj PRIVATE arbor arborio pybind11::module)
 
 # The Python library. MODULE will make a Python-exclusive model.


### PR DESCRIPTION
This reverts commit e8b08ca8d9b36a5c8e89ab60fd8876d0453fecbd. 

Closes #1557.

<!-- Please make sure your PR follows our [contribution guidelines](https://github.com/arbor-sim/arbor/tree/master/doc/contrib) and agree to the terms outlined in the [PR procedure](https://github.com/arbor-sim/arbor/tree/master/doc/contrib/pr.rst). -->
