### PR TITLE
Raise KeyError in catalogue.

### DIFF
--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -220,7 +220,7 @@ void register_cells(pybind11::module& m) {
         .def("__getitem__",
             [](label_dict_proxy& l, const char* name) {
                 if (!l.cache.count(name)) {
-                    throw std::runtime_error(util::pprintf("\nKeyError: '{}'", name));
+                    throw pybind11::key_error(name);
                 }
                 return l.cache.at(name);
             })

--- a/python/mechanism.cpp
+++ b/python/mechanism.cpp
@@ -135,7 +135,7 @@ void register_mechanisms(pybind11::module& m) {
                     return c[name];
                 }
                 catch (...) {
-                    throw std::runtime_error(util::pprintf("\nKeyError: '{}'", name));
+                    throw pybind11::key_error(name);
                 }
             })
         .def("extend", &arb::mechanism_catalogue::import,


### PR DESCRIPTION
Raise KeyError instead of generic RuntimeError on missing items in
- Mechanism catalogues,
- Label dicts.

Closes #1550 .
