### PR TITLE
Compile all arbor source files with `-fvisibility=hidden`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ separate_arguments(ARB_CXX_FLAGS_TARGET_FULL)
 
 target_compile_options(arbor-private-deps INTERFACE ${ARB_CXX_FLAGS_TARGET_FULL})
 target_compile_options(arborenv-private-deps INTERFACE ${ARB_CXX_FLAGS_TARGET_FULL})
+target_compile_options(arborio-private-deps INTERFACE ${ARB_CXX_FLAGS_TARGET_FULL})
 
 # Profiling and test features
 #-----------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,11 @@ else()
     set_arch_target(ARB_CXXOPT_ARCH ${ARB_ARCH})
     set(ARB_CXX_FLAGS_TARGET_FULL ${ARB_CXX_FLAGS_TARGET} ${ARB_CXXOPT_ARCH})
 endif()
+
+# Compile with `-fvisibility=hidden` to ensure that the symbols of the generated
+# arbor static libraries are hidden from the dynamic symbol tables of any shared
+# libraries that link against them.
+list(APPEND ARB_CXX_FLAGS_TARGET_FULL "-fvisibility=hidden")
 separate_arguments(ARB_CXX_FLAGS_TARGET_FULL)
 
 target_compile_options(arbor-private-deps INTERFACE ${ARB_CXX_FLAGS_TARGET_FULL})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,9 @@ endif()
 # Compile with `-fvisibility=hidden` to ensure that the symbols of the generated
 # arbor static libraries are hidden from the dynamic symbol tables of any shared
 # libraries that link against them.
-list(APPEND ARB_CXX_FLAGS_TARGET_FULL "-fvisibility=hidden")
+list(APPEND ARB_CXX_FLAGS_TARGET_FULL
+            "$<$<BUILD_INTERFACE:$<COMPILE_LANGUAGE:CXX>>:-fvisibility=hidden>"
+            "$<$<BUILD_INTERFACE:$<COMPILE_LANGUAGE:CUDA>>:-Xcompiler=-fvisibility=hidden>")
 separate_arguments(ARB_CXX_FLAGS_TARGET_FULL)
 
 target_compile_options(arbor-private-deps INTERFACE ${ARB_CXX_FLAGS_TARGET_FULL})

--- a/mechanisms/generate_catalogue
+++ b/mechanisms/generate_catalogue
@@ -120,7 +120,7 @@ const mechanism_catalogue& global_${catalogue}_catalogue() {
 
 #ifdef STANDALONE
 extern "C" {
-    __attribute__ ((visibility ("default"))) const void* get_catalogue() {
+    [[gnu::visibility("default")]] const void* get_catalogue() {
         static auto cat = arb::build_${catalogue}_catalogue();
         return (void*)&cat;
     }

--- a/mechanisms/generate_catalogue
+++ b/mechanisms/generate_catalogue
@@ -120,7 +120,7 @@ const mechanism_catalogue& global_${catalogue}_catalogue() {
 
 #ifdef STANDALONE
 extern "C" {
-    const void* get_catalogue() {
+    __attribute__ ((visibility ("default"))) const void* get_catalogue() {
         static auto cat = arb::build_${catalogue}_catalogue();
         return (void*)&cat;
     }


### PR DESCRIPTION
The visibility of symbols in the python shared library is set to 'hidden'. However, checking the dynamic symbol table of the generated `.so` file reveals that all the symbols of the static arbor libraries are still visible. This causes some issues on the Mac M1. To resolve, all source files should be compiled with `fvisibility=hidden`.

Fixes #1557
Fixes #1559