### PR TITLE
Attempt fixing a64fx build

### DIFF
--- a/ci/test-ault-fujitsu.sh
+++ b/ci/test-ault-fujitsu.sh
@@ -9,6 +9,9 @@ echo "=== loading environment"
 source /users/bcumming/a64fx/env.sh
 spack load git gcc@11.1.0 cmake ninja
 
+cd "$base_path"
+git submodule init
+git submodule update
 build_path="$base_path/build"
 echo "=== building: $build_path"
 mkdir "$build_path"

--- a/ci/test-ault-fujitsu.sh
+++ b/ci/test-ault-fujitsu.sh
@@ -15,7 +15,7 @@ mkdir "$build_path"
 cd "$build_path"
 echo "=== CC=gcc CXX=g++ cmake .. -DARB_USE_BUNDLED_LIBS=on -DARB_ARCH=armv8.2-a+sve -DARB_VECTORIZE=on -G Ninja"
 CC=gcc CXX=g++ cmake .. -DARB_USE_BUNDLED_LIBS=on -DARB_ARCH=armv8.2-a+sve -DARB_VECTORIZE=on -G Ninja
-ninja -j48 unit
+ninja -j 8 unit
 
 bin_path="$build_path/bin"
 echo "=== running unit tests: $bin_path/unit"

--- a/ci/test-ault-fujitsu.sh
+++ b/ci/test-ault-fujitsu.sh
@@ -15,7 +15,7 @@ mkdir "$build_path"
 cd "$build_path"
 echo "=== CC=gcc CXX=g++ cmake .. -DARB_USE_BUNDLED_LIBS=on -DARB_ARCH=armv8.2-a+sve -DARB_VECTORIZE=on -G Ninja"
 CC=gcc CXX=g++ cmake .. -DARB_USE_BUNDLED_LIBS=on -DARB_ARCH=armv8.2-a+sve -DARB_VECTORIZE=on -G Ninja
-ninja -j 8 unit
+ninja -j8 unit
 
 bin_path="$build_path/bin"
 echo "=== running unit tests: $bin_path/unit"


### PR DESCRIPTION
Reduce number of parallel build jobs to reduce risk of OOM in CI builds.
