### PR TITLE
Fix simulation::add_sampler cell_group dispatch

### DIFF
--- a/arbor/benchmark_cell_group.cpp
+++ b/arbor/benchmark_cell_group.cpp
@@ -98,9 +98,6 @@ void benchmark_cell_group::add_sampler(sampler_association_handle h,
                                    cell_member_predicate probe_ids,
                                    schedule sched,
                                    sampler_function fn,
-                                   sampling_policy policy)
-{
-    throw std::logic_error("A benchmark_cell group doen't support sampling of internal state!");
-}
+                                   sampling_policy policy) {}
 
 } // namespace arb

--- a/arbor/spike_source_cell_group.cpp
+++ b/arbor/spike_source_cell_group.cpp
@@ -74,9 +74,7 @@ void spike_source_cell_group::clear_spikes() {
     spikes_.clear();
 }
 
-void spike_source_cell_group::add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function, sampling_policy) {
-    throw std::logic_error("A spike_source_cell group doen't support sampling of internal state!");
-}
+void spike_source_cell_group::add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function, sampling_policy) {}
 
 } // namespace arb
 


### PR DESCRIPTION
Add check on dispatch to `cell_group::add_sampler` in `simulation_state::add_sampler` to avoid erroneous exceptions.

Fixes #1653 