### PR TITLE
Rephrase exception message in case of missing segment

### DIFF
--- a/arbor/morph/morphexcept.cpp
+++ b/arbor/morph/morphexcept.cpp
@@ -25,7 +25,7 @@ no_such_branch::no_such_branch(msize_t bid):
 {}
 
 no_such_segment::no_such_segment(msize_t id):
-    arbor_exception(pprintf("segment {} out of bounds", id)),
+    arbor_exception(pprintf("no such segment {}", id)),
     sid(id)
 {}
 


### PR DESCRIPTION
More helpful message (imho) and aligned with other exception messages.
