### PR TITLE
Fixed MRO and code duplication in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,7 @@ class _command_template:
     """
     Override a setuptools-like command to augment the command line options.
     Needs to appear before the command class in the class's argument list for
-    correct MRO. Will assume that the 2nd class is the base command class unless
-    a ``base`` kwarg is explicitly defined in the class's argument list.
-
+    correct MRO.
     Examples
     --------
 
@@ -79,8 +77,11 @@ class _command_template:
           pass
 
 
-      class complex_command(_command_template, mixin1, install, base=install):
-          pass
+      class complex_command(_command_template, mixin1, install):
+          def initialize_options(self):
+              # Both here and in `mixin1`, a `super` call is required
+              super().initialize_options()
+              # ...
 
     Usage
     -----
@@ -89,18 +90,13 @@ class _command_template:
         python3 setup.py bdist_wheel --vec --mpi --arch=none
 
     """
-    def __init_subclass__(cls, base=None, **kwargs):
+    def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        if base is None:
-            base = cls.__bases__[1]
-        cls.user_options = base.user_options + user_options_
-        cls._initialize_options = base.initialize_options
-        cls._finalize_options = base.finalize_options
-        cls._run = base.run
+        cls.user_options = super().user_options + user_options_
 
 
     def initialize_options(self):
-        self._initialize_options()
+        super().initialize_options()
         self.mpi  = None
         self.gpu  = None
         self.arch = None
@@ -109,7 +105,7 @@ class _command_template:
         self.sysdeps = None
 
     def finalize_options(self):
-        self._finalize_options()
+        super().finalize_options()
 
     def run(self):
         # The options are stored in global variables:
@@ -128,7 +124,7 @@ class _command_template:
         #             By default use bundled libs.
         opt['bundled'] = self.sysdeps is None
 
-        self._run()
+        super().run()
 
 
 # Extend the command line options available to the install phase.

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ class _command_template:
     Override a setuptools-like command to augment the command line options.
     Needs to appear before the command class in the class's argument list for
     correct MRO.
-    
+
     Examples
     --------
 
@@ -83,12 +83,6 @@ class _command_template:
               # Both here and in `mixin1`, a `super` call is required
               super().initialize_options()
               # ...
-
-    Usage
-    -----
-
-        python3 setup.py install --mpi --arch=skylake
-        pip3 install --install-option '--mpi' --install-option '--arch=skylake'
 
     """
     def __init_subclass__(cls, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ class _command_template:
     Override a setuptools-like command to augment the command line options.
     Needs to appear before the command class in the class's argument list for
     correct MRO.
+    
     Examples
     --------
 

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,8 @@ class _command_template:
     Usage
     -----
 
-        python3 setup.py install --mpi
-        python3 setup.py bdist_wheel --vec --mpi --arch=none
+        python3 setup.py install --mpi --arch=skylake
+        pip3 install --install-option '--mpi' --install-option '--arch=skylake'
 
     """
     def __init_subclass__(cls, **kwargs):
@@ -127,10 +127,6 @@ class _command_template:
         super().run()
 
 
-# Extend the command line options available to the install phase.
-# These arguments must come after `install` on the command line, e.g.:
-#    python3 setup.py install --mpi --arch=skylake
-#    pip3 install --install-option '--mpi' --install-option '--arch=skylake' .
 class install_command(_command_template, install):
     pass
 
@@ -138,9 +134,11 @@ if WHEEL_INSTALLED:
     class bdist_wheel_command(_command_template, bdist_wheel):
         pass
 
+
 class cmake_extension(Extension):
     def __init__(self, name):
         Extension.__init__(self, name, sources=[])
+
 
 class cmake_build(build_ext):
     def run(self):


### PR DESCRIPTION
The duplication arose from slightly more complicated composition than usual but could be resolved by proper MRO, it took me a few passes from its original form as well before I figured out the situation is not as complicated as it seems.

`super()` is equal to `super(cls, self)` where `cls` is obtained from the current function's class scope. If arg 2  is an object it will start an MRO search of the object, but skipping classes before the 1st arg type is encountered. In our case with the following base classes: `(_command_template, base_command_class)` this means we can define our base logic in `_command_template` and use `super()` calls there to traverse the MRO in `(base_command_class,)`, so by simply defining `class install_command(_command_template, install)` and `bdist_wheel_command(_command_template, bdist_wheel)` our MRO issue is solved and the duplication removed 👍 