### PR TITLE
Makejobs arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,7 @@ class _command_template:
     """
     Override a setuptools-like command to augment the command line options.
     Needs to appear before the command class in the class's argument list for
-    correct MRO. Will assume that the 2nd class is the base command class unless
-    a ``base`` kwarg is explicitly defined in the class's argument list.
-
+    correct MRO.
     Examples
     --------
 
@@ -79,8 +77,11 @@ class _command_template:
           pass
 
 
-      class complex_command(_command_template, mixin1, install, base=install):
-          pass
+      class complex_command(_command_template, mixin1, install):
+          def initialize_options(self):
+              # Both here and in `mixin1`, a `super` call is required
+              super().initialize_options()
+              # ...
 
     Usage
     -----
@@ -89,18 +90,13 @@ class _command_template:
         python3 setup.py bdist_wheel --vec --mpi --arch=none
 
     """
-    def __init_subclass__(cls, base=None, **kwargs):
+    def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        if base is None:
-            base = cls.__bases__[1]
-        cls.user_options = base.user_options + user_options_
-        cls._initialize_options = base.initialize_options
-        cls._finalize_options = base.finalize_options
-        cls._run = base.run
+        cls.user_options = super().user_options + user_options_
 
 
     def initialize_options(self):
-        self._initialize_options()
+        super().initialize_options()
         self.mpi  = None
         self.gpu  = None
         self.arch = None
@@ -109,7 +105,7 @@ class _command_template:
         self.sysdeps = None
 
     def finalize_options(self):
-        self._finalize_options()
+        super().finalize_options()
 
     def run(self):
         # The options are stored in global variables:
@@ -128,7 +124,7 @@ class _command_template:
         #             By default use bundled libs.
         opt['bundled'] = self.sysdeps is None
 
-        self._run()
+        super().run()
 
 
 # Extend the command line options available to the install phase.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ class CL_opt:
                                'vec': False,
                                'arch': 'none',
                                'neuroml': True,
-                               'bundled': True}
+                               'bundled': True,
+                               'makejobs': 2}
 
     def settings(self):
         return CL_opt.instance
@@ -43,7 +44,8 @@ user_options_ = [
         ('vec',   None, 'enable vectorization'),
         ('arch=', None, 'cpu architecture, e.g. haswell, skylake, armv8.2-a+sve, znver2 (default native).'),
         ('neuroml', None, 'enable parsing neuroml morphologies in Arbor (requires libxml)'),
-        ('sysdeps', None, 'don\'t use bundled 3rd party C++ dependencies (pybind11 and json). This flag forces use of dependencies installed on the system.')
+        ('sysdeps', None, 'don\'t use bundled 3rd party C++ dependencies (pybind11 and json). This flag forces use of dependencies installed on the system.'),
+        ('makejobs=', None, 'the amount of jobs to run `make` with.')
     ]
 
 # VERSION is in the same path as setup.py
@@ -103,9 +105,18 @@ class _command_template:
         self.vec  = None
         self.neuroml = None
         self.sysdeps = None
+        self.makejobs = 2
 
     def finalize_options(self):
         super().finalize_options()
+        try:
+            self.makejobs = int(self.makejobs)
+        except ValueError:
+            err = True
+        else:
+            err = False
+        if err or int(self.makejobs) < 1:
+            raise AssertionError('makejobs must be a strictly positive integer')
 
     def run(self):
         # The options are stored in global variables:
@@ -123,6 +134,9 @@ class _command_template:
         #   bundled : use bundled/git-submoduled 3rd party libraries.
         #             By default use bundled libs.
         opt['bundled'] = self.sysdeps is None
+        #   makejobs : specify amount of jobs.
+        #              By default 2.
+        opt['makejobs'] = int(self.makejobs)
 
         super().run()
 
@@ -174,7 +188,7 @@ class cmake_build(build_ext):
         build_args = ['--config', 'Release']
 
         # Assuming Makefiles
-        build_args += ['--', '-j2']
+        build_args += ['--', f'-j{opt["makejobs"]}']
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{}'.format(env.get('CXXFLAGS', ''))

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,8 @@ class _command_template:
     Usage
     -----
 
-        python3 setup.py install --mpi
-        python3 setup.py bdist_wheel --vec --mpi --arch=none
+        python3 setup.py install --mpi --arch=skylake
+        pip3 install --install-option '--mpi' --install-option '--arch=skylake'
 
     """
     def __init_subclass__(cls, **kwargs):
@@ -127,10 +127,6 @@ class _command_template:
         super().run()
 
 
-# Extend the command line options available to the install phase.
-# These arguments must come after `install` on the command line, e.g.:
-#    python3 setup.py install --mpi --arch=skylake
-#    pip3 install --install-option '--mpi' --install-option '--arch=skylake' .
 class install_command(_command_template, install):
     pass
 
@@ -138,9 +134,11 @@ if WHEEL_INSTALLED:
     class bdist_wheel_command(_command_template, bdist_wheel):
         pass
 
+
 class cmake_extension(Extension):
     def __init__(self, name):
         Extension.__init__(self, name, sources=[])
+
 
 class cmake_build(build_ext):
     def run(self):


### PR DESCRIPTION
Added a `--makejobs=4` user option to `setup.py` to control how many jobs should be started to `make` the project during the installation.

Depends on #1672 to avoid duplicate defenition of the arg and merge issues.