### PR TITLE
Write (c)make errors to `stdout` and `stderr`

### DIFF
--- a/scripts/build-catalogue.in
+++ b/scripts/build-catalogue.in
@@ -108,8 +108,19 @@ with TemporaryDirectory() as tmp:
         fd.write(cmake)
     shutil.copy2(f'@ARB_INSTALL_DATADIR@/BuildModules.cmake', tmp)
     shutil.copy2(f'@ARB_INSTALL_DATADIR@/generate_catalogue', tmp)
-    sp.run('cmake ..', shell=True, check=True, capture_output=not verbose)
-    sp.run('make',     shell=True, check=True, capture_output=not verbose)
+    try:
+        sp.run('cmake ..', shell=True, check=True, capture_output=not verbose)
+        sp.run('make',     shell=True, check=True, capture_output=not verbose)
+    except sp.CalledProcessError as e:
+        import sys, traceback as tb
+
+        sys.stdout.write("Build log:\n")
+        sys.stdout.write(e.stdout.decode())
+        sys.stderr.write(tb.format_exc() + " Error:\n\n")
+        sys.stderr.write(e.stderr.decode())
+        sys.stdout.flush()
+        sys.stderr.flush()
+        exit(e.returncode)
     shutil.copy2(f'{name}-catalogue.so', pwd)
     if not quiet:
         print(f'Catalogue has been built and copied to {pwd}/{name}-catalogue.so')


### PR DESCRIPTION
`build-catalogue` gobbled up the underlying (c)make output in the uncaught `CalledProcessError`s `e.stderr` and `e.stdout`.
