### PR TITLE
Added a debug mode to `build-catalogue`

### DIFF
--- a/scripts/build-catalogue.in
+++ b/scripts/build-catalogue.in
@@ -2,7 +2,7 @@
 
 import subprocess as sp
 import sys
-from tempfile import TemporaryDirectory
+from tempfile import mkdtemp, TemporaryDirectory
 import os
 from pathlib import Path
 import shutil
@@ -52,6 +52,10 @@ def parse_arguments():
                         action='store_true',
                         help='Less output.')
 
+    parser.add_argument('-d', '--debug',
+                        action='store_true',
+                        help='Don\'t clean up the generated temp cpp code.')
+
     parser.add_argument('-h', '--help',
                         action='help',
                         help='Display this help and exit.')
@@ -68,6 +72,7 @@ mod_dir = pwd / Path(args['modpfx'])
 mods    = [ f[:-4] for f in os.listdir(mod_dir) if f.endswith('.mod') ]
 verbose = args['verbose'] and not args['quiet']
 quiet   = args['quiet']
+debug   = args['debug']
 
 cmake = f"""
 cmake_minimum_required(VERSION 3.9)
@@ -96,8 +101,21 @@ make_catalogue(
 
 if not quiet:
     print(f"Building catalogue '{name}' from mechanisms in {mod_dir}")
+    if debug:
+        print("Debug mode enabled.")
     for m in mods:
         print(" *", m)
+
+if debug:
+    # Overwrite the local reference to `TemporaryDirectory` with a context
+    # manager that doesn't clean up the build folder so that the generated cpp
+    # code can be debugged
+    class TemporaryDirectory:
+        def __enter__(*args, **kwargs):
+            return mkdtemp()
+
+        def __exit__(*args, **kwargs):
+            pass
 
 with TemporaryDirectory() as tmp:
     tmp = Path(tmp)
@@ -113,3 +131,5 @@ with TemporaryDirectory() as tmp:
     shutil.copy2(f'{name}-catalogue.so', pwd)
     if not quiet:
         print(f'Catalogue has been built and copied to {pwd}/{name}-catalogue.so')
+        if debug:
+            print(f"Generated code available in '{tmp}'.")


### PR DESCRIPTION
A `--debug` flag is added so that users can inspect the out-of-tree generated C++ code of their catalogue builds.