### PR TITLE
Allow to keep the directory where the catalogue was built

### DIFF
--- a/scripts/build-catalogue.in
+++ b/scripts/build-catalogue.in
@@ -44,6 +44,10 @@ def parse_arguments():
                         type=str,
                         help='Directory name where *.mod files live.')
 
+    parser.add_argument('-s', '--stage',
+                        default=None,
+                        help="path to stage directory (uses temporary if not given)")
+
     parser.add_argument('-v', '--verbose',
                         action='store_true',
                         help='Verbose.')
@@ -68,6 +72,7 @@ mod_dir = pwd / Path(args['modpfx'])
 mods    = [ f[:-4] for f in os.listdir(mod_dir) if f.endswith('.mod') ]
 verbose = args['verbose'] and not args['quiet']
 quiet   = args['quiet']
+stage   = args['stage']
 
 cmake = f"""
 cmake_minimum_required(VERSION 3.9)
@@ -99,8 +104,8 @@ if not quiet:
     for m in mods:
         print(" *", m)
 
-with TemporaryDirectory() as tmp:
-    tmp = Path(tmp)
+def main(path):
+    tmp = Path(path)
     shutil.copytree(mod_dir, tmp / 'mod')
     os.mkdir(tmp / 'build')
     os.chdir(tmp / 'build')
@@ -113,3 +118,12 @@ with TemporaryDirectory() as tmp:
     shutil.copy2(f'{name}-catalogue.so', pwd)
     if not quiet:
         print(f'Catalogue has been built and copied to {pwd}/{name}-catalogue.so')
+
+if stage:
+    stage = os.path.abspath(stage)
+    stage = Path(stage)
+    stage.mkdir(parents=True, exist_ok=True)
+    main(stage)
+else:
+    with TemporaryDirectory() as tmp:
+        main(tmp)


### PR DESCRIPTION
E.g. for modifiying generated sources but still using the
convenience of the build-catalogue script.

<!-- Please make sure your PR follows our [contribution guidelines](https://github.com/arbor-sim/arbor/tree/master/doc/contrib) and agree to the terms outlined in the [PR procedure](https://github.com/arbor-sim/arbor/tree/master/doc/contrib/pr.rst). -->
