### PR TITLE
Fixed `build-catalogue` for Python 3.6 

### DIFF
--- a/scripts/build-catalogue.in
+++ b/scripts/build-catalogue.in
@@ -108,8 +108,12 @@ with TemporaryDirectory() as tmp:
         fd.write(cmake)
     shutil.copy2(f'@ARB_INSTALL_DATADIR@/BuildModules.cmake', tmp)
     shutil.copy2(f'@ARB_INSTALL_DATADIR@/generate_catalogue', tmp)
-    sp.run('cmake ..', shell=True, check=True, capture_output=not verbose)
-    sp.run('make',     shell=True, check=True, capture_output=not verbose)
+    sp_kwargs = dict()
+    if not verbose:
+        sp_kwargs["stdout"] = sp.PIPE
+        sp_kwargs["stderr"] = sp.PIPE
+    sp.run('cmake ..', shell=True, check=True, **sp_kwargs)
+    sp.run('make',     shell=True, check=True, **sp_kwargs)
     shutil.copy2(f'{name}-catalogue.so', pwd)
     if not quiet:
         print(f'Catalogue has been built and copied to {pwd}/{name}-catalogue.so')


### PR DESCRIPTION
`capture_output` kwarg was added in 3.7