### PR TITLE
Allow diagnostics of mechanism assignments to be printed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ else()
   unset(nlohmann_json_DIR CACHE)
 endif()
 add_subdirectory(ext)
+target_link_libraries(arbor-private-deps INTERFACE ${json_library_name})
 
 cmake_dependent_option(ARB_USE_BUNDLED_FMT "Use bundled FMT lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
 

--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -27,6 +27,8 @@
 #include "multicore_common.hpp"
 #include "shared_state.hpp"
 
+#include <nlohmann/json.hpp>
+
 namespace arb {
 namespace multicore {
 
@@ -597,6 +599,24 @@ void shared_state::instantiate(arb::mechanism& m, unsigned id, const mechanism_o
             arb_assert(compatible_index_constraints(node_index, util::range_n(m.ppack_.ion_states[idx].index, index_width_padded), m.iface_.partition_width));
         }
         if (mult_in_place) m.ppack_.multiplicity = writer.append(pos_data.multiplicity, 0);
+    }
+
+    if (m.dump_stats) {
+        nlohmann::json stats;
+        std::vector<unsigned> cells;
+        cells.reserve(pos_data.cv.size());
+        for(auto cv: pos_data.cv) cells.push_back(cv_to_cell[cv]);
+        stats["name"]  = m.mech_.name;
+        stats["kind"]  = arb_mechanism_kind_str(m.mech_.kind);
+        stats["id"]    = id;
+        stats["width"] = pos_data.cv.size();
+        stats["n_cv"]  = n_cv;
+        stats["cv"]    = pos_data.cv;
+        stats["cells"] = cells;
+        stats["diam"]  = diam_um;
+        std::stringstream ss;
+        ss << stats << '\n';
+        std::cout << ss.str();
     }
 }
 

--- a/arbor/fvm_layout.hpp
+++ b/arbor/fvm_layout.hpp
@@ -227,7 +227,7 @@ struct fvm_mechanism_config {
     using index_type = fvm_index_type;
 
     arb_mechanism_kind kind;
-
+    bool dump_stats = false;
     // Ordered CV indices where mechanism is present; may contain
     // duplicates for point mechanisms.
     std::vector<index_type> cv;

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -488,12 +488,14 @@ fvm_initialization_data fvm_lowered_cell_impl<Backend>::initialize(
     }
     std::vector<fvm_index_type> src_to_spike, cv_to_cell;
 
-    for (auto cell_idx: make_span(ncell)) {
-        for (auto lid: make_span(fvm_info.num_sources[gids[cell_idx]])) {
-            src_to_spike.push_back(cell_idx * max_detector + lid);
+    if (post_events_) {
+        for (auto cell_idx: make_span(ncell)) {
+            for (auto lid: make_span(fvm_info.num_sources[gids[cell_idx]])) {
+                src_to_spike.push_back(cell_idx * max_detector + lid);
+            }
         }
+        src_to_spike.shrink_to_fit();
     }
-    src_to_spike.shrink_to_fit();
     cv_to_cell = D.geometry.cv_to_cell;
 
 

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -479,7 +479,7 @@ fvm_initialization_data fvm_lowered_cell_impl<Backend>::initialize(
 
     auto gj_vector = fvm_gap_junctions(cells, gids, fvm_info.gap_junction_data, rec, D);
 
-    // Fill src_to_spike and cv_to_cell vectors only if mechanisms with post_events implemented are present.
+    // Fill src_to_spike vector only if mechanisms with post_events implemented are present.
     post_events_ = mech_data.post_events;
     auto max_detector = 0;
     if (post_events_) {
@@ -488,15 +488,14 @@ fvm_initialization_data fvm_lowered_cell_impl<Backend>::initialize(
     }
     std::vector<fvm_index_type> src_to_spike, cv_to_cell;
 
-    if (post_events_) {
-        for (auto cell_idx: make_span(ncell)) {
-            for (auto lid: make_span(fvm_info.num_sources[gids[cell_idx]])) {
-                src_to_spike.push_back(cell_idx * max_detector + lid);
-            }
+    for (auto cell_idx: make_span(ncell)) {
+        for (auto lid: make_span(fvm_info.num_sources[gids[cell_idx]])) {
+            src_to_spike.push_back(cell_idx * max_detector + lid);
         }
-        src_to_spike.shrink_to_fit();
-        cv_to_cell = D.geometry.cv_to_cell;
     }
+    src_to_spike.shrink_to_fit();
+    cv_to_cell = D.geometry.cv_to_cell;
+
 
     // Create shared cell state.
     // Shared state vectors should accommodate each mechanism's data alignment requests.
@@ -585,6 +584,7 @@ fvm_initialization_data fvm_lowered_cell_impl<Backend>::initialize(
         }
 
         auto minst = mech_instance(name);
+        minst.mech->dump_stats = config.dump_stats;
         state_->instantiate(*minst.mech, mech_id++, minst.overrides, layout);
         mechptr_by_name[name] = minst.mech.get();
 

--- a/arbor/include/arbor/cable_cell_param.hpp
+++ b/arbor/include/arbor/cable_cell_param.hpp
@@ -176,6 +176,9 @@ struct mechanism_desc {
         return i->second;
     }
 
+    void dump_stats(bool b) { do_dump_stats = b; }
+    bool dump_stats() const { return do_dump_stats; }
+
     const std::unordered_map<std::string, double>& values() const {
         return param_;
     }
@@ -185,6 +188,7 @@ struct mechanism_desc {
 private:
     std::string name_;
     std::unordered_map<std::string, double> param_;
+    bool do_dump_stats = false;
 };
 
 struct ion_reversal_potential_method {

--- a/arbor/include/arbor/mechanism.hpp
+++ b/arbor/include/arbor/mechanism.hpp
@@ -68,6 +68,8 @@ public:
     arb_mechanism_interface iface_;
     arb_mechanism_ppack ppack_;
     arb_value_type** time_ptr_ptr = nullptr;
+
+    bool dump_stats = false;
 };
 
 struct mechanism_layout {

--- a/arbor/include/arbor/mechanism_abi.h
+++ b/arbor/include/arbor/mechanism_abi.h
@@ -27,7 +27,7 @@ typedef uint32_t arb_backend_kind;
 #define arb_backend_kind_cpu 1
 #define arb_backend_kind_gpu 2
 
-inline const char* arb_mechsnism_kind_str(const arb_mechanism_kind& mech) {
+inline const char* arb_mechanism_kind_str(const arb_mechanism_kind& mech) {
     switch (mech) {
         case arb_mechanism_kind_density: return "density mechanism kind";
         case arb_mechanism_kind_point:   return "point mechanism kind";

--- a/doc/python/mechanisms.rst
+++ b/doc/python/mechanisms.rst
@@ -113,6 +113,49 @@ mechanism that is to be painted or placed on the cable cell.
 
        A dictionary of key-value pairs for the parameters.
 
+    .. py:property:: dump_stats
+        :type: bool
+
+        Display discretization level debug info at instantiation. Use **only for
+        debugging discretization**. This is not thread safe and using threads
+        will result in garbled output.
+
+        .. code-block:: Python
+
+          import arbor
+
+          hh = arbor.mechanism('hh')
+          hh.dump_stats = True
+
+        Results in the following output at instantiation time (after pretty
+        printing using `jq`)
+
+        .. code-block:: json
+
+          {
+            "cells": [
+              0,
+              0,
+              0
+            ],
+            "cv": [
+              0,
+              1,
+              2
+            ],
+            "diam": [
+              7.028884301062342,
+              3.0000000000000004,
+              2.9999999999999987
+            ],
+            "id": 0,
+            "kind": "density mechanism kind",
+            "n_cv": 3,
+            "name": "kamt",
+            "width": 3
+          }
+
+        Arrays are per-CV values and output is one block per cell group.
 
 .. py:class:: mechanism_info
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -2,8 +2,9 @@
 
 if(ARB_USE_BUNDLED_JSON)
   add_library(ext-json INTERFACE)
-  target_include_directories(ext-json INTERFACE json/single_include)
+  target_include_directories(ext-json INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/json/single_include)
   set(json_library_name ext-json PARENT_SCOPE)
+  install(TARGETS ext-json EXPORT arbor-targets)
 endif()
 
 # tinyopt command line parsing libary (header-only).

--- a/python/mechanism.cpp
+++ b/python/mechanism.cpp
@@ -100,7 +100,7 @@ void register_mechanisms(pybind11::module& m) {
             "True if a synapse mechanism has a `POST_EVENT` procedure defined.")
         .def_property_readonly("kind",
                 [](const arb::mechanism_info& info) {
-                    return arb_mechsnism_kind_str(info.kind);
+                    return arb_mechanism_kind_str(info.kind);
                 }, "String representation of the kind of the mechanism.")
         .def("__repr__",
                 [](const arb::mechanism_info& inf) {
@@ -228,7 +228,11 @@ void register_mechanisms(pybind11::module& m) {
             [](arb::mechanism_desc& md, std::string name, double value) {
                 md.set(name, value);
             },
-            "name"_a, "value"_a, "Set parameter value.")
+             "name"_a, "value"_a, "Set parameter value.")
+        .def_property("dump_stats",
+                      pybind11::overload_cast<>(&arb::mechanism_desc::dump_stats, pybind11::const_),
+                      pybind11::overload_cast<bool>(&arb::mechanism_desc::dump_stats),
+                      "[Debug] Print CV assignments and assorted statistics.")
         .def_property_readonly("name",
             [](const arb::mechanism_desc& md) {
                 return md.name();


### PR DESCRIPTION
- Add a `dump_stats` field to mechanisms to print out statistics
- Meant for debugging only
- Currently not thread safe due to shared access to `stdout` although best effort by converting to a single string first.

Example
```json
{
  "cells": [
    0,
    0,
    0
  ],
  "cv": [
    0,
    1,
    2
  ],
  "diam": [
    7.0289,
    3.0,
    3.0
  ],
  "id": 0,
  "kind": "density mechanism kind",
  "n_cv": 3,
  "name": "kamt",
  "width": 3
}
```