### PR TITLE
Generate correct simd code for reading `peer_index` and `v_peer`

### DIFF
--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -557,7 +557,7 @@ std::list<index_prop> gather_indexed_vars(const std::vector<LocalVariable*>& ind
             index_prop index_var = {outer_index_var, inner_index_var, d.index_var_kind};
             auto it = std::find(indices.begin(), indices.end(), index_var);
             if (it == indices.end()) {
-                // It an inner index is required, push this index to the end of the list
+                // If an inner index is required, push the outer index_var to the end of the list
                 if (nested) {
                     indices.push_back(index_var);
                 }

--- a/modcc/printer/gpuprinter.cpp
+++ b/modcc/printer/gpuprinter.cpp
@@ -364,13 +364,20 @@ void emit_api_body_cu(std::ostream& out, APIMethod* e, bool is_point_proc, bool 
     for (auto& sym: indexed_vars) {
         auto d = decode_indexed_variable(sym->external_variable());
         if (!d.scalar()) {
-            index_prop node_idx = {d.node_index_var, "tid_"};
-            auto it = std::find(indices.begin(), indices.end(), node_idx);
-            if (it == indices.end()) indices.push_front(node_idx);
-            if (!d.cell_index_var.empty()) {
-                index_prop cell_idx = {d.cell_index_var, index_i_name(d.node_index_var)};
-                auto it = std::find(indices.begin(), indices.end(), cell_idx);
-                if (it == indices.end()) indices.push_back(cell_idx);
+            if (!d.other_index_var.empty()) {
+                index_prop other_idx = {d.other_index_var, "tid_"};
+                auto it = std::find(indices.begin(), indices.end(), other_idx);
+                if (it == indices.end()) indices.push_front(other_idx);
+            }
+            else {
+                index_prop node_idx = {d.node_index_var, "tid_"};
+                auto it = std::find(indices.begin(), indices.end(), node_idx);
+                if (it == indices.end()) indices.push_front(node_idx);
+                if (!d.cell_index_var.empty()) {
+                    index_prop cell_idx = {d.cell_index_var, index_i_name(d.node_index_var)};
+                    auto it = std::find(indices.begin(), indices.end(), cell_idx);
+                    if (it == indices.end()) indices.push_back(cell_idx);
+                }
             }
         }
     }
@@ -419,7 +426,8 @@ namespace {
 
         deref(indexed_variable_info v): v(v) {}
         friend std::ostream& operator<<(std::ostream& o, const deref& wrap) {
-            auto index_var = wrap.v.cell_index_var.empty() ? wrap.v.node_index_var : wrap.v.cell_index_var;
+            auto index_var = !wrap.v.cell_index_var.empty()? wrap.v.cell_index_var:
+                             (!wrap.v.other_index_var.empty()? wrap.v.other_index_var : wrap.v.node_index_var);
             return o << pp_var_pfx << wrap.v.data_var << '['
                      << (wrap.v.scalar()? "0": index_i_name(index_var)) << ']';
         }
@@ -459,7 +467,8 @@ void emit_state_update_cu(std::ostream& out, Symbol* from,
 
         out << pp_var_pfx << "weight[tid_]*" << from->name() << ',';
 
-        auto index_var = d.cell_index_var.empty() ? d.node_index_var : d.cell_index_var;
+        auto index_var = !d.cell_index_var.empty()? d.cell_index_var:
+                         (!d.other_index_var.empty()? d.other_index_var : d.node_index_var);
         out << pp_var_pfx << d.data_var << ", " << index_i_name(index_var) << ", lane_mask_);\n";
     }
     else if (d.accumulate) {

--- a/modcc/printer/gpuprinter.cpp
+++ b/modcc/printer/gpuprinter.cpp
@@ -370,7 +370,7 @@ void emit_api_body_cu(std::ostream& out, APIMethod* e, bool is_point_proc, bool 
             index_prop index_var = {outer_index_var, inner_index_var};
             auto it = std::find(indices.begin(), indices.end(), index_var);
             if (it == indices.end()) {
-                // It an inner index is required, push this index to the end of the list
+                // If an inner index is required, push the outer index_var to the end of the list
                 if (nested) {
                     indices.push_back(index_var);
                 }

--- a/modcc/printer/gpuprinter.cpp
+++ b/modcc/printer/gpuprinter.cpp
@@ -364,19 +364,18 @@ void emit_api_body_cu(std::ostream& out, APIMethod* e, bool is_point_proc, bool 
     for (auto& sym: indexed_vars) {
         auto d = decode_indexed_variable(sym->external_variable());
         if (!d.scalar()) {
-            if (!d.other_index_var.empty()) {
-                index_prop other_idx = {d.other_index_var, "tid_"};
-                auto it = std::find(indices.begin(), indices.end(), other_idx);
-                if (it == indices.end()) indices.push_front(other_idx);
-            }
-            else {
-                index_prop node_idx = {d.node_index_var, "tid_"};
-                auto it = std::find(indices.begin(), indices.end(), node_idx);
-                if (it == indices.end()) indices.push_front(node_idx);
-                if (!d.cell_index_var.empty()) {
-                    index_prop cell_idx = {d.cell_index_var, index_i_name(d.node_index_var)};
-                    auto it = std::find(indices.begin(), indices.end(), cell_idx);
-                    if (it == indices.end()) indices.push_back(cell_idx);
+            auto nested = !d.inner_index_var().empty();
+            auto outer_index_var = d.outer_index_var();
+            auto inner_index_var = nested? index_i_name(d.inner_index_var()): "tid_";
+            index_prop index_var = {outer_index_var, inner_index_var};
+            auto it = std::find(indices.begin(), indices.end(), index_var);
+            if (it == indices.end()) {
+                // It an inner index is required, push this index to the end of the list
+                if (nested) {
+                    indices.push_back(index_var);
+                }
+                else {
+                    indices.push_front(index_var);
                 }
             }
         }
@@ -426,8 +425,7 @@ namespace {
 
         deref(indexed_variable_info v): v(v) {}
         friend std::ostream& operator<<(std::ostream& o, const deref& wrap) {
-            auto index_var = !wrap.v.cell_index_var.empty()? wrap.v.cell_index_var:
-                             (!wrap.v.other_index_var.empty()? wrap.v.other_index_var : wrap.v.node_index_var);
+            auto index_var = wrap.v.outer_index_var();
             return o << pp_var_pfx << wrap.v.data_var << '['
                      << (wrap.v.scalar()? "0": index_i_name(index_var)) << ']';
         }
@@ -467,8 +465,7 @@ void emit_state_update_cu(std::ostream& out, Symbol* from,
 
         out << pp_var_pfx << "weight[tid_]*" << from->name() << ',';
 
-        auto index_var = !d.cell_index_var.empty()? d.cell_index_var:
-                         (!d.other_index_var.empty()? d.other_index_var : d.node_index_var);
+        auto index_var = d.outer_index_var();
         out << pp_var_pfx << d.data_var << ", " << index_i_name(index_var) << ", lane_mask_);\n";
     }
     else if (d.accumulate) {

--- a/modcc/printer/printerutil.cpp
+++ b/modcc/printer/printerutil.cpp
@@ -139,7 +139,8 @@ indexed_variable_info decode_indexed_variable(IndexedVariable* sym) {
         break;
     case sourceKind::peer_voltage:
         v.data_var="vec_v";
-        v.node_index_var = "peer_index";
+        v.other_index_var = "peer_index";
+        v.node_index_var.clear();
         v.readonly = true;
         break;
     case sourceKind::current_density:

--- a/modcc/printer/printerutil.cpp
+++ b/modcc/printer/printerutil.cpp
@@ -121,18 +121,18 @@ PostEventExpression* find_post_event(const Module& m) {
 
 bool indexed_variable_info::scalar() const { return index_var_kind==index_kind::none; }
 
-std::string indexed_variable_info::index_var() const {
-    switch(index_var_kind) {
-    case index_kind::node: return node_index_var;
-    case index_kind::cell: return cell_index_var;
-    case index_kind::other: return other_index_var;
-    default: return {};
-    }
-}
-
-std::string indexed_variable_info::internal_index_var() const {
+std::string indexed_variable_info::inner_index_var() const {
     if (index_var_kind == index_kind::cell) return node_index_var;
     return {};
+}
+
+std::string indexed_variable_info::outer_index_var() const {
+    switch(index_var_kind) {
+        case index_kind::node: return node_index_var;
+        case index_kind::cell: return cell_index_var;
+        case index_kind::other: return other_index_var;
+        default: return {};
+    }
 }
 
 indexed_variable_info decode_indexed_variable(IndexedVariable* sym) {

--- a/modcc/printer/printerutil.cpp
+++ b/modcc/printer/printerutil.cpp
@@ -119,9 +119,26 @@ PostEventExpression* find_post_event(const Module& m) {
     return it==m.symbols().end()? nullptr: it->second->is_post_event();
 }
 
+bool indexed_variable_info::scalar() const { return index_var_kind==index_kind::none; }
+
+std::string indexed_variable_info::index_var() const {
+    switch(index_var_kind) {
+    case index_kind::node: return node_index_var;
+    case index_kind::cell: return cell_index_var;
+    case index_kind::other: return other_index_var;
+    default: return {};
+    }
+}
+
+std::string indexed_variable_info::internal_index_var() const {
+    if (index_var_kind == index_kind::cell) return node_index_var;
+    return {};
+}
+
 indexed_variable_info decode_indexed_variable(IndexedVariable* sym) {
     indexed_variable_info v;
     v.node_index_var = "node_index";
+    v.index_var_kind = index_kind::node;
     v.scale = 1;
     v.accumulate = true;
     v.readonly = true;
@@ -140,7 +157,8 @@ indexed_variable_info decode_indexed_variable(IndexedVariable* sym) {
     case sourceKind::peer_voltage:
         v.data_var="vec_v";
         v.other_index_var = "peer_index";
-        v.node_index_var.clear();
+        v.node_index_var = "";
+        v.index_var_kind = index_kind::other;
         v.readonly = true;
         break;
     case sourceKind::current_density:
@@ -170,6 +188,7 @@ indexed_variable_info decode_indexed_variable(IndexedVariable* sym) {
     case sourceKind::time:
         v.data_var = "vec_t";
         v.cell_index_var = "vec_di";
+        v.index_var_kind = index_kind::cell;
         v.readonly = true;
         break;
     case sourceKind::ion_current_density:
@@ -198,6 +217,7 @@ indexed_variable_info decode_indexed_variable(IndexedVariable* sym) {
     case sourceKind::ion_valence:
         v.data_var = ion_pfx+".ionic_charge";
         v.node_index_var = ""; // scalar global
+        v.index_var_kind = index_kind::none;
         v.readonly = true;
         break;
     case sourceKind::temperature:

--- a/modcc/printer/printerutil.hpp
+++ b/modcc/printer/printerutil.hpp
@@ -128,6 +128,7 @@ struct indexed_variable_info {
     std::string data_var;
     std::string node_index_var;
     std::string cell_index_var;
+    std::string other_index_var;
 
     bool accumulate = true; // true => add with weight_ factor on assignment
     bool readonly = false;  // true => can never be assigned to by a mechanism
@@ -135,7 +136,7 @@ struct indexed_variable_info {
     // Scale is the conversion factor from the data variable
     // to the NMODL value.
     double scale = 1;
-    bool scalar() const { return node_index_var.empty(); }
+    bool scalar() const { return node_index_var.empty() && other_index_var.empty(); }
 };
 
 indexed_variable_info decode_indexed_variable(IndexedVariable* sym);

--- a/modcc/printer/printerutil.hpp
+++ b/modcc/printer/printerutil.hpp
@@ -153,8 +153,8 @@ struct indexed_variable_info {
     // to the NMODL value.
     double scale = 1;
     bool scalar() const;
-    std::string index_var() const;
-    std::string internal_index_var() const;
+    std::string inner_index_var() const;
+    std::string outer_index_var() const;
 };
 
 indexed_variable_info decode_indexed_variable(IndexedVariable* sym);

--- a/modcc/printer/printerutil.hpp
+++ b/modcc/printer/printerutil.hpp
@@ -124,11 +124,27 @@ NetReceiveExpression* find_net_receive(const Module& m);
 
 PostEventExpression* find_post_event(const Module& m);
 
+// For generating vectorized code for reading and writing data sources.
+// node: The data source uses the CV index which is categorized into
+//       one of four constraints to optimize memory accesses.
+// cell: The data source uses the cell index, which is in turn indexed
+//       according to the CV index.
+// other: The data source is indexed according to some other index.
+//        Vector optimizations should be skipped.
+// none: The data source is scalar.
+enum class index_kind {
+    node,
+    cell,
+    other,
+    none
+};
+
 struct indexed_variable_info {
     std::string data_var;
     std::string node_index_var;
     std::string cell_index_var;
     std::string other_index_var;
+    index_kind  index_var_kind;
 
     bool accumulate = true; // true => add with weight_ factor on assignment
     bool readonly = false;  // true => can never be assigned to by a mechanism
@@ -136,7 +152,9 @@ struct indexed_variable_info {
     // Scale is the conversion factor from the data variable
     // to the NMODL value.
     double scale = 1;
-    bool scalar() const { return node_index_var.empty() && other_index_var.empty(); }
+    bool scalar() const;
+    std::string index_var() const;
+    std::string internal_index_var() const;
 };
 
 indexed_variable_info decode_indexed_variable(IndexedVariable* sym);


### PR DESCRIPTION
Use `constraint_category` only when reading/writing data sources indexed by `node_index`. Every other indexed data source assumes that the underlying index belongs to the category `index_constraint::none`. 
Fixes #1734.