### PR TITLE
Add cos and sin SVE implementations

### DIFF
--- a/arbor/include/arbor/simd/sve.hpp
+++ b/arbor/include/arbor/simd/sve.hpp
@@ -691,9 +691,9 @@ auto name(const typename detail::simd_traits<typename detail::sve_type_to_impl<T
 };
 
 
-ARB_PP_FOREACH(ARB_SVE_BINARY_ARITHMETIC_, add, sub, mul, div, pow, max, min, cos, sin)
+ARB_PP_FOREACH(ARB_SVE_BINARY_ARITHMETIC_, add, sub, mul, div, pow, max, min)
 ARB_PP_FOREACH(ARB_SVE_BINARY_ARITHMETIC_, cmp_eq, cmp_neq, cmp_leq, cmp_lt, cmp_geq, cmp_gt, logical_and, logical_or)
-ARB_PP_FOREACH(ARB_SVE_UNARY_ARITHMETIC_, logical_not, neg, abs, exp, log, expm1, exprelr)
+ARB_PP_FOREACH(ARB_SVE_UNARY_ARITHMETIC_, logical_not, neg, abs, exp, log, expm1, exprelr, cos, sin)
 
 #undef ARB_SVE_UNARY_ARITHMETIC_
 #undef ARB_SVE_BINARY_ARITHMETIC_

--- a/arbor/include/arbor/simd/sve.hpp
+++ b/arbor/include/arbor/simd/sve.hpp
@@ -576,6 +576,28 @@ struct sve_double {
         return copy_from(r);
     }
 
+    static svfloat64_t cos(const svfloat64_t& x) {
+        auto len = svlen_f64(x);
+        double a[len], r[len];
+        copy_to(x, a);
+
+        for (unsigned i = 0; i<len; ++i) {
+            r[i] = std::cos(a[i]);
+        }
+        return copy_from(r);
+    }
+
+    static svfloat64_t sin(const svfloat64_t& x) {
+        auto len = svlen_f64(x);
+        double a[len], r[len];
+        copy_to(x, a);
+
+        for (unsigned i = 0; i<len; ++i) {
+            r[i] = std::sin(a[i]);
+        }
+        return copy_from(r);
+    }
+
     static unsigned simd_width(const svfloat64_t& m) {
         return svlen_f64(m);
     }
@@ -669,7 +691,7 @@ auto name(const typename detail::simd_traits<typename detail::sve_type_to_impl<T
 };
 
 
-ARB_PP_FOREACH(ARB_SVE_BINARY_ARITHMETIC_, add, sub, mul, div, pow, max, min)
+ARB_PP_FOREACH(ARB_SVE_BINARY_ARITHMETIC_, add, sub, mul, div, pow, max, min, cos, sin)
 ARB_PP_FOREACH(ARB_SVE_BINARY_ARITHMETIC_, cmp_eq, cmp_neq, cmp_leq, cmp_lt, cmp_geq, cmp_gt, logical_and, logical_or)
 ARB_PP_FOREACH(ARB_SVE_UNARY_ARITHMETIC_, logical_not, neg, abs, exp, log, expm1, exprelr)
 


### PR DESCRIPTION
Add SVE implementations of `sin` and `cos` using `std::sin` and `std::cos` respectively. 
Fixes failing CI on a64fx architectures for vectorized builds.