### PR TITLE
modcc: exit solvers early if errors encountered.

### DIFF
--- a/modcc/solvers.cpp
+++ b/modcc/solvers.cpp
@@ -448,6 +448,7 @@ void SparseSolverVisitor::visit(ConserveExpression *e) {
 }
 
 void SparseSolverVisitor::finalize() {
+    if (has_error()) return;
 
     if (solve_variant_ == solverVariant::steadystate && !conserve_) {
         error({"Conserve statement(s) missing in steady-state solver", {}});
@@ -537,6 +538,8 @@ void LinearSolverVisitor::visit(LinearExpression *e) {
 }
 
 void LinearSolverVisitor::finalize() {
+    if (has_error()) return;
+
     system_.augment(rhs_);
 
     // Reduce the system
@@ -750,6 +753,7 @@ void SparseNonlinearSolverVisitor::visit(AssignmentExpression *e) {
 }
 
 void SparseNonlinearSolverVisitor::finalize() {
+    if (has_error()) return;
 
     // Create rhs of A_
     std::vector<std::string> rhs;


### PR DESCRIPTION
The `finalize` stage of the solvers can throw unhelpful exceptions during the Gauss-Jordan elimination phase. The real, useful  error messages are usually recorded earlier but not propagated to the user. To report back the real errors to the user, don't perform the final stage of the solvers if any errors have already been encountered. 

Fixes #1722.