### PR TITLE
fixes for non-standard code

### DIFF
--- a/arbor/hardware/memory.cpp
+++ b/arbor/hardware/memory.cpp
@@ -15,7 +15,11 @@ namespace hw {
 
 #if defined(__linux__)
 memory_size_type allocated_memory() {
+#if defined(__GLIBC__) && (__GLIBC__ > 2 || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 33)))
+    auto m = mallinfo2();
+#else
     auto m = mallinfo();
+#endif
     return m.hblkhd + m.uordblks;
 }
 #else

--- a/arbor/include/arbor/simd/simd.hpp
+++ b/arbor/include/arbor/simd/simd.hpp
@@ -174,7 +174,7 @@ namespace detail {
         {}
 
         indirect_indexed_expression& operator=(V s) {
-            typename simd_traits<ImplIndex>::scalar_type idx[width];
+            typename simd_traits<ImplIndex>::scalar_type idx[simd_traits<ImplIndex>::width];
             ImplIndex::copy_to(index.value_, idx);
             for (unsigned i = 0; i < width; ++i) {
                 p[idx[i]] = s;
@@ -244,10 +244,10 @@ namespace detail {
         switch (constraint) {
             case index_constraint::none:
             {
-                typename ImplIndex::scalar_type o[width];
+                typename ImplIndex::scalar_type o[simd_traits<ImplIndex>::width];
                 ImplIndex::copy_to(index.value_, o);
 
-                V a[width];
+                V a[simd_traits<Impl>::width];
                 Impl::copy_to(s.value_, a);
 
                 V temp = 0;

--- a/arbor/include/arbor/util/pp_util.hpp
+++ b/arbor/include/arbor/util/pp_util.hpp
@@ -34,7 +34,7 @@
 
 // Implementation macros for ARB_PP_FOREACH:
 
-#define ARB_PP_FOREACH_1_(M, A, ...)  M(A)
+#define ARB_PP_FOREACH_1_(M, A)  M(A)
 #define ARB_PP_FOREACH_2_(M, A, ...)  M(A) ARB_PP_FOREACH_1_(M, __VA_ARGS__)
 #define ARB_PP_FOREACH_3_(M, A, ...)  M(A) ARB_PP_FOREACH_2_(M, __VA_ARGS__)
 #define ARB_PP_FOREACH_4_(M, A, ...)  M(A) ARB_PP_FOREACH_3_(M, __VA_ARGS__)

--- a/arbor/io/trace.hpp
+++ b/arbor/io/trace.hpp
@@ -21,7 +21,7 @@
 //
 // TRACE output is to std::cerr is serialized.
 
-#define TRACE(vars...) arb::impl::debug_emit_trace(__FILE__, __LINE__, #vars, ##vars)
+#define TRACE(...) arb::impl::debug_emit_trace(__FILE__, __LINE__, #__VA_ARGS__, ##__VA_ARGS__)
 
 
 // DEBUG << ...;

--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -109,7 +109,13 @@ using fvm_probe_scratch = std::tuple<std::vector<double>, std::vector<cable_samp
 
 template <typename VoidFn, typename... A>
 void tuple_foreach(VoidFn&& f, std::tuple<A...>& t) {
-    (void)(int []){(f(std::get<A>(t)), 0)...};
+    // executes functions in order (pack expansion)
+    // uses comma operator (unary left fold)
+    // avoids potentially overloaded comma operator (cast to void)
+    std::apply(
+        [g = std::forward<VoidFn>(f)](auto&& ...x){
+            (..., static_cast<void>(g(std::forward<decltype(x)>(x))));},
+        t);
 }
 
 void reserve_scratch(fvm_probe_scratch& scratch, std::size_t n) {

--- a/arbor/s_expr.cpp
+++ b/arbor/s_expr.cpp
@@ -125,6 +125,16 @@ private:
     // Consume and return the next token in the stream.
     void parse() {
         using namespace std::string_literals;
+#define ARB_CASE_LETTERS                                                                           \
+        case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g': case 'h': case 'i':  \
+        case 'j': case 'k': case 'l': case 'm': case 'n': case 'o': case 'p': case 'q': case 'r':  \
+        case 's': case 't': case 'u': case 'v': case 'w': case 'x': case 'y': case 'z':            \
+        case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G': case 'H': case 'I':  \
+        case 'J': case 'K': case 'L': case 'M': case 'N': case 'O': case 'P': case 'Q': case 'R':  \
+        case 'S': case 'T': case 'U': case 'V': case 'W': case 'X': case 'Y': case 'Z':
+#define ARB_CASE_DIGITS                                                                            \
+        case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8':  \
+        case '9':
 
         while (!empty()) {
             switch (*stream_) {
@@ -166,11 +176,10 @@ private:
                 case ')':
                     token_ = {loc(), tok::rparen, {character()}};
                     return;
-                case 'a' ... 'z':
-                case 'A' ... 'Z':
+                ARB_CASE_LETTERS
                     token_ = symbol();
                     return;
-                case '0' ... '9':
+                ARB_CASE_DIGITS
                     token_ = number();
                     return;
                 case '"':
@@ -200,6 +209,8 @@ private:
                     return;
             }
         }
+#undef ARB_CASE_LETTERS
+#undef ARB_CASE_DIGITS
 
         if (!empty()) {
             // todo: handle error: should never hit this

--- a/arborio/asc_lexer.cpp
+++ b/arborio/asc_lexer.cpp
@@ -136,6 +136,16 @@ private:
     // Consume and return the next token in the stream.
     void parse() {
         using namespace std::string_literals;
+#define ARB_CASE_LETTERS                                                                           \
+        case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g': case 'h': case 'i':  \
+        case 'j': case 'k': case 'l': case 'm': case 'n': case 'o': case 'p': case 'q': case 'r':  \
+        case 's': case 't': case 'u': case 'v': case 'w': case 'x': case 'y': case 'z':            \
+        case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G': case 'H': case 'I':  \
+        case 'J': case 'K': case 'L': case 'M': case 'N': case 'O': case 'P': case 'Q': case 'R':  \
+        case 'S': case 'T': case 'U': case 'V': case 'W': case 'X': case 'Y': case 'Z':
+#define ARB_CASE_DIGITS                                                                            \
+        case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8':  \
+        case '9':
 
         while (!empty()) {
             switch (*stream_) {
@@ -177,11 +187,10 @@ private:
                 case ')':
                     token_ = {loc(), tok::rparen, {character()}};
                     return;
-                case 'a' ... 'z':
-                case 'A' ... 'Z':
+                ARB_CASE_LETTERS
                     token_ = symbol();
                     return;
-                case '0' ... '9':
+                ARB_CASE_DIGITS
                     token_ = number();
                     return;
                 case '"':
@@ -225,6 +234,8 @@ private:
                     return;
             }
         }
+#undef ARB_CASE_LETTERS
+#undef ARB_CASE_DIGITS
 
         if (!empty()) {
             token_ = {loc(), tok::error, "Internal lexer error: expected end of input, please open a bug report"s};

--- a/modcc/printer/infoprinter.cpp
+++ b/modcc/printer/infoprinter.cpp
@@ -35,54 +35,55 @@ std::string build_info_header(const Module& m, const printer_options& opt, bool 
                        "#include <{}mechanism_abi.h>\n\n",
                        arb_header_prefix());
 
-    const auto& [state_ids, global_ids, param_ids] = public_variable_ids(m);
-    const auto& assigned_ids = m.assigned_block().parameters;
-    auto fmt_var = [&](const auto& id) {
-        auto lo  = id.has_range() ? id.range.first  : lowest;
-        auto hi  = id.has_range() ? id.range.second : max;
-        auto val = id.has_value() ? id.value        : "NAN";
-        return fmt::format(FMT_COMPILE("{{ \"{}\", \"{}\", {}, {}, {} }}"), id.name(), id.unit_string(), val, lo, hi);
-    };
-
     out << fmt::format("extern \"C\" {{\n"
                        "  arb_mechanism_type make_{0}_{1}() {{\n"
                        "    // Tables\n",
                        std::regex_replace(opt.cpp_namespace, std::regex{"::"}, "_"),
                        name);
-    {
-        io::separator sep("", ",\n                                        ");
-        out << "    static arb_field_info globals[] = { ";
-        for (const auto& var: global_ids) out << sep << fmt_var(var);
-        out << fmt::format(" }};\n"
-                           "    static arb_size_type n_globals = {};\n", global_ids.size());
-    }
-    {
-        io::separator sep("", ",\n                                           ");
-        out << "    static arb_field_info state_vars[] = { ";
-        for (const auto& id: state_ids)    out << sep << fmt_var(id);
-        for (const auto& id: assigned_ids) out << sep << fmt_var(id);
-        out << fmt::format(" }};\n"
-                           "    static arb_size_type n_state_vars = {};\n", assigned_ids.size() + state_ids.size());
-    }
-    {
-        io::separator sep("", ",\n                                           ");
-        out << "    static arb_field_info parameters[] = { ";
-        for (const auto& id: param_ids) out << sep << fmt_var(id);
-        out << fmt::format(" }};\n"
-                           "    static arb_size_type n_parameters = {};\n", param_ids.size());
-    }
-    {
-        io::separator sep("", ",\n");
-        out << "    static arb_ion_info ions[] = { ";
-        for (const auto& ion: m.ion_deps()) out << sep
-                                                << fmt::format(FMT_COMPILE("{{ \"{}\", {}, {}, {}, {}, {}, {}, {} }}"),
-                                                               ion.name,
-                                                               ion.writes_concentration_int(), ion.writes_concentration_ext(),
-                                                               ion.writes_rev_potential(), ion.uses_rev_potential(),
-                                                               ion.uses_valence(), ion.verifies_valence(), ion.expected_valence);
-        out << fmt::format(" }};\n"
-                           "    static arb_size_type n_ions = {};\n", m.ion_deps().size());
-    }
+
+    const auto& [state_ids, global_ids, param_ids] = public_variable_ids(m);
+    const auto& assigned_ids = m.assigned_block().parameters;
+    auto fmt_id = [&](const auto& id) {
+        auto lo  = id.has_range() ? id.range.first  : lowest;
+        auto hi  = id.has_range() ? id.range.second : max;
+        auto val = id.has_value() ? id.value        : "NAN";
+        return fmt::format(FMT_COMPILE("{{ \"{}\", \"{}\", {}, {}, {} }}"), id.name(),
+                id.unit_string(), val, lo, hi);
+    };
+    auto fmt_ion = [&](const auto& ion) {
+        return fmt::format(FMT_COMPILE("{{ \"{}\", {}, {}, {}, {}, {}, {}, {} }}"),
+           ion.name,
+           ion.writes_concentration_int(), ion.writes_concentration_ext(),
+           ion.writes_rev_potential(), ion.uses_rev_potential(),
+           ion.uses_valence(), ion.verifies_valence(), ion.expected_valence);
+    };
+    auto print_array_head = [&](char const * type, char const * name, auto size) {
+        out << "    static " << type;
+        if (size) out << " " << name << "[] = {";
+        else out << "* " << name << " = NULL;";
+    };
+    auto print_array_tail = [&](char const * type, char const * name, auto size) {
+        if (size) out << " };";
+        out << fmt::format("\n    static arb_size_type n_{} = {};\n", name, size);
+    };
+    auto print_array = [&](char const* type, char const * name, auto & fmt_func, auto const & arr) {
+        io::separator sep("", ",\n        ");
+        print_array_head(type, name, arr.size());
+        for (const auto& var: arr) out << sep << fmt_func(var);
+        print_array_tail(type, name, arr.size());
+    };
+    auto print_arrays = [&](char const* type, char const * name, auto & fmt_func, auto const & arr0, auto const & arr1) {
+        io::separator sep("", ",\n        ");
+        print_array_head(type, name, arr0.size() + arr1.size());
+        for (const auto& var: arr0) out << sep << fmt_func(var);
+        for (const auto& var: arr1) out << sep << fmt_func(var);
+        print_array_tail(type, name, arr0.size() + arr1.size());
+    };
+
+    print_array("arb_field_info", "globals", fmt_id, global_ids);
+    print_arrays("arb_field_info", "state_vars", fmt_id, state_ids, assigned_ids);
+    print_array("arb_field_info", "parameters", fmt_id, param_ids);
+    print_array("arb_ion_info", "ions", fmt_ion, m.ion_deps());
 
     out << fmt::format(FMT_COMPILE("\n"
                                    "    arb_mechanism_type result;\n"


### PR DESCRIPTION
I noticed various non-standards compliant code when compiled with elevated warning levels (-Wall -Wpedantic). Here is a list of the problems I addressed:

**preprocessor**
- expansion of empty `__VA_ARGS__` in `ARB_PP_FOREACH`
- named variadic macro arguments in `TRACE` macro

**glibc** 
- deprecated `mallinfo` call for newer glibc versions

**simd**
- non-const C-array sizes

**modcc**
- generation of C-arrays of size 0

**switch/case**
- switch-case ranges

**tuple_foreach**
- compound literals