### PR TITLE
Bug fix: properly partition networks containing one-sided gap-junction connections

### DIFF
--- a/arbor/communication/dry_run_context.cpp
+++ b/arbor/communication/dry_run_context.cpp
@@ -71,7 +71,7 @@ struct dry_run_context_impl {
     }
 
     std::vector<std::vector<cell_gid_type>>
-    gather_connections(const std::vector<std::vector<cell_gid_type>> & local_connections) const {
+    gather_gj_connections(const std::vector<std::vector<cell_gid_type>> & local_connections) const {
         auto local_size = local_connections.size();
         std::vector<std::vector<cell_gid_type>> global_connections;
         global_connections.reserve(local_size*num_ranks_);
@@ -82,11 +82,12 @@ struct dry_run_context_impl {
 
         for (unsigned i = 0; i < num_ranks_; i++) {
             for (unsigned j = i*local_size; j < (i+1)*local_size; j++){
-                for (auto& conn: global_connections[j]) {
-                    conn += num_cells_per_tile_*i;
+                for (auto& conn_gid: global_connections[j]) {
+                    conn_gid += num_cells_per_tile_*i;
                 }
             }
         }
+        return global_connections;
     }
 
     cell_label_range gather_cell_label_range(const cell_label_range& local_ranges) const {

--- a/arbor/communication/dry_run_context.cpp
+++ b/arbor/communication/dry_run_context.cpp
@@ -70,6 +70,19 @@ struct dry_run_context_impl {
         return gathered_vector<cell_gid_type>(std::move(gathered_gids), std::move(partition));
     }
 
+    std::vector<std::vector<cell_gid_type>> gather_connections(const std::vector<std::vector<cell_gid_type>> & local_connections) const {
+        std::vector<std::vector<cell_gid_type>> global_connections;
+        for (unsigned i = 0; i < num_ranks_; i++) {
+            auto copy = local_connections;
+            for (auto& v: copy) {
+                for (auto& gid: v) {
+                    gid += i*num_cells_per_tile_;
+                }
+            }
+            global_connections.insert(global_connections.end(), copy.begin(), copy.end());
+        }
+    }
+
     cell_label_range gather_cell_label_range(const cell_label_range& local_ranges) const {
         cell_label_range global_ranges;
         for (unsigned i = 0; i < num_ranks_; i++) {

--- a/arbor/communication/mpi_context.cpp
+++ b/arbor/communication/mpi_context.cpp
@@ -40,7 +40,7 @@ struct mpi_context_impl {
     }
 
     std::vector<std::vector<cell_gid_type>>
-    gather_connections(const std::vector<std::vector<cell_gid_type>>& local_connections) const {
+    gather_gj_connections(const std::vector<std::vector<cell_gid_type>>& local_connections) const {
         return mpi::gather_all(local_connections, comm_);
     }
 

--- a/arbor/communication/mpi_context.cpp
+++ b/arbor/communication/mpi_context.cpp
@@ -39,6 +39,11 @@ struct mpi_context_impl {
         return mpi::gather_all_with_partition(local_gids, comm_);
     }
 
+    std::vector<std::vector<cell_gid_type>>
+    gather_connections(const std::vector<std::vector<cell_gid_type>>& local_connections) const {
+        return mpi::gather_all(local_connections, comm_);
+    }
+
     cell_label_range gather_cell_label_range(const cell_label_range& local_ranges) const {
         std::vector<cell_size_type> sizes;
         std::vector<cell_tag_type> labels;

--- a/arbor/distributed_context.hpp
+++ b/arbor/distributed_context.hpp
@@ -44,7 +44,7 @@ class distributed_context {
 public:
     using spike_vector = std::vector<arb::spike>;
     using gid_vector = std::vector<cell_gid_type>;
-    using connection_vector = std::vector<gid_vector>;
+    using gj_connection_vector = std::vector<gid_vector>;
 
     // default constructor uses a local context: see below.
     distributed_context();
@@ -65,8 +65,8 @@ public:
         return impl_->gather_gids(local_gids);
     }
 
-    connection_vector gather_connections(const connection_vector& local_connections) const {
-        return impl_->gather_connections(local_connections);
+    gj_connection_vector gather_gj_connections(const gj_connection_vector& local_connections) const {
+        return impl_->gather_gj_connections(local_connections);
     }
 
     cell_label_range gather_cell_label_range(const cell_label_range& local_ranges) const {
@@ -105,8 +105,8 @@ private:
             gather_spikes(const spike_vector& local_spikes) const = 0;
         virtual gathered_vector<cell_gid_type>
             gather_gids(const gid_vector& local_gids) const = 0;
-        virtual connection_vector
-            gather_connections(const connection_vector& local_connections) const = 0;
+        virtual gj_connection_vector
+            gather_gj_connections(const gj_connection_vector& local_connections) const = 0;
         virtual cell_label_range
             gather_cell_label_range(const cell_label_range& local_ranges) const = 0;
         virtual cell_labels_and_gids
@@ -137,8 +137,8 @@ private:
             return wrapped.gather_gids(local_gids);
         }
         std::vector<std::vector<cell_gid_type>>
-        gather_connections(const connection_vector& local_connections) const override {
-            return wrapped.gather_connections(local_connections);
+        gather_gj_connections(const gj_connection_vector& local_connections) const override {
+            return wrapped.gather_gj_connections(local_connections);
         }
         cell_label_range
         gather_cell_label_range(const cell_label_range& local_ranges) const override {
@@ -191,7 +191,7 @@ struct local_context {
         );
     }
     std::vector<std::vector<cell_gid_type>>
-    gather_connections(const std::vector<std::vector<cell_gid_type>>& local_connections) const {
+    gather_gj_connections(const std::vector<std::vector<cell_gid_type>>& local_connections) const {
         return local_connections;
     }
     cell_label_range

--- a/arbor/distributed_context.hpp
+++ b/arbor/distributed_context.hpp
@@ -44,6 +44,7 @@ class distributed_context {
 public:
     using spike_vector = std::vector<arb::spike>;
     using gid_vector = std::vector<cell_gid_type>;
+    using connection_vector = std::vector<gid_vector>;
 
     // default constructor uses a local context: see below.
     distributed_context();
@@ -62,6 +63,10 @@ public:
 
     gathered_vector<cell_gid_type> gather_gids(const gid_vector& local_gids) const {
         return impl_->gather_gids(local_gids);
+    }
+
+    connection_vector gather_connections(const connection_vector& local_connections) const {
+        return impl_->gather_connections(local_connections);
     }
 
     cell_label_range gather_cell_label_range(const cell_label_range& local_ranges) const {
@@ -100,6 +105,8 @@ private:
             gather_spikes(const spike_vector& local_spikes) const = 0;
         virtual gathered_vector<cell_gid_type>
             gather_gids(const gid_vector& local_gids) const = 0;
+        virtual connection_vector
+            gather_connections(const connection_vector& local_connections) const = 0;
         virtual cell_label_range
             gather_cell_label_range(const cell_label_range& local_ranges) const = 0;
         virtual cell_labels_and_gids
@@ -128,6 +135,10 @@ private:
         gathered_vector<cell_gid_type>
         gather_gids(const gid_vector& local_gids) const override {
             return wrapped.gather_gids(local_gids);
+        }
+        std::vector<std::vector<cell_gid_type>>
+        gather_connections(const connection_vector& local_connections) const override {
+            return wrapped.gather_connections(local_connections);
         }
         cell_label_range
         gather_cell_label_range(const cell_label_range& local_ranges) const override {
@@ -178,6 +189,10 @@ struct local_context {
                 std::vector<cell_gid_type>(local_gids),
                 {0u, static_cast<count_type>(local_gids.size())}
         );
+    }
+    std::vector<std::vector<cell_gid_type>>
+    gather_connections(const std::vector<std::vector<cell_gid_type>>& local_connections) const {
+        return local_connections;
     }
     cell_label_range
     gather_cell_label_range(const cell_label_range& local_ranges) const {

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -126,7 +126,7 @@ domain_decomposition partition_load_balance(
                     cg.push_back(element);
                     // Adjacency list
                     auto conns = global_gj_connection_table[element];
-                    for (auto peer: conns) {
+                    for (const auto& peer: conns) {
                         if (!visited.count(peer)) {
                             visited.insert(peer);
                             q.push(peer);

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -71,10 +71,11 @@ domain_decomposition partition_load_balance(
     // Global connection table
 
     // Generate a local connection table and communicate with other ranks
-    std::vector<std::vector<cell_gid_type>> local_connection_table(gid_part[domain_id].second-gid_part[domain_id].first);
+    const auto dom_range = gid_part[domain_id];
+    std::vector<std::vector<cell_gid_type>> local_connection_table(dom_range.second-dom_range.first);
     for (auto gid: make_span(gid_part[domain_id])) {
-        for (auto c: rec.gap_junctions_on(gid)) {
-            local_connection_table[gid].push_back(c.peer.gid);
+        for (const auto& c: rec.gap_junctions_on(gid)) {
+            local_connection_table[gid-dom_range.first].push_back(c.peer.gid);
         }
     }
     // Sort per cell connections

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
@@ -68,32 +67,34 @@ domain_decomposition partition_load_balance(
     auto gid_part = make_partition(
         gid_divisions, transform_view(make_span(num_domains), dom_size));
 
-    // Global connection table
+    // Global gj_connection table
 
-    // Generate a local connection table and communicate with other ranks
+    // Generate a local gj_connection table.
+    // The table is indexed by the index of the target gid in the gid_part of that domain.
+    // If gid_part[domain_id] = [a, b[; local_gj_connection of gid `x` is at index `x-a`.
     const auto dom_range = gid_part[domain_id];
-    std::vector<std::vector<cell_gid_type>> local_connection_table(dom_range.second-dom_range.first);
+    std::vector<std::vector<cell_gid_type>> local_gj_connection_table(dom_range.second-dom_range.first);
     for (auto gid: make_span(gid_part[domain_id])) {
         for (const auto& c: rec.gap_junctions_on(gid)) {
-            local_connection_table[gid-dom_range.first].push_back(c.peer.gid);
+            local_gj_connection_table[gid-dom_range.first].push_back(c.peer.gid);
         }
     }
-    // Sort per cell connections
-    for (auto& gid_conns: local_connection_table) {
+    // Sort the inner vectors of gj_connections.
+    for (auto& gid_conns: local_gj_connection_table) {
         util::sort(gid_conns);
     }
 
-    // Gather global connection table
-    // Assumes that the cells are assigned to ranks consecutively both within a rank and across ranks
-    auto global_connection_table = ctx->distributed->gather_connections(local_connection_table);
+    // Gather the global gj_connection table.
+    // The global gj_connection table after gathering is indexed by gid.
+    auto global_gj_connection_table = ctx->distributed->gather_gj_connections(local_gj_connection_table);
 
-    // Make all connections bidirectional
-    for (auto gid: make_span(global_connection_table.size())) {
-        const auto& local_conns = global_connection_table[gid];
+    // Modify the global gj_connection table to make all gj_connections bidirectional.
+    for (auto gid: make_span(global_gj_connection_table.size())) {
+        const auto& local_conns = global_gj_connection_table[gid];
         for (auto peer: local_conns) {
-            auto& peer_conns = global_connection_table[peer];
+            auto& peer_conns = global_gj_connection_table[peer];
             // If gid is not in the peer connection table insert it such that
-            // the vector remains sorted
+            // the vector remains sorted.
             auto it = std::lower_bound(peer_conns.begin(), peer_conns.end(), gid);
             if (it == peer_conns.end() || *it != gid) {
                 peer_conns.insert(it, gid);
@@ -112,7 +113,7 @@ domain_decomposition partition_load_balance(
     // Connected components algorithm using BFS
     std::queue<cell_gid_type> q;
     for (auto gid: make_span(gid_part[domain_id])) {
-        if (!global_connection_table[gid].empty()) {
+        if (!global_gj_connection_table[gid].empty()) {
             // If cell hasn't been visited yet, must belong to new super_cell
             // Perform BFS starting from that cell
             if (!visited.count(gid)) {
@@ -124,7 +125,7 @@ domain_decomposition partition_load_balance(
                     q.pop();
                     cg.push_back(element);
                     // Adjacency list
-                    auto conns = global_connection_table[element];
+                    auto conns = global_gj_connection_table[element];
                     for (auto peer: conns) {
                         if (!visited.count(peer)) {
                             visited.insert(peer);

--- a/test/unit-distributed/test_domain_decomposition.cpp
+++ b/test/unit-distributed/test_domain_decomposition.cpp
@@ -140,12 +140,27 @@ namespace {
         }
 
         std::vector<gap_junction_connection> gap_junctions_on(cell_gid_type gid) const override {
+            // Example topology on 4 ranks of 4 cells each
+            // Fully connected             Not fully connected
+            // 0  1  2  3                  0  1  2  3
+            // ^                           |
+            // |                           |
+            // v                           v
+            // 4  5  6  7                  4  5  6  7
+            //    ^                           |
+            //    |                           |
+            //    v                           v
+            // 8  9  10 11                 8  9  10 11
+            //       ^                           |
+            //       |                           |
+            //       v                           v
+            // 12 13 14 15                 12 13 14 15
             unsigned group = gid/groups_;
             unsigned id = gid%size_;
-            if (id == group && group != (groups_ - 1)) {
+            if (id == group && group != (groups_ - 1) && fully_connected_) {
                 return {gap_junction_connection({gid + size_, "gj"}, {"gj"}, 0.1)};
             }
-            else if (id == group - 1 && fully_connected_) {
+            else if (id == group - 1) {
                 return {gap_junction_connection({gid - size_, "gj"}, {"gj"}, 0.1)};
             }
             else {
@@ -178,6 +193,17 @@ namespace {
         }
 
         std::vector<gap_junction_connection> gap_junctions_on(cell_gid_type gid) const override {
+            // Example topology on 4 ranks of 4 cells each
+            // 0  1  2  3
+            //    |
+            //    v
+            // 4  5  6  7
+            //    |
+            //    v
+            // 8  9  10 11
+            //    |
+            //    v
+            // 12 13 14 15
             unsigned group = gid/groups_;
             unsigned id = gid%size_;
             if (group!= 0 && id == 1) {

--- a/test/unit-distributed/test_domain_decomposition.cpp
+++ b/test/unit-distributed/test_domain_decomposition.cpp
@@ -323,7 +323,7 @@ TEST(domain_decomposition, symmetric_groups)
         const auto D0 = partition_load_balance(R, ctx);
         EXPECT_EQ(6u, D0.groups.size());
 
-        unsigned shift = rank * R.num_cells() / nranks;
+        unsigned shift = rank * R.num_cells()/nranks;
         std::vector<std::vector<cell_gid_type>> expected_groups0 =
                 {{0 + shift},
                  {3 + shift},
@@ -337,9 +337,9 @@ TEST(domain_decomposition, symmetric_groups)
             EXPECT_EQ(expected_groups0[i], D0.groups[i].gids);
         }
 
-        unsigned cells_per_rank = R.num_cells() / nranks;
+        unsigned cells_per_rank = R.num_cells()/nranks;
         for (unsigned i = 0; i < R.num_cells(); i++) {
-            EXPECT_EQ(i / cells_per_rank, (unsigned) D0.gid_domain(i));
+            EXPECT_EQ(i/cells_per_rank, (unsigned) D0.gid_domain(i));
         }
 
         // Test different group_hints
@@ -357,10 +357,10 @@ TEST(domain_decomposition, symmetric_groups)
         EXPECT_EQ(expected_groups1, D1.groups[0].gids);
 
         for (unsigned i = 0; i < R.num_cells(); i++) {
-            EXPECT_EQ(i / cells_per_rank, (unsigned) D1.gid_domain(i));
+            EXPECT_EQ(i/cells_per_rank, (unsigned) D1.gid_domain(i));
         }
 
-        hints[cell_kind::cable].cpu_group_size = cells_per_rank / 2;
+        hints[cell_kind::cable].cpu_group_size = cells_per_rank/2;
         hints[cell_kind::cable].prefer_gpu = false;
 
         const auto D2 = partition_load_balance(R, ctx, hints);
@@ -374,7 +374,7 @@ TEST(domain_decomposition, symmetric_groups)
             EXPECT_EQ(expected_groups2[i], D2.groups[i].gids);
         }
         for (unsigned i = 0; i < R.num_cells(); i++) {
-            EXPECT_EQ(i / cells_per_rank, (unsigned) D2.gid_domain(i));
+            EXPECT_EQ(i/cells_per_rank, (unsigned) D2.gid_domain(i));
         }
     }
 }

--- a/test/unit-distributed/test_mpi.cpp
+++ b/test/unit-distributed/test_mpi.cpp
@@ -58,6 +58,40 @@ TEST(mpi, gather_all) {
     EXPECT_EQ(expected, gathered);
 }
 
+TEST(mpi, gather_all_nested_vec) {
+    int id = mpi::rank(MPI_COMM_WORLD);
+    int size = mpi::size(MPI_COMM_WORLD);
+
+    std::vector<std::vector<big_thing>> data;
+    if (id%2) {
+        for (int s = 0; s < (id+1)*2; s++) {
+            data.push_back({id + s, id + s + 7, id + s + 8});
+        }
+    }
+    else {
+        for (int s = 0; s < (id+1)*2; s++) {
+            data.push_back({id + 2*s});
+        }
+    }
+
+    std::vector<std::vector<big_thing>> expected;
+    for (int i = 0; i<size; ++i) {
+        if (i%2) {
+            for (int s = 0; s < (i+1)*2; s++) {
+                expected.push_back({i + s, i + s + 7, i + s + 8});
+            }
+        }
+        else {
+            for (int s = 0; s < (i+1)*2; s++) {
+                expected.push_back({i + 2*s});
+            }
+        }
+    }
+
+    auto gathered = mpi::gather_all(data, MPI_COMM_WORLD);
+    EXPECT_EQ(expected, gathered);
+}
+
 TEST(mpi, gather_all_with_partition) {
     int id = mpi::rank(MPI_COMM_WORLD);
     int size = mpi::size(MPI_COMM_WORLD);

--- a/test/unit/test_domain_decomposition.cpp
+++ b/test/unit/test_domain_decomposition.cpp
@@ -60,7 +60,7 @@ namespace {
 
     class gap_recipe: public recipe {
     public:
-        gap_recipe() {}
+        gap_recipe(bool full_connected): fully_connected_(full_connected) {}
 
         cell_size_type num_cells() const override {
             return size_;
@@ -77,46 +77,72 @@ namespace {
         }
         std::vector<gap_junction_connection> gap_junctions_on(cell_gid_type gid) const override {
             switch (gid) {
-                case 0 :  return {
-                    gap_junction_connection({13, "gj"}, {"gj"}, 0.1)
-                };
-                case 2 :  return {
-                    gap_junction_connection({7,  "gj"}, {"gj"}, 0.1),
-                    gap_junction_connection({11, "gj"}, {"gj"}, 0.1)
-                };
-                case 3 :  return {
-                    gap_junction_connection({4, "gj"}, {"gj"}, 0.1),
-                    gap_junction_connection({8, "gj"}, {"gj"}, 0.1)
-                };
-                case 4 :  return {
-                    gap_junction_connection({3, "gj"}, {"gj"}, 0.1),
-                    gap_junction_connection({8, "gj"}, {"gj"}, 0.1),
-                    gap_junction_connection({9, "gj"}, {"gj"}, 0.1)
-                };
-                case 7 :  return {
-                    gap_junction_connection({2,  "gj"}, {"gj"}, 0.1),
-                    gap_junction_connection({11, "gj"}, {"gj"}, 0.1)
-                };;
-                case 8 :  return {
-                    gap_junction_connection({3, "gj"}, {"gj"}, 0.1),
-                    gap_junction_connection({4, "gj"}, {"gj"}, 0.1)
-                };;
-                case 9 :  return {
-                    gap_junction_connection({4, "gj"}, {"gj"}, 0.1)
-                };
-                case 11 : return {
-                    gap_junction_connection({2, "gj"}, {"gj"}, 0.1),
-                    gap_junction_connection({7, "gj"}, {"gj"}, 0.1)
-                };
-                case 13 : return {
-                    gap_junction_connection({0, "gj"}, {"gj"}, 0.1)
-                };
-                default : return {};
+                case 0:  return {gap_junction_connection({13, "gj"}, {"gj"}, 0.1)};
+                case 2:  return {gap_junction_connection({7,  "gj"}, {"gj"}, 0.1)};
+                case 3:  return {gap_junction_connection({8, "gj"}, {"gj"}, 0.1)};
+                case 4: {
+                    if (!fully_connected_) return {gap_junction_connection({9, "gj"}, {"gj"}, 0.1)};
+                    return {
+                        gap_junction_connection({8, "gj"}, {"gj"}, 0.1),
+                        gap_junction_connection({9, "gj"}, {"gj"}, 0.1)
+                    };
+                }
+                case 7: {
+                    if (!fully_connected_) return {};
+                    return {
+                        gap_junction_connection({2, "gj"}, {"gj"}, 0.1),
+                        gap_junction_connection({11, "gj"}, {"gj"}, 0.1)
+                    };
+                }
+                case 8: {
+                    if (!fully_connected_) return {gap_junction_connection({4, "gj"}, {"gj"}, 0.1)};
+                    return {
+                        gap_junction_connection({3, "gj"}, {"gj"}, 0.1),
+                        gap_junction_connection({4, "gj"}, {"gj"}, 0.1)
+                    };
+                }
+                case 9: {
+                    if (!fully_connected_) return {};
+                    return {gap_junction_connection({4, "gj"}, {"gj"}, 0.1)};
+                }
+                case 11: return {gap_junction_connection({7, "gj"}, {"gj"}, 0.1)};
+                case 13: {
+                    if (!fully_connected_) return {};
+                    return { gap_junction_connection({0, "gj"}, {"gj"}, 0.1)};
+                }
+                default: return {};
             }
         }
 
     private:
+        bool fully_connected_ = true;
         cell_size_type size_ = 15;
+    };
+
+    class custom_gap_recipe: public recipe {
+    public:
+        custom_gap_recipe(cell_size_type ncells, std::vector<std::vector<gap_junction_connection>> gj_conns):
+        size_(ncells), gj_conns_(std::move(gj_conns)){}
+
+        cell_size_type num_cells() const override {
+            return size_;
+        }
+
+        arb::util::unique_any get_cell_description(cell_gid_type) const override {
+            auto c = arb::make_cell_soma_only(false);
+            c.decorations.place(mlocation{0,1}, junction("gj"), "gj");
+            return {arb::cable_cell(c)};
+        }
+
+        cell_kind get_cell_kind(cell_gid_type gid) const override {
+            return cell_kind::cable;
+        }
+        std::vector<gap_junction_connection> gap_junctions_on(cell_gid_type gid) const override {
+            return gj_conns_[gid];
+        }
+    private:
+        cell_size_type size_ = 7;
+        std::vector<std::vector<gap_junction_connection>> gj_conns_;
     };
 }
 
@@ -316,48 +342,119 @@ TEST(domain_decomposition, hints) {
     EXPECT_EQ(expected_ss_groups, ss_groups);
 }
 
-TEST(domain_decomposition, compulsory_groups)
-{
+TEST(domain_decomposition, gj_recipe) {
     proc_allocation resources;
     resources.num_threads = 1;
     resources.gpu_id = -1; // disable GPU if available
     auto ctx = make_context(resources);
 
-    auto R = gap_recipe();
-    const auto D0 = partition_load_balance(R, ctx);
-    EXPECT_EQ(9u, D0.groups.size());
+    auto recipes = {gap_recipe(false), gap_recipe(true)};
+    for (const auto& R: recipes) {
+        const auto D0 = partition_load_balance(R, ctx);
+        EXPECT_EQ(9u, D0.groups.size());
 
-    std::vector<std::vector<cell_gid_type>> expected_groups0 =
-            { {1}, {5}, {6}, {10}, {12}, {14}, {0, 13}, {2, 7, 11}, {3, 4, 8, 9} };
+        std::vector<std::vector<cell_gid_type>> expected_groups0 =
+            {{1}, {5}, {6}, {10}, {12}, {14}, {0, 13}, {2, 7, 11}, {3, 4, 8, 9}};
 
-    for (unsigned i = 0; i < 9u; i++) {
-        EXPECT_EQ(expected_groups0[i], D0.groups[i].gids);
+        for (unsigned i = 0; i < 9u; i++) {
+            EXPECT_EQ(expected_groups0[i], D0.groups[i].gids);
+        }
+
+        // Test different group_hints
+        partition_hint_map hints;
+        hints[cell_kind::cable].cpu_group_size = 3;
+        hints[cell_kind::cable].prefer_gpu = false;
+
+        const auto D1 = partition_load_balance(R, ctx, hints);
+        EXPECT_EQ(5u, D1.groups.size());
+
+         std::vector<std::vector<cell_gid_type>> expected_groups1 =
+            {{1, 5, 6}, {10, 12, 14}, {0, 13}, {2, 7, 11}, {3, 4, 8, 9}};
+
+        for (unsigned i = 0; i < 5u; i++) {
+            EXPECT_EQ(expected_groups1[i], D1.groups[i].gids);
+        }
+
+        hints[cell_kind::cable].cpu_group_size = 20;
+        hints[cell_kind::cable].prefer_gpu = false;
+
+        const auto D2 = partition_load_balance(R, ctx, hints);
+        EXPECT_EQ(1u, D2.groups.size());
+
+        std::vector<cell_gid_type> expected_groups2 =
+            {1, 5, 6, 10, 12, 14, 0, 13, 2, 7, 11, 3, 4, 8, 9};
+
+        EXPECT_EQ(expected_groups2, D2.groups[0].gids);
     }
+}
 
-    // Test different group_hints
-    partition_hint_map hints;
-    hints[cell_kind::cable].cpu_group_size = 3;
-    hints[cell_kind::cable].prefer_gpu = false;
+TEST(domain_decomposition, unidirectional_gj_recipe) {
+    proc_allocation resources;
+    resources.num_threads = 1;
+    resources.gpu_id = -1;
+    auto ctx = make_context(resources);
+    {
+        std::vector<std::vector<gap_junction_connection>> gj_conns =
+            {
+                {gap_junction_connection({1, "gj"}, {"gj"}, 0.1)},
+                {},
+                {gap_junction_connection({4, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({0, "gj"}, {"gj"}, 0.1), gap_junction_connection({5, "gj"}, {"gj"}, 0.1)},
+                {},
+                {gap_junction_connection({4, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({4, "gj"}, {"gj"}, 0.1)}
+            };
+        auto R = custom_gap_recipe(gj_conns.size(), gj_conns);
+        const auto D = partition_load_balance(R, ctx);
+        std::vector<cell_gid_type> expected_group = {0, 1, 2, 3, 4, 5, 6};
 
-    const auto D1 = partition_load_balance(R, ctx, hints);
-    EXPECT_EQ(5u, D1.groups.size());
-
-    std::vector<std::vector<cell_gid_type>> expected_groups1 =
-            { {1, 5, 6}, {10, 12, 14}, {0, 13}, {2, 7, 11}, {3, 4, 8, 9} };
-
-    for (unsigned i = 0; i < 5u; i++) {
-        EXPECT_EQ(expected_groups1[i], D1.groups[i].gids);
+        EXPECT_EQ(1u, D.groups.size());
+        EXPECT_EQ(expected_group, D.groups[0].gids);
     }
+    {
+        std::vector<std::vector<gap_junction_connection>> gj_conns =
+            {
+                {},
+                {gap_junction_connection({3, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({0, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({0, "gj"}, {"gj"}, 0.1), gap_junction_connection({1, "gj"}, {"gj"}, 0.1)},
+                {},
+                {gap_junction_connection({4, "gj"}, {"gj"}, 0.1)},
+                {},
+                {gap_junction_connection({9, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({7, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({8, "gj"}, {"gj"}, 0.1)}
+            };
+        auto R = custom_gap_recipe(gj_conns.size(), gj_conns);
+        const auto D = partition_load_balance(R, ctx);
+        std::vector<std::vector<cell_gid_type>> expected_groups = {{6}, {0, 1, 2, 3}, {4, 5}, {7, 8, 9}};
 
-    hints[cell_kind::cable].cpu_group_size = 20;
-    hints[cell_kind::cable].prefer_gpu = false;
+        EXPECT_EQ(expected_groups.size(), D.groups.size());
+        for (unsigned i=0; i < expected_groups.size(); ++i) {
+            EXPECT_EQ(expected_groups[i], D.groups[i].gids);
+        }
+    }
+    {
+        std::vector<std::vector<gap_junction_connection>> gj_conns =
+            {
+                {},
+                {},
+                {},
+                {gap_junction_connection({4, "gj"}, {"gj"}, 0.1)},
+                {},
+                {},
+                {gap_junction_connection({5, "gj"}, {"gj"}, 0.1), gap_junction_connection({7, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({5, "gj"}, {"gj"}, 0.1), gap_junction_connection({4, "gj"}, {"gj"}, 0.1)},
+                {gap_junction_connection({0, "gj"}, {"gj"}, 0.1)},
+                {}
+            };
+        auto R = custom_gap_recipe(gj_conns.size(), gj_conns);
+        const auto D = partition_load_balance(R, ctx);
+        std::vector<std::vector<cell_gid_type>> expected_groups = {{1}, {2}, {9}, {0, 8}, {3, 4, 5, 6, 7}};
 
-    const auto D2 = partition_load_balance(R, ctx, hints);
-    EXPECT_EQ(1u, D2.groups.size());
-
-    std::vector<cell_gid_type> expected_groups2 =
-            { 1, 5, 6, 10, 12, 14, 0, 13, 2, 7, 11, 3, 4, 8, 9 };
-
-    EXPECT_EQ(expected_groups2, D2.groups[0].gids);
-
+        EXPECT_EQ(expected_groups.size(), D.groups.size());
+        for (unsigned i=0; i < expected_groups.size(); ++i) {
+            EXPECT_EQ(expected_groups[i], D.groups[i].gids);
+        }
+    }
 }


### PR DESCRIPTION
The current `partition_load_balance` function assumes that gap-junction connections are always double-sided (i.e. if gid `x` has a gap-junction connection from peer gid `y`, then gid `y` must also have a gap-junction connection from peer gid `x`). This used to be a requirement that was checked prior to #1682. Since then, single-sided gap-junctions are in principle allowed, but `partition_load_balance` still operates under the bidirectional gap-junction connection assumption resulting in some gids being present in multiple cell-groups. 
This PR modifies the `partition_load_balance` function to do the following: 
1. On each rank, generate a gj_connection list per cell. (gj_connection list is a vector of gids that have an outgoing connection ending at the cell under consideration). 
2. On each rank, gather all the gj_connection lists for each cell in the network. 
3. On each rank, modify the global list of gj_connections in the network to make all gj_connections bidirectional. 
4. On each rank, use the global list of gj_connections in the network to partition the graph. 

Fixes #1767.