### PR TITLE
Fix cmake configuration of out-of-core fmt library

### DIFF
--- a/modcc/CMakeLists.txt
+++ b/modcc/CMakeLists.txt
@@ -31,19 +31,18 @@ set(modcc_sources modcc.cpp)
 
 add_library(libmodcc STATIC ${libmodcc_sources})
 target_include_directories(libmodcc PUBLIC .)
-target_include_directories(libmodcc PRIVATE ../ext/fmt/include)
+if (ARB_USE_BUNDLED_FMT)
+    target_include_directories(libmodcc PRIVATE ../ext/fmt/include)
+    target_compile_definitions(libmodcc PRIVATE FMT_HEADER_ONLY)
+else ()
+    find_package(fmt REQUIRED)
+    target_link_libraries(libmodcc PRIVATE fmt::fmt-header-only)
+endif ()
 
 set_target_properties(libmodcc PROPERTIES OUTPUT_NAME modcc)
 
-
 add_executable(modcc ${modcc_sources})
 target_link_libraries(modcc PRIVATE libmodcc ext-tinyopt)
-if (ARB_USE_BUNDLED_FMT)
-    target_include_directories(modcc PRIVATE ../ext/fmt/include)
-else ()
-    find_package(fmt)
-    target_link_libraries(modcc PRIVATE fmt::fmt-header-only)
-endif ()
 set_target_properties(modcc libmodcc PROPERTIES EXCLUDE_FROM_ALL ${ARB_WITH_EXTERNAL_MODCC})
 
 if (NOT ARB_WITH_EXTERNAL_MODCC)

--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -13,7 +13,6 @@
 #include "printer/printerutil.hpp"
 #include "printer/marks.hpp"
 
-#define FMT_HEADER_ONLY YES
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/compile.h>

--- a/modcc/printer/gpuprinter.cpp
+++ b/modcc/printer/gpuprinter.cpp
@@ -4,7 +4,6 @@
 #include <set>
 #include <regex>
 
-#define FMT_HEADER_ONLY YES
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/compile.h>

--- a/modcc/printer/infoprinter.cpp
+++ b/modcc/printer/infoprinter.cpp
@@ -3,7 +3,6 @@
 #include <string>
 #include <regex>
 
-#define FMT_HEADER_ONLY YES
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/compile.h>


### PR DESCRIPTION
Fix cmake configuration of out-of-core fmt library

- make it a dependency of libmodcc, not modcc
- set FMT_HEADER_ONLY as a compiler flag to avoid double definition

Fixes #1795
