### PR TITLE
Py/setuptools wheel fixes

### DIFF
--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - v*
 
+  schedule:
+    - cron: '0 2 * * 0' # run at 2 AM every sunday
+
 jobs:
   build_binary_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -22,29 +25,30 @@ jobs:
 
       - name: Build wheels Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        uses: pypa/cibuildwheel@v1.9.0
+        uses: pypa/cibuildwheel@v2.3.0
         with:
           output-dir: dist
         env:
-          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
+          CIBW_BEFORE_ALL: yum -y install libxml2-devel
+          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools cmake
           CIBW_BUILD: "cp3?-manylinux_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_LINUX: x86_64
-          # CIBW_TEST_COMMAND: TODO
+          CIBW_TEST_COMMAND: python -m unittest discover -v -s {project}/python
 
       - name: Build wheels macos
         if: ${{ startsWith(matrix.os, 'macos') }}
-        uses: pypa/cibuildwheel@v1.9.0
+        uses: pypa/cibuildwheel@v2.3.0
         with:
           output-dir: dist
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.15" #needed to undo some CIBW settings
-          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools
+          CIBW_BEFORE_BUILD: python -m pip install numpy setuptools cmake
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_ARCHS_MACOS: x86_64 universal2
-          # CIBW_TEST_COMMAND: TODO
+          CIBW_TEST_COMMAND: python -m unittest discover -v -s {project}/python
 
       # this action runs auditwheel automatically with the following args:
       # https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command
@@ -61,6 +65,8 @@ jobs:
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
+      - name: Get packages
+        run: python -m pip install numpy setuptools cmake
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -35,7 +35,7 @@ jobs:
           CIBW_SKIP: "cp35-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_TEST_COMMAND: python -m unittest discover -v -s {project}/python
+          # CIBW_TEST_COMMAND: python -m unittest discover -v -s {project}/python
 
       - name: Build wheels macos
         if: ${{ startsWith(matrix.os, 'macos') }}
@@ -48,7 +48,7 @@ jobs:
           CIBW_BUILD: "cp3?-macosx_x86_64"
           CIBW_SKIP: "cp35-*"
           CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_TEST_COMMAND: python -m unittest discover -v -s {project}/python
+          # CIBW_TEST_COMMAND: python -m unittest discover -v -s {project}/python
 
       # this action runs auditwheel automatically with the following args:
       # https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command

--- a/arbor/include/CMakeLists.txt
+++ b/arbor/include/CMakeLists.txt
@@ -46,6 +46,10 @@ if(ARB_WITH_PROFILING)
     # define ARB_PROFILE_ENABLED in version.hpp
     list(APPEND arb_features PROFILE)
 endif()
+if(ARB_USE_BUNDLED_LIBS)
+    # define ARB_BUNDLED_ENABLED in version.hpp
+    list(APPEND arb_features BUNDLED)
+endif()
 if(ARB_VECTORIZE)
     list(APPEND arb_features VECTORIZE)
 endif()

--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -84,6 +84,11 @@ The following optional flags can be used to configure the installation:
   See :ref:`install-architecture` for details.
 * ``--arch``: CPU micro-architecture to target. The advised default is ``native``.
   See `here <https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html>`_ for a full list of options.
+* ``--nobundled``: Disable use of Arbor supplied libraries. See ``/ext`` for which ones. This flag can be used if you wish to supply your own
+  versions of these libraries.
+* ``--noneuroml``: Disable NeuroML support. By default, Arbor will build with the widest range of fileformats available, including NeuroML.
+  NeuroML requires a ``libxml2`` development package to be available. If you do not need NeuroML support and/or do not have access to ``libxml2``
+  source code, you can disable the requirement with this flag.
 * ``--makejobs``: Specify the amount of jobs to ``make`` the project with for faster build times on multicore systems. By default set to ``2``.
 
 **Vanilla install** with no additional features enabled:

--- a/python/config.cpp
+++ b/python/config.cpp
@@ -44,6 +44,11 @@ pybind11::dict config() {
 #else
     dict[pybind11::str("neuroml")] = pybind11::bool_(false);
 #endif
+#ifdef ARB_BUNDLED_ENABLED
+    dict[pybind11::str("bundled")] = pybind11::bool_(true);
+#else
+    dict[pybind11::str("bundled")] = pybind11::bool_(false);
+#endif
     dict[pybind11::str("version")] = pybind11::str(ARB_VERSION);
     dict[pybind11::str("source")]  = pybind11::str(ARB_SOURCE_ID);
     dict[pybind11::str("arch")]    = pybind11::str(ARB_ARCH);

--- a/python/config.cpp
+++ b/python/config.cpp
@@ -39,6 +39,11 @@ pybind11::dict config() {
 #else
     dict[pybind11::str("profiling")] = pybind11::bool_(false);
 #endif
+#ifdef ARB_NEUROML_ENABLED
+    dict[pybind11::str("neuroml")] = pybind11::bool_(true);
+#else
+    dict[pybind11::str("neuroml")] = pybind11::bool_(false);
+#endif
     dict[pybind11::str("version")] = pybind11::str(ARB_VERSION);
     dict[pybind11::str("source")]  = pybind11::str(ARB_SOURCE_ID);
     dict[pybind11::str("arch")]    = pybind11::str(ARB_ARCH);

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -2,7 +2,7 @@
 # A script that can be ran in the PyPA manywheel containers if you want to produce uploadable wheels for PyPI.
 # Steps:
 # 1. Prepare a (temporary) working directory (referred to as $LOCAL_WORK_DIR). 
-# 2. Have the version of Arbor available at $LOCAL_WORK_DIR/arbor
+# 2. Have the version of Arbor you want to build manylinux compliant wheels for available at $LOCAL_WORK_DIR/arbor
 # 3. Start an instance of the docker image with $LOCAL_WORK_DIR mounted at /src_dir
 #    Then, run /src_dir/arbor/scripts/build-wheels.sh
 #    Using podman, the follow command can be used:

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# A script that can be ran in the PyPA manywheel containers if you want to produce uploadable wheels for PyPI.
+# Steps:
+# 1. Prepare a (temporary) working directory (referred to as $LOCAL_WORK_DIR). 
+# 2. Have the version of Arbor available at $LOCAL_WORK_DIR/arbor
+# 3. Start an instance of the docker image with $LOCAL_WORK_DIR mounted at /src_dir
+#    Using podman, the follow command would suffice. as follows:
+#    podman run -v $LOCAL_WORK_DIR:/src_dir:Z -ti quay.io/pypa/manylinux2014_x86_64 /src_dir/arbor/scripts/build-wheels.sh
+# 4. On the prompt in the machine, execute this script.
+#    /src_dir/arbor/scripts/build-wheels.sh
+# 5. After the run is complete, find in $LOCAL_WORK_DIR/wheelhouse the wheels ready for PyPI.
+
+set -e -u -x
+
+yum -y install libxml2-devel libxml2-static
+/opt/python/cp39-cp39/bin/pip install ninja cmake
+rm -rf /opt/python/cp35-cp35m #skip building for Python 3.5
+
+rm -rf /src_dir/arbor/_skbuild
+
+export CIBUILDWHEEL=1 #Set condition for cmake
+
+for PYBIN in /opt/python/cp*/bin; do
+    "${PYBIN}/python" -m pip install wheel scikit-build auditwheel
+    export PATH="${PYBIN}":$PATH
+    "${PYBIN}/python" -m pip wheel --wheel-dir="/src_dir/builtwheel${PYBIN}/" /src_dir/arbor
+    "${PYBIN}/python" -m auditwheel repair /src_dir/builtwheel${PYBIN}/arbor*.whl -w /src_dir/wheelhouse
+done
+
+# Todo: Install packages and test

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -4,11 +4,12 @@
 # 1. Prepare a (temporary) working directory (referred to as $LOCAL_WORK_DIR). 
 # 2. Have the version of Arbor available at $LOCAL_WORK_DIR/arbor
 # 3. Start an instance of the docker image with $LOCAL_WORK_DIR mounted at /src_dir
-#    Using podman, the follow command would suffice. as follows:
+#    Then, run /src_dir/arbor/scripts/build-wheels.sh
+#    Using podman, the follow command can be used:
 #    podman run -v $LOCAL_WORK_DIR:/src_dir:Z -ti quay.io/pypa/manylinux2014_x86_64 /src_dir/arbor/scripts/build-wheels.sh
-# 4. On the prompt in the machine, execute this script.
-#    /src_dir/arbor/scripts/build-wheels.sh
-# 5. After the run is complete, find in $LOCAL_WORK_DIR/wheelhouse the wheels ready for PyPI.
+# 4. After the run is complete, find in $LOCAL_WORK_DIR/wheelhouse the wheels ready for PyPI.
+#    $LOCAL_WORK_DIR/builtwheel contains the wheel before auditwheel has processed them. Can be discarded,
+#    or used for analysis in case of build failure.
 
 set -e -u -x
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,25 @@ except:
     WHEEL_INSTALLED = False
     pass
 
+# Hard coded, because scikit-build does not do build options.
+# Override by instructing CMAKE, e.g.:
+# pip install . -- -DARB_USE_BUNDLED_LIBS=ON -DARB_WITH_MPI=ON -DARB_GPU=cuda
+opt = {'mpi': False,
+       'gpu': 'none',
+       'vec': False,
+       'arch': 'none',
+       'neuroml': True,
+       'bundled': True}
+
+# VERSION is in the same path as setup.py
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'VERSION')) as version_file:
+    version_ = version_file.read().strip()
+
+# Get the contents of the readme
+with open(os.path.join(here, 'python/readme.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
 # Singleton class that holds the settings configured using command line
 # options. This information has to be stored in a singleton so that it
 # can be passed between different stages of the build, and because pip
@@ -47,15 +66,6 @@ user_options_ = [
         ('sysdeps', None, 'don\'t use bundled 3rd party C++ dependencies (pybind11 and json). This flag forces use of dependencies installed on the system.'),
         ('makejobs=', None, 'the amount of jobs to run `make` with.')
     ]
-
-# VERSION is in the same path as setup.py
-here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'VERSION')) as version_file:
-    version_ = version_file.read().strip()
-
-# Get the contents of the readme
-with open(os.path.join(here, 'python/readme.md'), encoding='utf-8') as f:
-    long_description = f.read()
 
 def check_cmake():
     try:

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,6 @@ class _command_template:
 
     def initialize_options(self):
         super().initialize_options()
-        # for k,v in opt.items():
-        #     setattr(self, k, v)
         self.mpi  = None
         self.gpu  = None
         self.arch = None
@@ -195,7 +193,6 @@ setuptools.setup(
     name='arbor',
     version=version_,
     python_requires='>=3.6',
-
     install_requires=['numpy'],
     setup_requires=[],
     zip_safe=False,
@@ -210,7 +207,7 @@ setuptools.setup(
     },
 
     author='The Arbor dev team.',
-    url='https://github.com/arbor-sim/arbor',
+    url='https://arbor-sim.org',
     description='High performance simulation of networks of multicompartment neurons.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -222,6 +219,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: C++',
     ],
     project_urls={


### PR DESCRIPTION
Changes setup.py to build binary wheels with nml enabled. See https://github.com/arbor-sim/arbor/actions/runs/1668149223

Todo:
* [x] Add `nml` status to `config()`. ('bundled' added as well.)
* [x] Add `build-wheels.sh` to `scripts/` which can be used to generate manylinux wheels using docker/podman. This script is not used by the Github Action, and should be kept in sync with it (`.github/workflows/ciwheel.yml`).
* [ ] Run tests on the wheel. Currently blocked by `setup.py` not correctly installing the build-catalog script.
* [x] Adjust docs (renamed some install options, and the defaults)
* [ ] If #1784 is merged, this PR is obsolete.