### PR TITLE
CMake CUDA clean-up.

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -75,7 +75,7 @@ jobs:
           }
         - {
             name:  "MacOS Max",
-            os:    "macos-10.15", # TODO: 11.0 is still private preview, fix later.
+            os:    "macos-11",
             cc:    "clang",
             cxx:   "clang++",
             py:    "3.9",

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -98,7 +98,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y "clang-8" "lldb-8" "lld-8" "clang-format-8" g++-8
       - name: Set up cmake
-        uses: jwlawson/actions-setup-cmake@v1.7
+        uses: jwlawson/actions-setup-cmake@v1.12
         with:
           cmake-version: ${{ matrix.config.cmake }}
       - name: Set up Python

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -19,7 +19,7 @@ jobs:
             cc:    "gcc-8",
             cxx:   "g++-8",
             py:    "3.6",
-            cmake: "3.12.x",
+            cmake: "3.18.x",
             mpi:   "ON",
             simd:  "OFF"
           }
@@ -29,7 +29,7 @@ jobs:
             cc:    "clang-8",
             cxx:   "clang++-8",
             py:    "3.6",
-            cmake: "3.12.x",
+            cmake: "3.18.x",
             mpi:   "ON",
             simd:  "OFF"
           }
@@ -39,7 +39,7 @@ jobs:
             cc:    "clang",
             cxx:   "clang++",
             py:    "3.6",
-            cmake: "3.12.x",
+            cmake: "3.18.x",
             mpi:   "ON",
             simd:  "OFF"
           }
@@ -49,7 +49,7 @@ jobs:
             cc:    "gcc-10",
             cxx:   "g++-10",
             py:    "3.9",
-            cmake: "3.19.x",
+            cmake: "3.22.x",
             mpi:   "ON",
             simd:  "OFF"
           }
@@ -59,7 +59,7 @@ jobs:
             cc:    "gcc-10",
             cxx:   "g++-10",
             py:    "3.9",
-            cmake: "3.19.x",
+            cmake: "3.22.x",
             mpi:   "OFF",
             simd:  "ON"
           }
@@ -69,7 +69,7 @@ jobs:
             cc:    "clang-10",
             cxx:   "clang++-10",
             py:    "3.9",
-            cmake: "3.19.x",
+            cmake: "3.22.x",
             mpi:   "ON",
             simd:  "OFF"
           }
@@ -79,7 +79,7 @@ jobs:
             cc:    "clang",
             cxx:   "clang++",
             py:    "3.9",
-            cmake: "3.19.x",
+            cmake: "3.22.x",
             mpi:   "ON",
             simd:  "OFF"
           }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.18)
 include(CMakeDependentOption)
+
+# Make CUDA support throw errors if architectures remain unclear
+cmake_policy(SET CMP0104 NEW)
 
 file(READ VERSION FULL_VERSION_STRING)
 string(STRIP "${FULL_VERSION_STRING}" FULL_VERSION_STRING)
@@ -90,7 +93,7 @@ option(ARB_WITH_PYTHON "enable Python front end" OFF)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 include(GitSubmodule) # required for check_git_submodule
 include(ErrorTarget)  # reguired for add_error_target
-include(FindThreadsCudaFix) # bug work around
+include(FindCUDAToolkit)
 
 # Set release as the default build type (CMake default is debug.)
 
@@ -100,40 +103,26 @@ if (NOT CMAKE_BUILD_TYPE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "debug" "release")
 endif()
 
-# When we find threads, prefer not to use the -pthread option
-# in order to avoid a CMake 3.12 issue.
-set(THREADS_PREFER_PTHREAD_FLAG OFF)
-
-# Add CUDA as a language if GPU support requested.
-# (This has to be set early so as to enable CUDA tests in generator
-# expressions.)
-
+# Add CUDA as a language if GPU support requested. (This has to be set early so
+# as to enable CUDA tests in generator expressions.)
 if(ARB_GPU STREQUAL "cuda")
     set(ARB_WITH_NVCC TRUE)
-
-    # CMake 18 and later set the default CUDA architecture for
-    # each target according to CMAKE_CUDA_ARCHITECTURES.
-    if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-        set(CMAKE_CUDA_ARCHITECTURES 60 70 80)
-    endif()
-
-    # This fixes nvcc picking up a wrong host compiler for linking, causing issues
-    # with outdated libraries, eg libstdc++ and std::filesystem. Must happend before
-    # all calls to enable_language(CUDA)
+    # This fixes nvcc picking up a wrong host compiler for linking, causing
+    # issues with outdated libraries, eg libstdc++ and std::filesystem. Must
+    # happen before all calls to enable_language(CUDA)
     set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
-
     enable_language(CUDA)
-
-    # Despite native CUDA support, the CUDA package is still required to export
-    # the cuda library dependencies from the installed target.
-    find_package(CUDA 10 REQUIRED)
-
+    find_package(CUDAToolkit)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        if(CUDAToolkit_VERSION_MAJOR GREATER 10)
+            set(CMAKE_CUDA_ARCHITECTURES 60 70 80)
+        else()
+            set(CMAKE_CUDA_ARCHITECTURES 60 70)
+        endif()
+    endif()
 elseif(ARB_GPU STREQUAL "cuda-clang")
     set(ARB_WITH_CUDA_CLANG TRUE)
-
-    # The CUDA package is needed for clang compilation for the same reasons as above.
-    # enable_langaue(CUDA) has a bug with clang
-    find_package(CUDA 10 REQUIRED)
+    enable_language(CUDA)
 elseif(ARB_GPU STREQUAL "hip")
     set(ARB_WITH_HIP_CLANG TRUE)
 endif()
@@ -357,31 +346,18 @@ if(ARB_WITH_GPU)
 
     if(ARB_WITH_NVCC OR ARB_WITH_CUDA_CLANG)
         target_include_directories(arborenv-private-deps INTERFACE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-
         add_compile_options(
                 "$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--diag_suppress=integer_sign_change>"
                 "$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--diag_suppress=unsigned_compare_with_zero>")
     endif()
 
-
     if(ARB_WITH_NVCC)
-        target_compile_options(arbor-private-deps INTERFACE
-            $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_60,code=sm_60>)
-        target_compile_options(arbor-private-deps INTERFACE
-            $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_70,code=sm_70>)
-        if (${CUDA_VERSION_MAJOR} GREATER 10)
-            target_compile_options(arbor-private-deps INTERFACE
-                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_80,code=sm_80>)
-        endif()
-
         target_compile_definitions(arbor-private-deps INTERFACE ARB_CUDA)
         target_compile_definitions(arborenv-private-deps INTERFACE ARB_CUDA)
-
     elseif(ARB_WITH_CUDA_CLANG)
         set(clang_options_ -DARB_CUDA -xcuda --cuda-gpu-arch=sm_60 --cuda-gpu-arch=sm_70 --cuda-gpu-arch=sm_80 --cuda-path=${CUDA_TOOLKIT_ROOT_DIR})
         target_compile_options(arbor-private-deps INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${clang_options_}>)
         target_compile_options(arborenv-private-deps INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${clang_options_}>)
-
     elseif(ARB_WITH_HIP_CLANG)
         set(clang_options_ -DARB_HIP -xhip --amdgpu-target=gfx906 --amdgpu-target=gfx900)
         target_compile_options(arbor-private-deps INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${clang_options_}>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,6 @@ endif()
 #-----------------
 
 find_package(Threads REQUIRED)
-find_threads_cuda_fix()
 target_link_libraries(arbor-private-deps INTERFACE Threads::Threads)
 
 list(APPEND arbor_export_dependencies "Threads")

--- a/ci/release/build.Dockerfile
+++ b/ci/release/build.Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake
-RUN wget -q "https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.tar.gz" -O cmake.tar.gz && \
-    echo "486edd6710b5250946b4b199406ccbf8f567ef0e23cfe38f7938b8c78a2ffa5f cmake.tar.gz" | sha256sum --check --quiet && \
+RUN wget -q "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.6-Linux-x86_64.tar.gz" -O cmake.tar.gz && \
+    echo "87136646867ed65e935d6bacd44d52a740c448ad0806f6897d8c3d47ce438c8b cmake.tar.gz" | sha256sum --check --quiet && \
     tar --strip-components=1 -xzf cmake.tar.gz -C /usr/local && \
     rm -rf cmake.tar.gz
 

--- a/ci/release/build.Dockerfile
+++ b/ci/release/build.Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake
-RUN wget -q "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.6-Linux-x86_64.tar.gz" -O cmake.tar.gz && \
+RUN wget -q "https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-Linux-x86_64.tar.gz" -O cmake.tar.gz && \
     echo "87136646867ed65e935d6bacd44d52a740c448ad0806f6897d8c3d47ce438c8b cmake.tar.gz" | sha256sum --check --quiet && \
     tar --strip-components=1 -xzf cmake.tar.gz -C /usr/local && \
     rm -rf cmake.tar.gz

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -28,7 +28,7 @@ with very few tools.
     Tool        Notes
     =========== ============================================
     Git         To check out the code, minimum version 2.0.
-    CMake       To set up the build, minimum version 3.12.
+    CMake       To set up the build, minimum version 3.18.
     compiler    A C++17 compiler. See `compilers <install-compilers_>`_.
     =========== ============================================
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 find_package(Threads REQUIRED)
-find_threads_cuda_fix()
 
 add_library(gtest EXCLUDE_FROM_ALL STATIC gtest-all.cpp)
 target_include_directories(gtest PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
- Bump CMake to 3.18 for better CUDA support
- Clean-up our use of said support
- Remove old cruft and workarounds

- Maintenance in CI
  - enable MacOS 11
  - bump CMake versions to 3.18 / 3.22
  - bump bors CMake to 3.18

Fixes #1790 
