### PR TITLE
Build Python 3.10 binary wheels. Add v0.6 to spackfile.

### DIFF
--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL: yum -y install libxml2-devel
           CIBW_BEFORE_BUILD: python -m pip install numpy setuptools scikit-build ninja cmake
-          CIBW_BUILD: "cp3?-manylinux_x86_64"
+          CIBW_BUILD: "cp3*-manylinux_x86_64"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_LINUX: x86_64
           CIBW_REPAIR_WHEEL_COMMAND: 'auditwheel repair -w {dest_dir} {wheel} && python /project/scripts/patchwheel.py {dest_dir}'
@@ -47,7 +47,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.15" #needed to undo some CIBW settings
           CIBW_BEFORE_BUILD: python -m pip install numpy setuptools scikit-build ninja cmake
-          CIBW_BUILD: "cp3?-macosx_x86_64"
+          CIBW_BUILD: "cp3*-macosx_x86_64"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_COMMAND: python -m unittest discover -v -s {project}/python
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -12,10 +12,11 @@ class Arbor(CMakePackage, CudaPackage):
 
     homepage = 'https://arbor-sim.org'
     git      = 'https://github.com/arbor-sim/arbor.git'
-    url      = 'https://github.com/arbor-sim/arbor/releases/download/v0.5.2/arbor-v0.5.2-full.tar.gz'
+    url      = 'https://github.com/arbor-sim/arbor/releases/download/v0.6/arbor-v0.6-full.tar.gz'
     maintainers = ['bcumming', 'brenthuisman', 'haampie', 'halfflat']
 
     version('master', branch='master', submodules=True)
+    version('0.6', sha256='4cd333b18effc8833428ddc0b99e7dc976804771bc85da90034c272c7019e1e8', url='https://github.com/arbor-sim/arbor/releases/download/v0.6/arbor-v0.6-full.tar.gz')
     version('0.5.2', sha256='290e2ad8ca8050db1791cabb6b431e7c0409c305af31b559e397e26b300a115d', url='https://github.com/arbor-sim/arbor/releases/download/v0.5.2/arbor-v0.5.2-full.tar.gz')
     version('0.5', sha256='d0c8a4c7f97565d7c30493c66249be794d1dc424de266fc79cecbbf0e313df59', url='https://github.com/arbor-sim/arbor/releases/download/v0.5/arbor-v0.5-full.tar.gz')
 


### PR DESCRIPTION
* Build Python 3.10 binary wheels.
* Add v0.6 to spackfile.