### PR TITLE
🐍 Be more lenient when accepting args to file I/O

### DIFF
--- a/python/cable_cell_io.cpp
+++ b/python/cable_cell_io.cpp
@@ -13,7 +13,10 @@
 
 namespace pyarb {
 
-arborio::cable_cell_component load_component(const std::string& fname) {
+namespace py = pybind11;
+
+arborio::cable_cell_component load_component(py::object fn) {
+    const std::string fname = py::str(fn);
     std::ifstream fid{fname};
     if (!fid.good()) {
         throw pyarb_error("Can't open file '{}'" + fname);
@@ -26,13 +29,13 @@ arborio::cable_cell_component load_component(const std::string& fname) {
 };
 
 template<typename T>
-void write_component(const T& component, const std::string& fname) {
-    std::ofstream fid(fname);
+void write_component(const T& component, py::object fn) {
+    std::ofstream fid(std::string{py::str(fn)});
     arborio::write_component(fid, component, arborio::meta_data{});
 }
 
-void write_component(const arborio::cable_cell_component& component, const std::string& fname) {
-    std::ofstream fid(fname);
+void write_component(const arborio::cable_cell_component& component, py::object fn) {
+    std::ofstream fid(std::string{py::str(fn)});
     arborio::write_component(fid, component);
 }
 
@@ -43,40 +46,40 @@ void register_cable_loader(pybind11::module& m) {
           "Load arbor-component (decor, morphology, label_dict, cable_cell) from file.");
 
     m.def("write_component",
-          [](const arborio::cable_cell_component& d, const std::string& fname) {
-            return write_component(d, fname);
+          [](const arborio::cable_cell_component& d, py::object fn) {
+            return write_component(d, fn);
           },
           pybind11::arg_v("object", "the cable_component object."),
           pybind11::arg_v("filename", "the name of the file."),
           "Write cable_component to file.");
 
     m.def("write_component",
-          [](const arb::decor& d, const std::string& fname) {
-            return write_component<arb::decor>(d, fname);
+          [](const arb::decor& d, py::object fn) {
+            return write_component<arb::decor>(d, fn);
           },
           pybind11::arg_v("object", "the decor object."),
           pybind11::arg_v("filename", "the name of the file."),
           "Write decor to file.");
 
     m.def("write_component",
-          [](const arb::label_dict& d, const std::string& fname) {
-            return write_component<arb::label_dict>(d, fname);
+          [](const arb::label_dict& d, py::object fn) {
+            return write_component<arb::label_dict>(d, fn);
           },
           pybind11::arg_v("object", "the label_dict object."),
           pybind11::arg_v("filename", "the name of the file."),
           "Write label_dict to file.");
 
     m.def("write_component",
-          [](const arb::morphology& d, const std::string& fname) {
-            return write_component<arb::morphology>(d, fname);
+          [](const arb::morphology& d, py::object fn) {
+            return write_component<arb::morphology>(d, fn);
           },
           pybind11::arg_v("object", "the morphology object."),
           pybind11::arg_v("filename", "the name of the file."),
           "Write morphology to file.");
 
     m.def("write_component",
-          [](const arb::cable_cell& d, const std::string& fname) {
-            return write_component<arb::cable_cell>(d, fname);
+          [](const arb::cable_cell& d, py::object fn) {
+            return write_component<arb::cable_cell>(d, fn);
           },
           pybind11::arg_v("object", "the cable_cell object."),
           pybind11::arg_v("filename", "the name of the file."),

--- a/python/mechanism.cpp
+++ b/python/mechanism.cpp
@@ -197,7 +197,10 @@ void register_mechanisms(pybind11::module& m) {
     m.def("default_catalogue", [](){return arb::global_default_catalogue();});
     m.def("allen_catalogue", [](){return arb::global_allen_catalogue();});
     m.def("bbp_catalogue", [](){return arb::global_bbp_catalogue();});
-    m.def("load_catalogue", [](const std::string& fn){return arb::load_catalogue(fn);});
+    m.def("load_catalogue", [](pybind11::object obj){
+        const std::string fn = pybind11::str(obj);
+        return arb::load_catalogue(fn);
+    });
 
     // arb::mechanism_desc
     // For specifying a mechanism in the cable_cell interface.

--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -250,7 +250,8 @@ void register_morphology(py::module& m) {
     // Function that creates a morphology from an swc file.
     // Wraps calls to C++ functions arborio::parse_swc() and arborio::load_swc_arbor().
     m.def("load_swc_arbor",
-        [](std::string fname) {
+        [](py::object fn) {
+            const auto fname = py::str(fn);
             std::ifstream fid{fname};
             if (!fid.good()) {
                 throw pyarb_error(util::pprintf("can't open file '{}'", fname));
@@ -275,7 +276,8 @@ void register_morphology(py::module& m) {
         "  are no gaps in the resulting morphology.");
 
     m.def("load_swc_neuron",
-        [](std::string fname) {
+        [](py::object fn) {
+            const auto fname = py::str(fn);
             std::ifstream fid{fname};
             if (!fid.good()) {
                 throw pyarb_error(util::pprintf("can't open file '{}'", fname));
@@ -383,7 +385,8 @@ void register_morphology(py::module& m) {
     neuroml
         // constructors
         .def(py::init(
-            [](std::string fname) {
+            [](py::object fn) {
+                const auto fname = py::str(fn);
                 std::ifstream fid{fname};
                 if (!fid.good()) {
                     throw pyarb_error(util::pprintf("can't open file '{}'", fname));


### PR DESCRIPTION
PyArbor I/O routines now try to cast `filename` arguments to a string.
This allows passing `pathlib.Path` objects.