### PR TITLE
Users may not give dt < 0.

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -10,6 +10,8 @@ namespace arb {
 
 using arb::util::pprintf;
 
+domain_error::domain_error(const std::string& w): arbor_exception(w) {}
+
 bad_cell_probe::bad_cell_probe(cell_kind kind, cell_gid_type gid):
     arbor_exception(pprintf("recipe::get_grobe() is not supported for cell with gid {} of kind {})", gid, kind)),
     gid(gid),

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -28,6 +28,13 @@ struct arbor_exception: std::runtime_error {
     {}
 };
 
+// Logic errors
+
+// Argument violates domain constraints, eg ln(-1)
+struct domain_error: arbor_exception {
+    domain_error(const std::string&);
+};
+
 // Recipe errors:
 
 struct bad_cell_probe: arbor_exception {

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -515,7 +515,7 @@ void simulation::reset() {
 
 time_type simulation::run(time_type tfinal, time_type dt) {
     if (dt <= 0.0) {
-        throw arbor_exception("Finite time-step must be supplied.");
+        throw domain_error("Finite time-step must be supplied.");
     }
     return impl_->run(tfinal, dt);
 }

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -514,6 +514,9 @@ void simulation::reset() {
 }
 
 time_type simulation::run(time_type tfinal, time_type dt) {
+    if (dt <= 0.0) {
+        throw arbor_exception("Finite time-step must be supplied.");
+    }
     return impl_->run(tfinal, dt);
 }
 


### PR DESCRIPTION
Fixes an obvious bug w/ `dt <= 0`.