### PR TITLE
run buildwheel action on latest cibuildwheel image, in order to test new minor releases

### DIFF
--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build wheels Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@latest
         with:
           output-dir: dist
         env:
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build wheels macos
         if: ${{ startsWith(matrix.os, 'macos') }}
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@latest
         with:
           output-dir: dist
         env:


### PR DESCRIPTION
Fixes #1808. The fundamental problem is that I don't know that we can trigger upon a Python minor release, so the next best thing is to run the regular `cibuildwheel` builds/tests with the `latest` image, which should include new Python minor version not long after they are released.

Publishing wheels for a new Python minor release still is tied to having a new Arbor release.