### PR TITLE
New policy 'round_robin_halt'

### DIFF
--- a/arbor/common_types_io.cpp
+++ b/arbor/common_types_io.cpp
@@ -8,6 +8,8 @@ ARB_ARBOR_API std::ostream& operator<<(std::ostream& o, lid_selection_policy pol
     switch (policy) {
     case lid_selection_policy::round_robin:
         return o << "round_robin";
+	case lid_selection_policy::round_robin_halt:
+        return o << "round_robin_halt";
     case lid_selection_policy::assert_univalent:
         return o << "univalent";
     }

--- a/arbor/include/arbor/common_types.hpp
+++ b/arbor/include/arbor/common_types.hpp
@@ -70,6 +70,7 @@ struct lid_range {
 
 enum class lid_selection_policy {
     round_robin,
+	round_robin_halt,
     assert_univalent // throw if the range of possible lids is wider than 1
 };
 

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -126,6 +126,11 @@ lid_hopefully round_robin_state::update(const label_resolution_map::range_set& r
     return lid;
 }
 
+lid_hopefully round_robin_halt_state::update(const label_resolution_map::range_set& range_set) {
+    auto lid = range_set.at(state);
+    return lid;
+}
+
 lid_hopefully assert_univalent_state::update(const label_resolution_map::range_set& range_set) {
     if (range_set.size() != 1) {
         return util::unexpected("range is not univalent");
@@ -139,6 +144,8 @@ resolver::state_variant resolver::construct_state(lid_selection_policy pol) {
     switch (pol) {
     case lid_selection_policy::round_robin:
         return round_robin_state();
+	case lid_selection_policy::round_robin_halt:
+        return round_robin_halt_state();
     case lid_selection_policy::assert_univalent:
        return assert_univalent_state();
     default: return assert_univalent_state();

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -94,6 +94,13 @@ struct ARB_ARBOR_API round_robin_state {
     lid_hopefully update(const label_resolution_map::range_set& range);
 };
 
+struct ARB_ARBOR_API round_robin_halt_state {
+    cell_size_type state = 0;
+    round_robin_halt_state() : state(0) {};
+    round_robin_halt_state(cell_lid_type state) : state(state) {};
+    lid_hopefully update(const label_resolution_map::range_set& range);
+};
+
 struct ARB_ARBOR_API assert_univalent_state {
     lid_hopefully update(const label_resolution_map::range_set& range);
 };
@@ -105,7 +112,7 @@ struct ARB_ARBOR_API resolver {
     cell_lid_type resolve(const cell_global_label_type& iden);
 
 private:
-    using state_variant = std::variant<round_robin_state, assert_univalent_state>;
+    using state_variant = std::variant<round_robin_state, round_robin_halt_state, assert_univalent_state>;
 
     state_variant construct_state(lid_selection_policy pol);
 

--- a/doc/cpp/cell.rst
+++ b/doc/cpp/cell.rst
@@ -54,6 +54,10 @@ cells and members of cell-local collections.
 
       Iterate over the items of the group in a round-robin fashion.
 
+   .. cpp:enumerator:: round_robin_halt
+
+      Halts at the current item of the group until the round_robin policy is called (again).
+
    .. cpp:enumerator:: assert_univalent
 
       Assert that ony one item is available in the group. Throws an exception if the assertion

--- a/doc/python/cell.rst
+++ b/doc/python/cell.rst
@@ -18,6 +18,10 @@ The types defined below are used as identifiers for cells and members of cell-lo
 
       Iterate over the items of the group in a round-robin fashion.
 
+   .. attribute:: round_robin_halt
+
+      Halts at the current item of the group until the round_robin policy is called (again).
+
    .. attribute:: univalent
 
       Assert that only one item is available in the group. Throws an exception if the assertion

--- a/python/identifiers.cpp
+++ b/python/identifiers.cpp
@@ -18,7 +18,9 @@ void register_identifiers(py::module& m) {
     py::enum_<arb::lid_selection_policy>(m, "selection_policy",
         "Enumeration used to identify a selection policy, used by the model for selecting one of possibly multiple locations on the cell associated with a labeled item.")
         .value("round_robin", arb::lid_selection_policy::round_robin,
-               "iterate round-robin over all possible locations.")
+               "Iterate round-robin over all possible locations.")
+		.value("round_robin_halt", arb::lid_selection_policy::round_robin_halt,
+               "Halts at the current location until the round_robin policy is called (again).")
         .value("univalent", arb::lid_selection_policy::assert_univalent,
                "Assert that there is only one possible location associated with a labeled item on the cell. The model throws an exception if the assertion fails.");
 


### PR DESCRIPTION
Introduces the new policy `round_robin_halt`. This enables to halt at the current item until the policy `round_robin` is called again.

Related to issue #1749.