### PR TITLE
Add support for epoch callbacks

### DIFF
--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -18,6 +18,7 @@
 namespace arb {
 
 using spike_export_function = std::function<void(const std::vector<spike>&)>;
+using epoch_function = std::function<void(double time, double tfinal)>;
 
 // simulation_state comprises private implementation for simulation class.
 class simulation_state;
@@ -57,6 +58,10 @@ public:
     // spike vector.
     void set_local_spike_callback(spike_export_function = spike_export_function{});
 
+    // Register a callback that will be called at the end of each epoch, and at the
+    // start of the simulation.
+    void set_epoch_callback(epoch_function = epoch_function{}, bool global=true);
+
     // Add events directly to targets.
     // Must be called before calling simulation::run, and must contain events that
     // are to be delivered at or after the current simulation time.
@@ -67,5 +72,8 @@ public:
 private:
     std::unique_ptr<simulation_state> impl_;
 };
+
+// An epoch callback function that prints out a text progress bar.
+epoch_function epoch_progress_bar();
 
 } // namespace arb

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -74,6 +74,6 @@ private:
 };
 
 // An epoch callback function that prints out a text progress bar.
-epoch_function epoch_progress_bar();
+ARB_ARBOR_API epoch_function epoch_progress_bar();
 
 } // namespace arb

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -60,7 +60,7 @@ public:
 
     // Register a callback that will be called at the end of each epoch, and at the
     // start of the simulation.
-    void set_epoch_callback(epoch_function = epoch_function{}, bool global=true);
+    void set_epoch_callback(epoch_function = epoch_function{});
 
     // Add events directly to targets.
     // Must be called before calling simulation::run, and must contain events that

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -578,24 +578,30 @@ simulation::~simulation() = default;
 ARB_ARBOR_API epoch_function epoch_progress_bar() {
     struct impl {
         double t0 = 0;
-        unsigned calls = 0;
-
-        const char* PBSTR = "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||";
-        unsigned PBWIDTH = 50;
+        bool first = true;
 
         void operator() (double t, double tfinal) {
-            if (calls==0) {
+            constexpr unsigned bar_width = 50;
+            static const std::string bar_buffer(bar_width+1, '-');
+
+            if (first) {
+                first = false;
                 t0 = t;
             }
 
             double percentage = (tfinal==t0)? 1: (t-t0)/(tfinal-t0);
             int val = percentage * 100;
-            int lpad = percentage * PBWIDTH;
-            int rpad = PBWIDTH - lpad;
-            printf("\r%3d%% [%.*s%*s]  %12ums", val, lpad, PBSTR, rpad, "", (unsigned)t);
-            fflush(stdout);
+            int lpad = percentage * bar_width;
+            int rpad = bar_width - lpad;
+            printf("\r%3d%% |%.*s%*s|  %12ums", val, lpad, bar_buffer.c_str(), rpad, "", (unsigned)t);
 
-            ++calls;
+            if (t==tfinal) {
+                // Print new line and reset counters on the last step.
+                printf("\n");
+                t0 = tfinal;
+                first = true;
+            }
+            fflush(stdout);
         }
     };
 

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -565,7 +565,7 @@ void simulation::set_local_spike_callback(spike_export_function export_callback)
     impl_->local_export_callback_ = std::move(export_callback);
 }
 
-void simulation::set_epoch_callback(epoch_function epoch_callback, bool global) {
+void simulation::set_epoch_callback(epoch_function epoch_callback) {
     impl_->epoch_callback_ = std::move(epoch_callback);
 }
 

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -575,7 +575,7 @@ void simulation::inject_events(const cse_vector& events) {
 
 simulation::~simulation() = default;
 
-epoch_function epoch_progress_bar() {
+ARB_ARBOR_API epoch_function epoch_progress_bar() {
     struct impl {
         double t0 = 0;
         unsigned calls = 0;

--- a/doc/python/simulation.rst
+++ b/doc/python/simulation.rst
@@ -156,6 +156,10 @@ over the local and distributed hardware resources (see :ref:`pydomdec`). Then, t
         be a NumPy array, with the first column corresponding to sample time and subsequent columns holding
         the value or values that were sampled from that probe at that time.
 
+    .. function:: progress_banner()
+
+        Print a progress bar during simulation, with elapsed miliseconds and percentage of simulation completed.
+
 **Types:**
 
 .. class:: binning

--- a/example/drybench/CMakeLists.txt
+++ b/example/drybench/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(drybench EXCLUDE_FROM_ALL drybench.cpp)
 add_dependencies(examples drybench)
 
-target_link_libraries(drybench PRIVATE arbor arborenv arbor-sup ext-json)
+target_link_libraries(drybench PRIVATE arbor arborenv arbor-sup ${json_library_name})

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -44,15 +44,9 @@ struct ring_params {
     ring_params() = default;
 
     std::string name = "default";
-<<<<<<< HEAD
-    unsigned num_cells = 10;
-    double min_delay = 10;
-    double duration = 200;
-=======
-    unsigned num_cells = 20;
+    unsigned num_cells = 100;
     double min_delay = 10;
     double duration = 1000;
->>>>>>> 7df6f6d7 (wip - python integration remaining)
     cell_parameters cell;
 };
 
@@ -196,7 +190,7 @@ int main(int argc, char** argv) {
         if (root) {
             sim.set_epoch_callback(arb::epoch_progress_bar());
         }
-        std::cout << "running simulation\n\n";
+        std::cout << "running simulation\n" << std::endl;
         // Run the simulation for 100 ms, with time steps of 0.025 ms.
         sim.run(params.duration, 0.025);
 

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -200,7 +200,7 @@ int main(int argc, char** argv) {
 
         // Write spikes to file
         if (root) {
-            std::cout << "\n\n" << ns << " spikes generated at rate of "
+            std::cout << "\n" << ns << " spikes generated at rate of "
                       << params.duration/ns << " ms between spikes\n";
             std::ofstream fid("spikes.gdf");
             if (!fid.good()) {

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -44,9 +44,15 @@ struct ring_params {
     ring_params() = default;
 
     std::string name = "default";
+<<<<<<< HEAD
     unsigned num_cells = 10;
     double min_delay = 10;
     double duration = 200;
+=======
+    unsigned num_cells = 20;
+    double min_delay = 10;
+    double duration = 1000;
+>>>>>>> 7df6f6d7 (wip - python integration remaining)
     cell_parameters cell;
 };
 
@@ -187,7 +193,10 @@ int main(int argc, char** argv) {
 
         meters.checkpoint("model-init", context);
 
-        std::cout << "running simulation" << std::endl;
+        if (root) {
+            sim.set_epoch_callback(arb::epoch_progress_bar());
+        }
+        std::cout << "running simulation\n\n";
         // Run the simulation for 100 ms, with time steps of 0.025 ms.
         sim.run(params.duration, 0.025);
 
@@ -197,7 +206,7 @@ int main(int argc, char** argv) {
 
         // Write spikes to file
         if (root) {
-            std::cout << "\n" << ns << " spikes generated at rate of "
+            std::cout << "\n\n" << ns << " spikes generated at rate of "
                       << params.duration/ns << " ms between spikes\n";
             std::ofstream fid("spikes.gdf");
             if (!fid.good()) {

--- a/python/example/network_ring.py
+++ b/python/example/network_ring.py
@@ -122,7 +122,7 @@ handles = [sim.sample((gid, 0), arbor.regular_schedule(0.1)) for gid in range(nc
 # (15) Run simulation for 100 ms
 sim.progress_banner()
 sim.run(100)
-print('\nSimulation finished')
+print('Simulation finished')
 
 # (16) Print spike times
 print('spikes:')

--- a/python/example/network_ring.py
+++ b/python/example/network_ring.py
@@ -120,8 +120,9 @@ sim.record(arbor.spike_recording.all)
 handles = [sim.sample((gid, 0), arbor.regular_schedule(0.1)) for gid in range(ncells)]
 
 # (15) Run simulation for 100 ms
+sim.progress_banner()
 sim.run(100)
-print('Simulation finished')
+print('\nSimulation finished')
 
 # (16) Print spike times
 print('spikes:')

--- a/python/simulation.cpp
+++ b/python/simulation.cpp
@@ -169,6 +169,10 @@ public:
             return py::list{};
         }
     }
+
+    void progress_banner() {
+        sim_->set_epoch_callback(arb::epoch_progress_bar());
+    }
 };
 
 void register_simulation(pybind11::module& m, pyarb_global_ptr global_ptr) {
@@ -236,7 +240,9 @@ void register_simulation(pybind11::module& m, pyarb_global_ptr global_ptr) {
             "Remove sampling associated with the given handle.",
             "handle"_a)
         .def("remove_all_samplers", &simulation_shim::remove_sampler,
-            "Remove all sampling on the simulatr.");
+            "Remove all sampling on the simulatr.")
+        .def("progress_banner", &simulation_shim::progress_banner,
+            "Show a text progress bar during simulation.");
 
 }
 


### PR DESCRIPTION
Adds support for the user to add a generic callback that is to be called:
1. before the first time step
2. at the end of every epoch

One implementation of such a callback that prints a progress bar to the screen is provided, and wrapped for the Python front end. Example output of the progress bar:

```
 57% [||||||||||||||||||||||||||||                      ]           575ms
```

Fixes #1870