### PR TITLE
Sort (in python) the mechanism names (for convenience).

### DIFF
--- a/python/mechanism.cpp
+++ b/python/mechanism.cpp
@@ -113,7 +113,9 @@ void register_mechanisms(pybind11::module& m) {
     pybind11::class_<arb::mechanism_catalogue> cat(m, "catalogue");
 
     struct mech_cat_iter_state {
-        mech_cat_iter_state(const arb::mechanism_catalogue &cat_, pybind11::object ref_): names(cat_.mechanism_names()), ref(ref_), cat(cat_) { }
+        mech_cat_iter_state(const arb::mechanism_catalogue &cat_, pybind11::object ref_): names(cat_.mechanism_names()), ref(ref_), cat(cat_) {
+            std::sort(names.begin(), names.end());
+        }
         std::vector<std::string> names;      // cache the names else these will be allocated multiple times
         pybind11::object ref;                // keep a reference to cat lest it dies while we iterate
         const arb::mechanism_catalogue& cat; // to query the C++ object


### PR DESCRIPTION
Return mechanism names in sorted order.

Fixes #1879 