### PR TITLE
Add introspection for global properties.

### DIFF
--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -497,6 +497,11 @@ void register_cells(pybind11::module& m) {
             return util::pprintf("(threshold_detector {})", d.threshold);});
 
     // arb::cable_cell_global_properties
+    pybind11::class_<arb::cable_cell_ion_data> ion_data(m, "ion_data");
+    ion_data
+        .def_readonly("internal_concentration", &arb::cable_cell_ion_data::init_int_concentration, "Internal concentration.")
+        .def_readonly("external_concentration", &arb::cable_cell_ion_data::init_ext_concentration, "External concentration.")
+        .def_readonly("reversal_concentration", &arb::cable_cell_ion_data::init_reversal_potential, "Reversal potential.");
 
     pybind11::class_<arb::cable_cell_global_properties> gprop(m, "cable_global_properties");
     gprop
@@ -506,6 +511,24 @@ void register_cells(pybind11::module& m) {
                 arb::check_global_properties(props);},
                 "Test whether all default parameters and ion species properties have been set.")
         // set cable properties
+        .def_property("membrane_potential",
+                      [](const arb::cable_cell_global_properties& props) { return props.default_parameters.init_membrane_potential; },
+                      [](arb::cable_cell_global_properties& props, double u) { props.default_parameters.init_membrane_potential = u; })
+        .def_property("membrane_capacitance",
+                      [](const arb::cable_cell_global_properties& props) { return props.default_parameters.membrane_capacitance; },
+                      [](arb::cable_cell_global_properties& props, double u) { props.default_parameters.membrane_capacitance = u; })
+        .def_property("temperature",
+                      [](const arb::cable_cell_global_properties& props) { return props.default_parameters.temperature_K; },
+                      [](arb::cable_cell_global_properties& props, double u) { props.default_parameters.temperature_K = u; })
+        .def_property("axial_resisitivity",
+                      [](const arb::cable_cell_global_properties& props) { return props.default_parameters.axial_resistivity; },
+                      [](arb::cable_cell_global_properties& props, double u) { props.default_parameters.axial_resistivity = u; })
+        .def_property_readonly("ion_data",
+                      [](const arb::cable_cell_global_properties& props) { return props.default_parameters.ion_data; })
+        .def_property_readonly("ion_valence",
+                      [](const arb::cable_cell_global_properties& props) { return props.ion_species; })
+        .def_property_readonly("ion_reversal_potential",
+                      [](const arb::cable_cell_global_properties& props) { return props.default_parameters.reversal_potential_method; })
         .def("set_property",
             [](arb::cable_cell_global_properties& props,
                optional<double> Vm, optional<double> cm,
@@ -534,8 +557,8 @@ void register_cells(pybind11::module& m) {
                 if (valence) props.ion_species[ion] = *valence;
 
                 auto& data = props.default_parameters.ion_data[ion];
-                if (int_con) data.init_int_concentration = *int_con;
-                if (ext_con) data.init_ext_concentration = *ext_con;
+                if (int_con) data.init_int_concentration  = *int_con;
+                if (ext_con) data.init_ext_concentration  = *ext_con;
                 if (rev_pot) data.init_reversal_potential = *rev_pot;
 
                 if (auto m = maybe_method(method)) {


### PR DESCRIPTION
Add accessors for the following items in `global_properties`
- ion_species (name -> valence) RO
- ion_data (name -> initial values) RO
- ion_rev_pot (name -> rev pot mech) RO
- Vm, rL, TK, Cm: RW

Fixes: #1802 