### PR TITLE
remove test statements for move ctor

### DIFF
--- a/test/unit/test_thread.cpp
+++ b/test/unit/test_thread.cpp
@@ -72,7 +72,8 @@ TEST(task_system, test_copy) {
         ts.async(f, 0);
 
         // Copy into new ftor and move ftor into a task (std::function<void()>)
-        EXPECT_EQ(1, nmove);
+        // move ctor is elided with some compilers
+        //EXPECT_EQ(1, nmove);
         EXPECT_EQ(1, ncopy);
         reset();
     }
@@ -99,7 +100,8 @@ TEST(notification_queue, test_copy) {
     q.push({task(f), 0});
 
     // Copy into new ftor and move ftor into a task (std::function<void()>)
-    EXPECT_EQ(1, nmove);
+    // move ctor is elided with some compilers
+    //EXPECT_EQ(1, nmove);
     EXPECT_EQ(1, ncopy);
     reset();
 }


### PR DESCRIPTION
Remove checks for move ctor when it could be elided:

Newer compilers choose to elide the move constructor in certain cases. This leads to failure of 2 tests. As this behaviour is completely legal (and even desirable) it should not lead to failure. I therefore commented out the two statements in question and added a comment about this in the code. Note, that here we anyways only check the behaviour of `std::function<void()>` for which the `task` type is an alias at this point, so in my opinion the whole point of the test is a bit questionable.
