### PR TITLE
add cmake checks for non-bundled random123

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,8 @@ install(FILES mechanisms/generate_catalogue DESTINATION ${ARB_INSTALL_DATADIR} P
 # External libraries in `ext` sub-directory: json, tinyopt and randon123.
 # Creates interface libraries `ext-json`, `ext-tinyopt` and `ext-random123`
 
+cmake_dependent_option(ARB_USE_BUNDLED_FMT "Use bundled FMT lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
+
 cmake_dependent_option(ARB_USE_BUNDLED_JSON "Use bundled Niels Lohmann's json library." ON "ARB_USE_BUNDLED_LIBS" OFF)
 if(NOT ARB_USE_BUNDLED_JSON)
   find_package(nlohmann_json)
@@ -239,10 +241,17 @@ if(NOT ARB_USE_BUNDLED_JSON)
 else()
   unset(nlohmann_json_DIR CACHE)
 endif()
+
+cmake_dependent_option(ARB_USE_BUNDLED_RANDOM123 "Use bundled Random123 lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
+add_library(ext-random123 INTERFACE)
+if(NOT ARB_USE_BUNDLED_RANDOM123)
+    find_package(Random123 REQUIRED)
+    target_include_directories(ext-random123 INTERFACE ${RANDOM123_INCLUDE_DIR})
+endif()
+
 add_subdirectory(ext)
 
-cmake_dependent_option(ARB_USE_BUNDLED_FMT "Use bundled FMT lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
-cmake_dependent_option(ARB_USE_BUNDLED_RANDOM123 "Use bundled Random123 lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
+install(TARGETS ext-random123 EXPORT arbor-targets)
 
 # Keep track of packages we need to add to the generated CMake config
 # file for arbor.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ endif()
 add_subdirectory(ext)
 
 cmake_dependent_option(ARB_USE_BUNDLED_FMT "Use bundled FMT lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
+cmake_dependent_option(ARB_USE_BUNDLED_RANDOM123 "Use bundled Random123 lib." ON "ARB_USE_BUNDLED_LIBS" OFF)
 
 # Keep track of packages we need to add to the generated CMake config
 # file for arbor.

--- a/cmake/FindRandom123.cmake
+++ b/cmake/FindRandom123.cmake
@@ -1,0 +1,23 @@
+
+# CMake find_package() Module for Random123 header-only C++ library
+# https://github.com/DEShawResearch/random123
+#
+# Example usage:
+#
+# find_package(Random123)
+#
+# If successful the following variables will be defined
+# RANDOM123_FOUND
+# RANDOM123_INCLUDE_DIR
+
+find_path(RANDOM123_INCLUDE_DIR Random123/threefry.h)
+
+if(RANDOM123_INCLUDE_DIR)
+    set(RANDOM123_FOUND TRUE)
+    message(STATUS "Found Random123: ${RANDOM123_INCLUDE_DIR}")
+endif()
+
+if(RANDOM123_FIND_REQUIRED AND NOT RANDOM123_FOUND)
+    message(FATAL_ERROR "Required package Random123 not found")
+endif()
+

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -6,16 +6,22 @@ if(ARB_USE_BUNDLED_JSON)
   set(json_library_name ext-json PARENT_SCOPE)
 endif()
 
+# Random123 (DE Shaw Research) counter-based random number generators (header-only)
+
+add_library(ext-random123 INTERFACE)
+if(ARB_USE_BUNDLED_RANDOM123)
+    target_include_directories(ext-random123 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/random123/include)
+    install(TARGETS ext-random123 EXPORT arbor-targets)
+else()
+    find_package(Random123 REQUIRED)
+    target_include_directories(ext-random123 INTERFACE ${RANDOM123_INCLUDE_DIR})
+endif()
+install(TARGETS ext-random123 EXPORT arbor-targets)
+
 # tinyopt command line parsing libary (header-only).
 
 add_library(ext-tinyopt INTERFACE)
 target_include_directories(ext-tinyopt INTERFACE tinyopt/include)
-
-# Random123 (DE Shaw Research) counter-based random number generators (header-only)
-
-add_library(ext-random123 INTERFACE)
-target_include_directories(ext-random123 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/random123/include)
-install(TARGETS ext-random123 EXPORT arbor-targets)
 
 # Google benchmark for microbenchmarks:
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -8,15 +8,14 @@ endif()
 
 # Random123 (DE Shaw Research) counter-based random number generators (header-only)
 
-add_library(ext-random123 INTERFACE)
 if(ARB_USE_BUNDLED_RANDOM123)
+    check_git_submodule(random123 random123)
+    if(NOT random123_avail)
+        message(FATAL_ERROR "Required Random123 submodule is not available.")
+    endif()
     target_include_directories(ext-random123 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/random123/include)
-    install(TARGETS ext-random123 EXPORT arbor-targets)
-else()
-    find_package(Random123 REQUIRED)
-    target_include_directories(ext-random123 INTERFACE ${RANDOM123_INCLUDE_DIR})
+    message(STATUS "Using Random123 submodule: ${CMAKE_CURRENT_SOURCE_DIR}>/random123")
 endif()
-install(TARGETS ext-random123 EXPORT arbor-targets)
 
 # tinyopt command line parsing libary (header-only).
 


### PR DESCRIPTION
Now that Random123 is a proper sub-module, and not simply bundled in tree, ensure that the system version is used when we don't `USE_BUNDLED_LIBS`.