### PR TITLE
Allow single quotes in Python s-exp 

### DIFF
--- a/arborio/label_parse.cpp
+++ b/arborio/label_parse.cpp
@@ -147,7 +147,7 @@ std::string eval_description(const char* name, const std::vector<std::any>& args
     };
 
     const auto nargs = args.size();
-    std::string msg = concat("'", name, "' with ", nargs, "argument", nargs!=1u?"s:" : ":");
+    std::string msg = concat("'", name, "' with ", nargs, " argument", nargs!=1u?"s:" : ":");
     if (nargs) {
         msg += " (";
         bool first = true;

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -75,14 +75,29 @@ std::string to_string(const arb::cable_cell_global_properties& props) {
 }
 
 // location helpers
-arb::region region_from_string(std::string reg) {
-    std::replace(reg.begin(), reg.end(), '\'', '"');
-    return arborio::parse_region_expression(reg).unwrap();
+
+// Convert ' -> " _unless_ in a quoted string inside the s-exp lang.
+// This simple implementation is fine, as our s-exp strings do not
+// allow escape sequences.
+std::string sanitize_label(const std::string& inp) {
+    std::string str;
+    bool in_quote = false;
+    for (auto c: inp) {
+        in_quote ^= c == '"';
+        if (c == '\'' && !in_quote) c = '"';
+        str.push_back(c);
+    }
+    return str;
 }
 
-arb::locset locset_from_string(std::string ls) {
-    std::replace(ls.begin(), ls.end(), '\'', '"');
-    return arborio::parse_locset_expression(ls).unwrap();
+arb::region region_from_string(const std::string& inp) {
+    auto str = sanitize_label(inp);
+    return arborio::parse_region_expression(str).unwrap();
+}
+
+arb::locset locset_from_string(const std::string& inp) {
+    auto str = sanitize_label(inp);
+    return arborio::parse_locset_expression(str).unwrap();
 }
 
 // cv_policy helpers

--- a/python/test/unit/test_decor.py
+++ b/python/test/unit/test_decor.py
@@ -11,6 +11,15 @@ TODO: Coverage for more than just iclamp.
 """
 
 class TestDecorClasses(unittest.TestCase):
+    def test_labels(self):
+        decor = A.decor()
+
+        decor.paint("(all)",            A.density("hh"))
+        decor.paint("'all'",            A.density("hh"))
+        decor.paint("\"all\"",          A.density("hh"))
+        decor.paint('"all"',            A.density("hh"))
+        decor.paint("(region \"all\")", A.density("hh"))
+
     def test_iclamp(self):
         # Constant amplitude iclamp:
         clamp = A.iclamp(10);

--- a/python/test/unit/test_decor.py
+++ b/python/test/unit/test_decor.py
@@ -19,6 +19,8 @@ class TestDecorClasses(unittest.TestCase):
         decor.paint("\"all\"",          A.density("hh"))
         decor.paint('"all"',            A.density("hh"))
         decor.paint("(region \"all\")", A.density("hh"))
+        decor.paint("(region \"al'l\")", A.density("hh"))
+        decor.paint("(region 'all')", A.density("hh"))
 
     def test_iclamp(self):
         # Constant amplitude iclamp:

--- a/test/unit/test_s_expr.cpp
+++ b/test/unit/test_s_expr.cpp
@@ -44,7 +44,7 @@ TEST(s_expr, atoms) {
         EXPECT_EQ(a.spelling, spelling);
     }
     // test parsing of strings
-    for (auto spelling: {"foo", "dog cat", ""}) {
+    for (auto spelling: {"foo", "dog cat", "", "'", "'quoted", "in'fix"}) {
         auto s = "\""s+spelling+"\"";
         auto a = get_atom(parse_s_expr(s));
         EXPECT_EQ(a.kind, tok::string);

--- a/test/unit/test_s_expr.cpp
+++ b/test/unit/test_s_expr.cpp
@@ -3,7 +3,6 @@
 
 #include "../test/gtest.h"
 
-#include <arbor/morph/region.hpp>
 #include <arbor/morph/locset.hpp>
 #include <arbor/cv_policy.hpp>
 #include <arbor/s_expr.hpp>

--- a/test/unit/test_s_expr.cpp
+++ b/test/unit/test_s_expr.cpp
@@ -44,7 +44,7 @@ TEST(s_expr, atoms) {
         EXPECT_EQ(a.spelling, spelling);
     }
     // test parsing of strings
-    for (auto spelling: {"foo", "dog cat", "", "'", "'quoted", "in'fix"}) {
+    for (auto spelling: {"foo", "dog cat", "", "'", "'quoted'", "in'fix"}) {
         auto s = "\""s+spelling+"\"";
         auto a = get_atom(parse_s_expr(s));
         EXPECT_EQ(a.kind, tok::string);

--- a/test/unit/test_s_expr.cpp
+++ b/test/unit/test_s_expr.cpp
@@ -49,6 +49,13 @@ TEST(s_expr, atoms) {
         auto a = get_atom(parse_s_expr(s));
         EXPECT_EQ(a.kind, tok::string);
     }
+    // test parsing of strings: errors
+    for (auto spelling: {"\"double\"", "\\\"double\\\"", "in\"side", "in\\\"side"}) {
+        auto s = "\""s+spelling+"\"";
+        auto a = get_atom(parse_s_expr(s));
+        EXPECT_EQ(a.kind, tok::error);
+    }
+
 }
 
 TEST(s_expr, atoms_in_parens) {


### PR DESCRIPTION
Python uses `'` and `"` interchangibly, so allow this in Python s-exps.
```py
d.paint("'all'", ...)
d.paint("(region 'all')", ...)
```
and so on. 

NB. These expressions are therefore now equivalent
```
d.paint("\"fine'in's-exp\"")
d.paint("'fine\'in\'s-exp'")
```
when used from python.