### PR TITLE
Reformulate Python build system in `pyproject.toml`, bump Python minver to 3.7

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,5 +20,3 @@ extend-exclude =
                .*,
                # artifacts
                build,
-               # nah, don't care
-               spack/package.py

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Update pip
         run: python3 -m pip install --upgrade pip
       - name: Get packages
-        run: python3 -m pip install numpy setuptools scikit-build ninja cmake
+        run: python3 -m pip install build #numpy setuptools scikit-build ninja cmake
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Make sdist
-        run:  python3 setup.py sdist
+        run: python -m build -s
       - name: Install sdist
         run:  python3 -m pip install dist/arbor*.tar.gz
       - name: Run Python tests

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -43,10 +43,8 @@ jobs:
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
-      - name: Update pip
-        run: python3 -m pip install --upgrade pip
       - name: Get packages
-        run: python3 -m pip install build #numpy setuptools scikit-build ninja cmake
+        run: python3 -m pip install build
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Update pip
-        run: python3 -m pip install --upgrade pip
         
       - name: Install cibuildwheel
         run: python3 -m pip install cibuildwheel

--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -24,13 +24,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-        
       - name: Install cibuildwheel
         run: python3 -m pip install cibuildwheel
-
       - name: Build wheels
         run: python3 -m cibuildwheel --output-dir dist
-      
       - uses: actions/upload-artifact@v2
         with:
           name: dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ endif()
 #----------------------------------------------------------
 
 # The minimum version of Python supported by Arbor.
-set(arb_py_version 3.6.0)
+set(arb_py_version 3.7.0)
 
 if(DEFINED PYTHON_EXECUTABLE)
     set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})

--- a/doc/dependencies.csv
+++ b/doc/dependencies.csv
@@ -19,7 +19,7 @@ bench,Google-benchmark,,submodule ``ext/google-benchmark``,
 --,fmt,,submodule ``ext/fmt``,
 --,tinyopt,,source copy ``ext/tinyopt``,
 ARB_WITH_PYTHON,pybind11,,submodule ``python/pybind11``,
-ARB_WITH_PYTHON,Python,3.6,Python compatiblity is the range between the latest officially released point version and the minimum here specified.,"* it is not more advanced than the version specified by NEP 29.
+ARB_WITH_PYTHON,Python,3.7,Python compatiblity is the range between the latest officially released point version and the minimum here specified.,"* it is not more advanced than the version specified by NEP 29.
 * it is available as a cray-python version on Piz Daint
 * it is available on labs.ebrains.eu
 

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -135,7 +135,7 @@ More information on building with MPI is in the `HPC cluster section <cluster_>`
 Python
 ~~~~~~
 
-Arbor has a Python frontend, for which a minimum of Python 3.6 is required.
+Arbor has a Python frontend, for which a minimum of Python 3.7 is required.
 In addition, `numpy` is a runtime requirement for the Python package.
 In order to use MPI in combination with the python frontend the
 `mpi4py <https://mpi4py.readthedocs.io/en/stable/install.html#>`_

--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -42,14 +42,10 @@ You are now ready to use Arbor! You can continue reading these documentation pag
     for any other platforms than listed above, ``pip`` will attempt a build from source and thus require these
     packages as well.
 
-    * Ubuntu/Debian: `git cmake gcc python3-dev python3-pip libxml2-dev`
-    * Fedora/CentOS/OpenSuse: `git cmake gcc-c++ python3-devel python3-pip libxml2-devel`
-    * MacOS: get `brew` `here <https://brew.sh>`_ and run `brew install cmake clang python3 libxml2`
+    * Ubuntu/Debian: ``git cmake gcc python3-dev python3-pip libxml2-dev``
+    * Fedora/CentOS/OpenSuse: ``git cmake gcc-c++ python3-devel python3-pip libxml2-devel``
+    * MacOS: get ``brew`` `here <https://brew.sh>`_ and run ``brew install cmake clang python3 libxml2``
     * Windows: the simplest way is to use `WSL <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and then follow the instructions for Ubuntu.
-
-    In addition, you'll need a few Python packages present:
-
-    ``pip3 install ninja scikit-build wheel setuptools numpy``
 
 .. _in_python_custom:
 
@@ -77,21 +73,16 @@ Every time you make changes to the code, you'll have to repeat the second step.
 Advanced options
 ^^^^^^^^^^^^^^^^
 
-By default Arbor is installed with multi-threading enabled. To enable more
-advanced forms of parallelism and other features, Arbor comes with a few
-compilation options. These are of the form ``-D<KEY>=<VALUE>``, must be appended
-to the ``pip`` invocation via ``--install-option="-D<...>" --install-option="-D<...>" ...`` and can
-be used on both local (``pip3 install ./arbor``) and remote (``pip3 install
-arbor``) copies of Arbor. See the examples below.
+Arbor comes with a few compilation options, some of them related to advanced forms of parallelism and other features.
+The options and flags are the same :ref:`as documented for the CMAKE build <quickstart>`, but they are passed differently. To enable more
+They must be placed in the ``CMAKE_ARGS`` environment variable. The simplest way to do this is by prepending the ``pip``
+command with ``CMAKE_ARGS=""``, where you place the arguments separated by space inside the quotes.
 
 .. Note::
 
    If you run into build issues while experimenting with build options, be sure
    to remove the ``_skbuild`` directory. If you had Arbor installed already,
    you may need to remove it first before you can (re)compile it with the flags you need.
-
-   Also, make sure to pass each option individually via
-   ``--install-option="..."``.
 
 The following flags can be used to configure the installation:
 
@@ -117,6 +108,11 @@ The following flags can be used to configure the installation:
    and ``CMake`` under the hood, so all flags and options valid in ``CMake`` can
    be used in this fashion.
 
+   Allthough the `scikit-build documentation <https://scikit-build.readthedocs.io/en/latest/usage.html#environment-variable-configuration>`_
+   mentions that you can also pass the build options with ``--install-option=""``, this will cause ``pip`` to build
+   all dependencies, including all build-dependencies, instead of downloading them from PyPI. ``CMAKE_ARGS=""``
+   saves you the build time, and also downloading and setting up the dependencies they in turn require to be present.
+
    Detailed instructions on how to install using CMake are in the :ref:`Python
    configuration <install-python>` section of the :ref:`installation guide
    <in_build_install>`. CMake is recommended if you need more control over
@@ -136,33 +132,33 @@ In the examples below we assume you are installing from a local copy.
 
 .. code-block:: bash
 
-    pip3 install ./arbor --install-option="-DARB_WITH_MPI=ON"
+    CMAKE_ARGS="-DARB_WITH_MPI=ON" pip3 install ./arbor
 
 **Compile with** :ref:`vectorization <install-vectorize>` on a system with a SkyLake
 :ref:`architecture <install-architecture>`:
 
 .. code-block:: bash
 
-    pip3 install ./arbor --install-option="-DARB_VECTORIZE=ON" --install-option="-DARB_ARCH=skylake"
-
+    CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=skylake" pip3 install ./arbor
+    
 **Enable NVIDIA GPUs (compiled with nvcc)**. This requires the :ref:`CUDA toolkit <install-gpu>`:
 
 .. code-block:: bash
 
-    pip3 install ./arbor --install-option="-DARB_GPU=cuda"
+    CMAKE_ARGS="-DARB_GPU=cuda" pip3 install ./arbor
 
 **Enable NVIDIA GPUs (compiled with clang)**. This also requires the :ref:`CUDA toolkit <install-gpu>`:
 
 .. code-block:: bash
 
-    pip3 install ./arbor --install-option="-DARB_GPU=cuda-clang"
+    CMAKE_ARGS="-DARB_GPU=cuda-clang" pip3 install ./arbor
 
 **Enable AMD GPUs (compiled with hipcc)**. This requires setting the ``CC`` and ``CXX``
-:ref:`environment variables <install-gpu>`
+:ref:`environment variables <install-gpu>`:
 
 .. code-block:: bash
 
-    pip3 install ./arbor --install-option="-DARB_GPU=hip"
+    CC=clang CXX=hipcc CMAKE_ARGS="-DARB_GPU=hip" pip3 install ./arbor
 
 Note on performance
 -------------------

--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -6,7 +6,7 @@ Python Installation
 Arbor's Python API will be the most convenient interface for most users.
 
 .. note::
-    Arbor requires Python version 3.6 and later. It is advised that you update ``pip`` as well.
+    Arbor requires Python version 3.7 and later. It is advised that you update ``pip`` as well.
     We strongly encourage using ``pip`` to install Arbor.
     
     To get help in case of problems installing with pip, run pip with the ``--verbose`` flag, and attach the output

--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -112,6 +112,7 @@ The following flags can be used to configure the installation:
    mentions that you can also pass the build options with ``--install-option=""``, this will cause ``pip`` to build
    all dependencies, including all build-dependencies, instead of downloading them from PyPI. ``CMAKE_ARGS=""``
    saves you the build time, and also downloading and setting up the dependencies they in turn require to be present.
+   Setting ``CMAKE_ARGS=""`` is addition compatible with build front-ends like `build <https://pypa-build.readthedocs.io>`_.
 
    Detailed instructions on how to install using CMake are in the :ref:`Python
    configuration <install-python>` section of the :ref:`installation guide

--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -112,7 +112,7 @@ The following flags can be used to configure the installation:
    mentions that you can also pass the build options with ``--install-option=""``, this will cause ``pip`` to build
    all dependencies, including all build-dependencies, instead of downloading them from PyPI. ``CMAKE_ARGS=""``
    saves you the build time, and also downloading and setting up the dependencies they in turn require to be present.
-   Setting ``CMAKE_ARGS=""`` is addition compatible with build front-ends like `build <https://pypa-build.readthedocs.io>`_.
+   Setting ``CMAKE_ARGS=""`` is in addition compatible with build front-ends like `build <https://pypa-build.readthedocs.io>`_.
 
    Detailed instructions on how to install using CMake are in the :ref:`Python
    configuration <install-python>` section of the :ref:`installation guide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [project]
 name = "arbor"
-#version = {file = "VERSION"}
-#license = {file = ["LICENSE"]}
-#readme = {file = ["python/readme.md"]}
-#version = "0.6.99"
 dynamic = ["version", "readme"]
 license = {file = "LICENSE"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "arbor"
 dynamic = ["version", "readme"]
 license = {file = "LICENSE"}
 description = "High performance simulation of networks of multicompartment neurons."
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 keywords = ["simulator", "neuroscience", "morphological detail", "HPC", "GPU", "C++"]
 authors = [
     {name = "Arbor Dev Team", email = "contact@arbor-sim.org"}
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -42,9 +41,9 @@ changelog = "https://github.com/arbor-sim/arbor/releases"
 
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools",
     "wheel",
-    "scikit-build>=0.12",
+    "scikit-build",
     "cmake>=3.18",
     "ninja",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 name = "arbor"
 dynamic = ["version", "readme"]
 license = {file = "LICENSE"}
-
 description = "High performance simulation of networks of multicompartment neurons."
 requires-python = ">=3.6"
 keywords = ["simulator", "neuroscience", "morphological detail", "HPC", "GPU", "C++"]
@@ -24,7 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: C++"
 ]
-
 dependencies = [
     "numpy"
 ]
@@ -53,8 +51,9 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
+build-frontend = "build"
 build = ["cp3*-manylinux_x86_64","cp3*-macosx_universal2","cp3*-musllinux_x86_64","cp3*-musllinux_aarch64"]
-before-build = "python3 -m pip install numpy setuptools scikit-build ninja cmake auditwheel"
+#before-build = "python3 -m pip install numpy setuptools scikit-build ninja cmake auditwheel"
 test-command = "python3 -m unittest discover -v -s {project}/python"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = ["cp3*-manylinux_x86_64","cp3*-macosx_universal2","cp3*-musllinux_x86_64","cp3*-musllinux_aarch64"]
-#before-build = "python3 -m pip install numpy setuptools scikit-build ninja cmake auditwheel"
+build = ["cp3*-manylinux_x86_64","cp3*-macosx_universal2"]#,"cp3*-musllinux_x86_64","cp3*-musllinux_aarch64"]
 test-command = "python3 -m unittest discover -v -s {project}/python"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build-frontend = "build"
 build = ["cp3*-manylinux_x86_64","cp3*-macosx_universal2"]#,"cp3*-musllinux_x86_64","cp3*-musllinux_aarch64"]
+skip = "cp36-*"
 test-command = "python3 -m unittest discover -v -s {project}/python"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ MACOSX_DEPLOYMENT_TARGET = "10.15"
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux2014"
 before-all = "yum -y install libxml2-devel"
-repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
+#repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ MACOSX_DEPLOYMENT_TARGET = "10.15"
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux2014"
 before-all = "yum -y install libxml2-devel"
-#repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -16,11 +16,12 @@ set -e -u -x
 yum -y install libxml2-devel
 
 rm -rf /src_dir/arbor/_skbuild
+rm -rf /opt/python/cp36-cp36m
 
 export CIBUILDWHEEL=1 #Set condition for cmake
 
-for PYBIN in /opt/python/cp3{7..10}*/bin; do
-#     "${PYBIN}/python" -m pip install pip ninja cmake wheel scikit-build auditwheel -U
+for PYBIN in /opt/python/cp3*/bin; do
+    "${PYBIN}/python" -m pip install pip auditwheel -U
     export PATH="${PYBIN}":$PATH
     "${PYBIN}/python" -m pip wheel --wheel-dir="/src_dir/builtwheel${PYBIN}/" /src_dir/arbor
     "${PYBIN}/python" -m auditwheel repair /src_dir/builtwheel${PYBIN}/arbor*.whl -w /src_dir/wheelhouse

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -14,14 +14,13 @@
 set -e -u -x
 
 yum -y install libxml2-devel
-/opt/python/cp310-cp310/bin/pip install ninja cmake
 
 rm -rf /src_dir/arbor/_skbuild
 
 export CIBUILDWHEEL=1 #Set condition for cmake
 
-for PYBIN in /opt/python/cp*/bin; do
-    "${PYBIN}/python" -m pip install wheel scikit-build auditwheel
+for PYBIN in /opt/python/cp3{7..10}*/bin; do
+#     "${PYBIN}/python" -m pip install pip ninja cmake wheel scikit-build auditwheel -U
     export PATH="${PYBIN}":$PATH
     "${PYBIN}/python" -m pip wheel --wheel-dir="/src_dir/builtwheel${PYBIN}/" /src_dir/arbor
     "${PYBIN}/python" -m auditwheel repair /src_dir/builtwheel${PYBIN}/arbor*.whl -w /src_dir/wheelhouse

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -16,7 +16,7 @@ set -e -u -x
 yum -y install libxml2-devel
 
 rm -rf /src_dir/arbor/_skbuild
-rm -rf /opt/python/cp36-cp36m
+rm -rf /opt/python/cp36-cp36m # Python build toolchain does not work on Py3.6
 
 export CIBUILDWHEEL=1 #Set condition for cmake
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -69,14 +69,14 @@ class Arbor(CMakePackage, CudaPackage):
 
     # python (bindings)
     extends("python", when="+python")
-    depends_on("python@3.6:", when="+python", type=("build", "run"))
+    depends_on("python@3.7:", when="+python", type=("build", "run"))
     depends_on("py-numpy", when="+python", type=("build", "run"))
     with when("+python"):
         depends_on("py-pybind11@2.6:", type=("build", "run"))
         depends_on("py-pybind11@2.8.1:", when="@0.5.3:", type=("build", "run"))
 
     # sphinx based documentation
-    depends_on("python@3.6:", when="+doc", type="build")
+    depends_on("python@3.7:", when="+doc", type="build")
     depends_on("py-sphinx", when="+doc", type="build")
     depends_on("py-svgwrite", when="+doc", type="build")
 


### PR DESCRIPTION
* Failing Macos Python wheel builds fixed. (There is a weekly job, I just have not been checking it.)
* Macos Python wheels now come with dual-arch (x86-64 and arm64)
  * Testers wanted. I don't have Macs, let alone M1s.
* Moved (nearly) all Python build instructions to `pyproject.toml`
  * Enables 'build isolation', and need to specify build-deps only once, no need for users or CI scripts to pre-install them.
  * Enables editable `pip` installs (`pip install -e ./arbor`)
    * Testers wanted!
  * Compatible with 'build frontends' `pip` and `build`.
  * Passing CMake options actually got shorter
* Drop Python 3.6 support. This way of building does not work on that version anymore, but does 3.7 up to 3.11beta. I did my best to find the actual reason, or a formal declaration of cease of support, but couldn't find it. I assume something in this rather complex concoction of tooling is perhaps assuming 3.6 is in fact EOL.

Wheels available here: https://github.com/brenthuisman/arbor/actions/runs/2550193753

Closes #1683, #1414, #1409