### PR TITLE
Spack cache change, bump versions

### DIFF
--- a/.github/workflows/ciwheel.yml
+++ b/.github/workflows/ciwheel.yml
@@ -67,8 +67,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v2
       - name: Get packages
         run: python3 -m pip install build
       - name: Get Arbor

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
       - name: Get packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Get packages
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.spack-cache
-          key: ccache-${{ github.run_id }}
-          restore-keys: ccache-
+          key: arbor-cache-${{ github.run_id }}
+          restore-keys: arbor-cache-
 
       - name: Build Arbor's Spack package against the develop branch
         run: arbor/scripts/build_spack_package.sh arbor develop

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.spack-cache
-          key: cache-${{ github.sha }}
-          restore-keys: cache-
+          key: ccache-${{ github.run_id }}
+          restore-keys: ccache-
 
       - name: Build Arbor's Spack package against the develop branch
         run: arbor/scripts/build_spack_package.sh arbor develop

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.spack-cache
-          key: cache-${{ github.run_id }}
-          restore-keys: cache-
+          key: ccache-${{ github.run_id }}
+          restore-keys: ccache-
 
       - name: Build Arbor's Spack package against the develop branch
         run: arbor/scripts/build_spack_package.sh arbor develop

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.spack-cache
-          key: ccache-${{ github.run_id }}
-          restore-keys: ccache-
+          key: cache-${{ github.run_id }}
+          restore-keys: cache-
 
       - name: Build Arbor's Spack package against the develop branch
         run: arbor/scripts/build_spack_package.sh arbor develop

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           cmake-version: ${{ matrix.config.cmake }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.config.py }}
       - name: Update pip

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -46,8 +46,8 @@ jobs:
         - {
             name:  "Linux Max GCC",
             os:    "ubuntu-22.04",
-            cc:    "gcc-10",
-            cxx:   "g++-10",
+            cc:    "gcc-11",
+            cxx:   "g++-11",
             py:    "3.10",
             cmake: "3.22.x",
             mpi:   "ON",
@@ -56,8 +56,8 @@ jobs:
         - {
             name:  "Linux SIMD",
             os:    "ubuntu-22.04",
-            cc:    "gcc-10",
-            cxx:   "g++-10",
+            cc:    "gcc-11",
+            cxx:   "g++-11",
             py:    "3.10",
             cmake: "3.22.x",
             mpi:   "OFF",
@@ -66,8 +66,8 @@ jobs:
         - {
             name:  "Linux Max Clang",
             os:    "ubuntu-22.04",
-            cc:    "clang-10",
-            cxx:   "clang++-10",
+            cc:    "clang-14",
+            cxx:   "clang++-14",
             py:    "3.10",
             cmake: "3.22.x",
             mpi:   "ON",
@@ -93,11 +93,16 @@ jobs:
         # See https://github.com/open-mpi/ompi/issues/6518
         OMPI_MCA_btl: "self,tcp"
     steps:
-      - name: "Linux: get clang/gcc 8, libxml2"
+      - name: "Linux: get libxml2"
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y "clang-8" "lldb-8" "lld-8" "clang-format-8" g++-8 libxml2-dev
+          sudo apt-get install -y libxml2-dev
+      - name: "Linux-Min: get clang/gcc 8"
+        if: ${{ startsWith(matrix.config.os, 'ubuntu-18') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y "clang-8" "lldb-8" "lld-8" "clang-format-8" g++-8
       - name: "MacOS: get libxml2"
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         run: |

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -35,7 +35,7 @@ jobs:
           }
         - {
             name:  "MacOS Min",
-            os:    "macos-10.15",
+            os:    "macos-11",
             cc:    "clang",
             cxx:   "clang++",
             py:    "3.7",
@@ -45,7 +45,7 @@ jobs:
           }
         - {
             name:  "Linux Max GCC",
-            os:    "ubuntu-20.04",
+            os:    "ubuntu-22.04",
             cc:    "gcc-10",
             cxx:   "g++-10",
             py:    "3.10",
@@ -55,7 +55,7 @@ jobs:
           }
         - {
             name:  "Linux SIMD",
-            os:    "ubuntu-20.04",
+            os:    "ubuntu-22.04",
             cc:    "gcc-10",
             cxx:   "g++-10",
             py:    "3.10",
@@ -65,7 +65,7 @@ jobs:
           }
         - {
             name:  "Linux Max Clang",
-            os:    "ubuntu-20.04",
+            os:    "ubuntu-22.04",
             cc:    "clang-10",
             cxx:   "clang++-10",
             py:    "3.10",
@@ -75,7 +75,7 @@ jobs:
           }
         - {
             name:  "MacOS Max",
-            os:    "macos-11",
+            os:    "macos-12",
             cc:    "clang",
             cxx:   "clang++",
             py:    "3.10",

--- a/doc/ecosystem/index.rst
+++ b/doc/ecosystem/index.rst
@@ -38,6 +38,8 @@ nmlcc
 Wider ecosystem
 ---------------
 
+A list of tools in the computational neuroscience ecosystem is being maintained at `compneuroweb <https://compneuroweb.com/sftwr.html>`_. We've made a slightly more hierarchical overview of some of the simulators below, as well as an overview of some commonly used frameworks.
+
 Simulators
 ~~~~~~~~~~
 


### PR DESCRIPTION
- It's actually a Github cache trick: https://github.com/actions/cache/issues/342#issuecomment-673371329
  - First run: 1h 7m 38s 
  - Second run: same duration. Hmm....
  - Third run: ~10 minutes!
  - 4th: ~7.5 min.
- Bump in configs: macos 10.15 will disappear in a month: https://github.com/actions/virtual-environments/issues/5583
  - Bump clang-max to 14, gcc-max to 11
  - macos-min to 11, macos-max to 12.