### PR TITLE
modcc: Allow redundant, but correct READ declaration.

### DIFF
--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -723,17 +723,24 @@ void Module::add_variables_to_symbols() {
     }
 
     std::set<std::string> cond;
-    for(auto const& ion : neuron_block_.ions) {
-        for(auto const& var : ion.read) {
-            update_ion_symbols(var, accessKind::read, ion.name);
-        }
-        for(auto const& var : ion.write) {
+    for(auto const& ion: neuron_block_.ions) {
+        for(auto const& var: ion.write) {
             update_ion_symbols(var, accessKind::write, ion.name);
             auto name = "conductivity_" + ion.name + "_";
             if (cond.find(name) == cond.end()) {
                 create_indexed_variable(name, sourceKind::ion_conductivity, accessKind::write, ion.name, var.location);
                 cond.insert(name);
             }
+        }
+
+        for(auto const& var: ion.read) {
+            // Skip vars we have already processed as WRITE, since those can be read as well.
+            if (std::count_if(ion.write.begin(),
+                              ion.write.end(),
+                              [&var](const auto& it) { return var.spelling == it.spelling; })) {
+                continue;
+            }
+            update_ion_symbols(var, accessKind::read, ion.name);
         }
 
         if(ion.uses_valence()) {

--- a/test/unit-modcc/mod_files/test-rw-ion.mod
+++ b/test/unit-modcc/mod_files/test-rw-ion.mod
@@ -1,0 +1,8 @@
+NEURON {
+    SUFFIX hh
+    USEION na READ ena, ina WRITE ina
+}
+
+BREAKPOINT { ina = 5*(v - ena) }
+
+INITIAL {}

--- a/test/unit-modcc/test_module.cpp
+++ b/test/unit-modcc/test_module.cpp
@@ -113,3 +113,12 @@ TEST(Module, breakpoint) {
 
     EXPECT_TRUE(m.semantic());
 }
+
+TEST(Module, read_write_ion) {
+    Module m(io::read_all(DATADIR "/mod_files/test-rw-ion.mod"), "test-rw-ion.mod");
+    EXPECT_NE(m.buffer().size(), 0);
+
+    Parser p(m, false);
+    EXPECT_TRUE(p.parse());
+    EXPECT_TRUE(m.semantic());
+}


### PR DESCRIPTION

Fixes https://github.com/arbor-sim/arbor/issues/1845
