### PR TITLE
Elaborate on mpi4py.

### DIFF
--- a/doc/install/python.rst
+++ b/doc/install/python.rst
@@ -91,8 +91,9 @@ The following flags can be used to configure the installation:
 
 * ``ARB_WITH_NEUROML=<ON|OFF>``: Enable support for NeuroML2 morphologies,
   requires ``libxml2`` library. Default ``OFF``
-* ``ARB_WITH_MPI=<ON|OFF>``: Enable MPI support, requires MPI library.
-  Default ``OFF``.
+* ``ARB_WITH_MPI=<ON|OFF>``: Enable MPI support, requires MPI library. Default
+  ``OFF``. If you intend to use ``mpi4py``, you need to install the package before
+  building Arbor, as binding it requires access to its headers.
 * ``ARB_GPU=<none|cuda|cuda-clang|hip>``: Enable GPU support for NVIDIA GPUs
   with nvcc using ``cuda``, or with clang using ``cuda-clang`` (both require
   cudaruntime). Enable GPU support for AMD GPUs with hipcc using ``hip``. By

--- a/python/context.cpp
+++ b/python/context.cpp
@@ -161,7 +161,12 @@ void register_contexts(pybind11::module& m) {
                     throw pyarb_error("Attempt to set an MPI communicator but Arbor is not configured with MPI support.");
                 }
 #else
-                const char* mpi_err_str = "mpi must be None, or an MPI communicator";
+                const char* mpi_err_str = "mpi must be None, or a known MPI communicator type. Supported MPI implementations = native"
+#ifdef ARB_WITH_MPI4PY
+                    ", mpi4py.";
+#else
+                    ". Consider installing mpi4py and rebuilding Arbor.";
+#endif
                 if (can_convert_to_mpi_comm(mpi)) {
                     return context_shim(arb::make_context(a, convert_to_mpi_comm(mpi)));
                 }


### PR DESCRIPTION
Explain that
- mpi4py might be needed when throwing MPI error.
- mpi4py needs to be baked into Arbor at build time.

Closes #1785 