### PR TITLE
Deny WATCH statements.

### DIFF
--- a/modcc/parser.cpp
+++ b/modcc/parser.cpp
@@ -1008,6 +1008,8 @@ expression_ptr Parser::parse_statement() {
         return parse_solve();
     case tok::local:
         return parse_local();
+    case tok::watch:
+        return parse_watch();
     case tok::identifier:
         return parse_line_expression();
     case tok::conserve:
@@ -1399,6 +1401,7 @@ expression_ptr Parser::parse_unaryop() {
 /// expects one of :
 ///  ::  number
 ///  ::  identifier
+///  ::  watch
 ///  ::  call
 ///  ::  parenthesis expression (parsed recursively)
 ///  ::  prefix binary operators
@@ -1655,6 +1658,19 @@ conductance_statement_error:
         loc);
     return nullptr;
 }
+
+// WATCH (cond) flag
+expression_ptr Parser::parse_watch() {
+    Location loc = location_; // solve location for expression
+    get_token();              // consume keyword
+
+    parse_parenthesis_expression();
+    parse_expression();
+
+    error("WATCH statements are not supported in modcc.", loc);
+    return nullptr;
+}
+
 
 expression_ptr Parser::parse_if() {
     Token if_token = token_;

--- a/modcc/parser.hpp
+++ b/modcc/parser.hpp
@@ -36,6 +36,7 @@ public:
     expression_ptr parse_local();
     expression_ptr parse_solve();
     expression_ptr parse_conductance();
+    expression_ptr parse_watch();
     expression_ptr parse_block(bool);
     expression_ptr parse_initial();
     expression_ptr parse_compartment_statement();

--- a/modcc/token.cpp
+++ b/modcc/token.cpp
@@ -74,6 +74,7 @@ static Keyword keywords[] = {
     {"exprelr",     tok::exprelr},
     {"safeinv",     tok::safeinv},
     {"CONDUCTANCE", tok::conductance},
+    {"WATCH",       tok::watch},
     {nullptr,       tok::reserved},
 };
 
@@ -152,6 +153,7 @@ static TokenString token_strings[] = {
     {"sin",         tok::sin},
     {"cnexp",       tok::cnexp},
     {"CONDUCTANCE", tok::conductance},
+    {"WATCH",       tok::watch},
     {"error",       tok::reserved},
 };
 

--- a/modcc/token.hpp
+++ b/modcc/token.hpp
@@ -83,6 +83,9 @@ enum class tok {
 
     conductance,
 
+    // trap unsupported keywords
+    watch,
+
     reserved, // placeholder for generating keyword lookup
 };
 

--- a/test/unit-modcc/test_parser.cpp
+++ b/test/unit-modcc/test_parser.cpp
@@ -279,6 +279,10 @@ TEST(Parser, parse_conductance) {
     }
 }
 
+TEST(Parser, parse_watch) {
+    EXPECT_TRUE(check_parse_fail(&Parser::parse_watch, "WATCH( 0 < 1) 42"));
+}
+
 TEST(Parser, parse_if) {
     std::unique_ptr<IfExpression> s;
 


### PR DESCRIPTION
Throw an error if `WATCH` is encountered.

Closes #18 