### PR TITLE
Fix cmake paths so we can use Arbor as a sub-project.

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -159,8 +159,11 @@ function(export_visibility target)
 
     # generate config file
     get_target_property(target_binary_dir ${target} BINARY_DIR)
+    message("current src: ${CMAKE_CURRENT_SOURCE_DIR}")
+    message("project src: ${PROJECT_SOURCE_DIR}")
+    message("target  bin: ${target_binary_dir}")
     configure_file(
         ${PROJECT_SOURCE_DIR}/cmake/export.hpp.in
-        ${CMAKE_CURRENT_BINARY_DIR}/include/${target_short_name}/export.hpp
+        ${target_binary_dir}/include/${target_short_name}/export.hpp
         @ONLY)
 endfunction()

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -159,9 +159,6 @@ function(export_visibility target)
 
     # generate config file
     get_target_property(target_binary_dir ${target} BINARY_DIR)
-    message("current src: ${CMAKE_CURRENT_SOURCE_DIR}")
-    message("project src: ${PROJECT_SOURCE_DIR}")
-    message("target  bin: ${target_binary_dir}")
     configure_file(
         ${PROJECT_SOURCE_DIR}/cmake/export.hpp.in
         ${target_binary_dir}/include/${target_short_name}/export.hpp

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -160,7 +160,7 @@ function(export_visibility target)
     # generate config file
     get_target_property(target_binary_dir ${target} BINARY_DIR)
     configure_file(
-        ${CMAKE_SOURCE_DIR}/cmake/export.hpp.in
-        ${target_binary_dir}/include/${target_short_name}/export.hpp
+        ${PROJECT_SOURCE_DIR}/cmake/export.hpp.in
+        ${CMAKE_CURRENT_BINARY_DIR}/include/${target_short_name}/export.hpp
         @ONLY)
 endfunction()

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -690,6 +690,9 @@ void register_cells(pybind11::module& m) {
             "while the method for calculating reversal potential is global for all\n"
             "compartments in the cell, and can't be overriden locally.")
         // Paint mechanisms.
+        .def("paintings",
+            [](arb::decor& dec) { return dec.paintings(); },
+            "Return a view of all painted items.")
         .def("paint",
             [](arb::decor& dec, const char* region, const arb::density& mechanism) {
                 return dec.paint(arborio::parse_region_expression(region).unwrap(), mechanism);

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -690,9 +690,6 @@ void register_cells(pybind11::module& m) {
             "while the method for calculating reversal potential is global for all\n"
             "compartments in the cell, and can't be overriden locally.")
         // Paint mechanisms.
-        .def("paintings",
-            [](arb::decor& dec) { return dec.paintings(); },
-            "Return a view of all painted items.")
         .def("paint",
             [](arb::decor& dec, const char* region, const arb::density& mechanism) {
                 return dec.paint(arborio::parse_region_expression(region).unwrap(), mechanism);


### PR DESCRIPTION
The current CMake utility CompilerOptions.cmake uses the wrong kind of paths 
which evaluate to the _current_ project, even if that is not Arbor itself. That becomes
an issue if Arbor is built as a submodule.

Closes #1947 
