### PR TITLE
Make `mpoint`s hashable.

### DIFF
--- a/arbor/include/arbor/morph/primitives.hpp
+++ b/arbor/include/arbor/morph/primitives.hpp
@@ -122,3 +122,4 @@ ARB_ARBOR_API bool test_invariants(const mcable_list&);
 
 ARB_DEFINE_HASH(arb::mcable, a.branch, a.prox_pos, a.dist_pos);
 ARB_DEFINE_HASH(arb::mlocation, a.branch, a.pos);
+ARB_DEFINE_HASH(arb::mpoint, a.x, a.y, a.z, a.radius);


### PR DESCRIPTION
The GUI would like to have lookups from `arb::mpoint` to something, so please make it happen ;)