### PR TITLE
Remove abuse of arg_v.

### DIFF
--- a/python/cable_cell_io.cpp
+++ b/python/cable_cell_io.cpp
@@ -45,47 +45,47 @@ void write_component(const arborio::cable_cell_component& component, py::object 
 void register_cable_loader(pybind11::module& m) {
     m.def("load_component",
           &load_component,
-          pybind11::arg_v("filename", "the name of the file."),
+          pybind11::arg("filename"),
           "Load arbor-component (decor, morphology, label_dict, cable_cell) from file.");
 
     m.def("write_component",
           [](const arborio::cable_cell_component& d, py::object fn) {
             return write_component(d, fn);
           },
-          pybind11::arg_v("object", "the cable_component object."),
-          pybind11::arg_v("filename", "the path of the file."),
+          pybind11::arg("object"),
+          pybind11::arg("filename"),
           "Write cable_component to file.");
 
     m.def("write_component",
           [](const arb::decor& d, py::object fn) {
             return write_component<arb::decor>(d, fn);
           },
-          pybind11::arg_v("object", "the decor object."),
-          pybind11::arg_v("filename", "the name of the file."),
+          pybind11::arg("object"),
+          pybind11::arg("filename"),
           "Write decor to file.");
 
     m.def("write_component",
           [](const arb::label_dict& d, py::object fn) {
             return write_component<arb::label_dict>(d, fn);
           },
-          pybind11::arg_v("object", "the label_dict object."),
-          pybind11::arg_v("filename", "the name of the file."),
+          pybind11::arg("object"),
+          pybind11::arg("filename"),
           "Write label_dict to file.");
 
     m.def("write_component",
           [](const arb::morphology& d, py::object fn) {
             return write_component<arb::morphology>(d, fn);
           },
-          pybind11::arg_v("object", "the morphology object."),
-          pybind11::arg_v("filename", "the name of the file."),
+          pybind11::arg("object"),
+          pybind11::arg("filename"),
           "Write morphology to file.");
 
     m.def("write_component",
           [](const arb::cable_cell& d, py::object fn) {
             return write_component<arb::cable_cell>(d, fn);
           },
-          pybind11::arg_v("object", "the cable_cell object."),
-          pybind11::arg_v("filename", "the name of the file."),
+          pybind11::arg("object"),
+          pybind11::arg("filename"),
           "Write cable_cell to file.");
 
     // arborio::meta_data

--- a/python/cable_cell_io.cpp
+++ b/python/cable_cell_io.cpp
@@ -45,7 +45,7 @@ void write_component(const arborio::cable_cell_component& component, py::object 
 void register_cable_loader(pybind11::module& m) {
     m.def("load_component",
           &load_component,
-          pybind11::arg("filename"),
+          pybind11::arg("filename_or_descriptor"),
           "Load arbor-component (decor, morphology, label_dict, cable_cell) from file.");
 
     m.def("write_component",
@@ -53,7 +53,7 @@ void register_cable_loader(pybind11::module& m) {
             return write_component(d, fn);
           },
           pybind11::arg("object"),
-          pybind11::arg("filename"),
+          pybind11::arg("filename_or_descriptor"),
           "Write cable_component to file.");
 
     m.def("write_component",
@@ -61,7 +61,7 @@ void register_cable_loader(pybind11::module& m) {
             return write_component<arb::decor>(d, fn);
           },
           pybind11::arg("object"),
-          pybind11::arg("filename"),
+          pybind11::arg("filename_or_descriptor"),
           "Write decor to file.");
 
     m.def("write_component",
@@ -69,7 +69,7 @@ void register_cable_loader(pybind11::module& m) {
             return write_component<arb::label_dict>(d, fn);
           },
           pybind11::arg("object"),
-          pybind11::arg("filename"),
+          pybind11::arg("filename_or_descriptor"),
           "Write label_dict to file.");
 
     m.def("write_component",
@@ -77,7 +77,7 @@ void register_cable_loader(pybind11::module& m) {
             return write_component<arb::morphology>(d, fn);
           },
           pybind11::arg("object"),
-          pybind11::arg("filename"),
+          pybind11::arg("filename_or_descriptor"),
           "Write morphology to file.");
 
     m.def("write_component",
@@ -85,7 +85,7 @@ void register_cable_loader(pybind11::module& m) {
             return write_component<arb::cable_cell>(d, fn);
           },
           pybind11::arg("object"),
-          pybind11::arg("filename"),
+          pybind11::arg("filename_or_descriptor"),
           "Write cable_cell to file.");
 
     // arborio::meta_data

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -450,8 +450,8 @@ void register_cells(pybind11::module& m) {
                 s.scale(std::move(name), arborio::parse_iexpr_expression(ex).unwrap());
                 return s;
             },
-            pybind11::arg_v("name", "name of parameter to scale."),
-            pybind11::arg_v("ex", "iexpr for scaling"),
+            pybind11::arg("name"),
+            pybind11::arg("ex"),
             "Add a scaling expression to a parameter.")
         .def("__repr__",
             [](const arb::scaled_mechanism<arb::density>& d) {
@@ -611,7 +611,7 @@ void register_cells(pybind11::module& m) {
                     props.default_parameters.reversal_potential_method[ion] = *m;
                 }
             },
-            pybind11::arg_v("ion", "name of the ion species."),
+            pybind11::arg("ion"),
             pybind11::arg_v("valence", pybind11::none(), "valence of the ion species."),
             pybind11::arg_v("int_con", pybind11::none(), "initial internal concentration [mM]."),
             pybind11::arg_v("ext_con", pybind11::none(), "initial external concentration [mM]."),
@@ -678,7 +678,7 @@ void register_cells(pybind11::module& m) {
                 if (auto m = maybe_method(method)) d.set_default(arb::ion_reversal_potential_method{ion, *m});
                 return d;
             },
-            pybind11::arg_v("ion", "name of the ion species."),
+            pybind11::arg("ion"),
             pybind11::arg_v("int_con", pybind11::none(), "initial internal concentration [mM]."),
             pybind11::arg_v("ext_con", pybind11::none(), "initial external concentration [mM]."),
             pybind11::arg_v("rev_pot", pybind11::none(), "reversal potential [mV]."),
@@ -716,7 +716,7 @@ void register_cells(pybind11::module& m) {
                 if (tempK) dec.paint(r, arb::temperature_K{*tempK});
                 return dec;
             },
-            pybind11::arg_v("region", "the region label or description."),
+            pybind11::arg("region"),
             pybind11::arg_v("Vm",    pybind11::none(), "initial membrane voltage [mV]."),
             pybind11::arg_v("cm",    pybind11::none(), "membrane capacitance [F/m²]."),
             pybind11::arg_v("rL",    pybind11::none(), "axial resistivity [Ω·cm]."),
@@ -774,13 +774,15 @@ void register_cells(pybind11::module& m) {
             "The group of spike detectors has the label 'label', used for forming connections between cells.")
         .def("discretization",
             [](arb::decor& dec, const arb::cv_policy& p) { return dec.set_default(p); },
-            pybind11::arg_v("policy", "A cv_policy used to discretise the cell into compartments for simulation"))
+            pybind11::arg("policy"),
+             "A cv_policy used to discretise the cell into compartments for simulation")
         .def("discretization",
             [](arb::decor& dec, const std::string& p) {
                 return dec.set_default(arborio::parse_cv_policy_expression(p).unwrap());
             },
-            pybind11::arg_v("policy", "An s-expression string representing a cv_policy used to discretise the "
-                                      "cell into compartments for simulation"));
+            pybind11::arg("policy"),
+            "An s-expression string representing a cv_policy used to discretise the "
+            "cell into compartments for simulation");
 
     // arb::cable_cell
 


### PR DESCRIPTION
Do not abuse `pybind::arg_v("name", T default, "description")` as `pybind::arg_v("name", "description")`.
Use descriptive names and `pybind::arg` instead.

Closes #1754 