### PR TITLE
bump pybind11 for py3.11 compat

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -79,6 +79,7 @@ class Arbor(CMakePackage, CudaPackage):
     with when("+python"):
         depends_on("py-pybind11@2.6:", type=("build"))
         depends_on("py-pybind11@2.8.1:", when="@0.5.3:", type=("build"))
+        depends_on("py-pybind11@2.10.0:", when="@0.7.1:", type=("build"))
 
     # sphinx based documentation
     depends_on("python@3.7:", when="+doc", type="build")


### PR DESCRIPTION
With a Python 3.11 RC out, our CI wheel builder was running into problems: https://github.com/arbor-sim/arbor/runs/7936097742?check_suite_focus=true#step:7:4491
This PR bumps the Pybind11 module to 2.10.0, which provides ~~Windows~~ Python 3.11 support. See https://github.com/arbor-sim/arbor/actions/runs/2902228009