### PR TITLE
Remove explicit generator

### DIFF
--- a/example/diffusion/diffusion.cpp
+++ b/example/diffusion/diffusion.cpp
@@ -31,7 +31,7 @@ struct linear: public recipe {
     cell_kind get_cell_kind(cell_gid_type)                       const override { return cell_kind::cable; }
     std::any get_global_properties(cell_kind)                    const override { return gprop; }
     std::vector<probe_info> get_probes(cell_gid_type)            const override { return {cable_probe_ion_diff_concentration_cell{"na"}}; }
-    std::vector<event_generator> event_generators(cell_gid_type) const override { return {explicit_generator({{{"Zap"}, 0.0, 0.005}})}; }
+    std::vector<event_generator> event_generators(cell_gid_type) const override { return {explicit_generator({"Zap"}, 0.005, std::vector<float>{0.f})}; }
     util::unique_any get_cell_description(cell_gid_type)         const override {
         // Stick morphology
         // -----|-----

--- a/example/dryrun/dryrun.cpp
+++ b/example/dryrun/dryrun.cpp
@@ -112,7 +112,7 @@ public:
     std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
         std::vector<arb::event_generator> gens;
         if (gid%20 == 0) {
-            gens.push_back(arb::explicit_generator({{{"synapse"}, 1.0, event_weight_}}));
+            gens.push_back(arb::explicit_generator({"synapse"}, event_weight_, std::vector<float>{1.0f}));
         }
         return gens;
     }

--- a/example/ring/ring.cpp
+++ b/example/ring/ring.cpp
@@ -100,7 +100,7 @@ public:
     std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
         std::vector<arb::event_generator> gens;
         if (!gid) {
-            gens.push_back(arb::explicit_generator({{{"primary_syn"}, 1.0, event_weight_}}));
+            gens.push_back(arb::explicit_generator({"primary_syn"}, event_weight_, std::vector<float>{1.0f}));
         }
         return gens;
     }

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -107,7 +107,7 @@ static std::vector<arb::event_generator> convert_gen(std::vector<pybind11::objec
         auto& p = cast<const pyarb::event_generator_shim&>(g);
 
         // convert the event_generator to an arb::event_generator
-        gens.push_back(arb::schedule_generator(p.target, p.weight, std::move(p.time_sched)));
+        gens.push_back(arb::event_generator(p.target, p.weight, std::move(p.time_sched)));
     }
 
     return gens;

--- a/test/unit/test_diffusion.cpp
+++ b/test/unit/test_diffusion.cpp
@@ -54,7 +54,9 @@ struct linear: public recipe {
 
     std::vector<arb::event_generator> event_generators(arb::cell_gid_type gid) const override {
         std::vector<arb::event_generator> result;
-        for (const auto& [t, w]: inject_at) result.push_back(arb::explicit_generator({{{"Zap"}, t, w}}));
+        for (const auto& [t, w]: inject_at) {
+            result.push_back(arb::explicit_generator({"Zap"}, w, std::vector<float>{t}));
+        }
         return result;
     }
 
@@ -62,7 +64,7 @@ struct linear: public recipe {
     double extent = 1.0,
            diameter = 1.0,
            cv_length = 1.0;
-    std::vector<std::tuple<double, float>> inject_at;
+    std::vector<std::tuple<float, float>> inject_at;
     morphology morph;
     arb::decor decor;
 

--- a/test/unit/test_event_generators.cpp
+++ b/test/unit/test_event_generators.cpp
@@ -33,8 +33,7 @@ TEST(event_generators, assign_and_copy) {
     event_generator g1(gen);
     EXPECT_EQ(expected, first(g1.events(0., 1.)));
 
-    event_generator g2;
-    g2 = gen;
+    event_generator g2 = gen;
     EXPECT_EQ(expected, first(g2.events(0., 1.)));
 
     const auto& const_gen = gen;
@@ -42,8 +41,7 @@ TEST(event_generators, assign_and_copy) {
     event_generator g3(const_gen);
     EXPECT_EQ(expected, first(g3.events(0., 1.)));
 
-    event_generator g4;
-    g4 = gen;
+    event_generator g4 = gen;
     EXPECT_EQ(expected, first(g4.events(0., 1.)));
 
     event_generator g5(std::move(gen));

--- a/test/unit/test_event_generators.cpp
+++ b/test/unit/test_event_generators.cpp
@@ -82,54 +82,30 @@ TEST(event_generators, regular) {
     EXPECT_EQ(expected({12, 12.5}), as_vector(gen.events(12, 12.7)));
 }
 
+using lse_vector = std::vector<std::tuple<cell_local_label_type, time_type, float>>;
+
 TEST(event_generators, seq) {
-    explicit_generator::lse_vector in = {
-        {{"l0"}, 0.1, 1.0},
-        {{"l0"}, 1.0, 2.0},
-        {{"l2"}, 1.0, 3.0},
-        {{"l1"}, 1.5, 4.0},
-        {{"l2"}, 2.3, 5.0},
-        {{"l0"}, 3.0, 6.0},
-        {{"l0"}, 3.5, 7.0},
-    };
-    std::unordered_map<cell_tag_type, cell_lid_type> lid_map = {{"l0", 0},{"l1", 1}, {"l2", 2}};
+    std::vector<arb::time_type> times = {1, 2, 3, 4, 5, 6, 7};
+    lse_vector in;
     pse_vector expected;
-    std::transform(in.begin(), in.end(), std::back_inserter(expected),
-        [lid_map](const auto& item) {return spike_event{lid_map.at(item.label.tag), item.time, item.weight};});
+    float weight = 0.42;
+    arb::cell_local_label_type l0 = {"l0"};
+    for (auto time: times) {
+        in.push_back({l0, weight, time});
+        expected.push_back({0, time, weight});
+    }
 
-    event_generator gen = explicit_generator(in);
-    gen.resolve_label([lid_map](const cell_local_label_type& item) {return lid_map.at(item.tag);});
+    event_generator gen = explicit_generator(l0, weight, times);
+    gen.resolve_label([](const cell_local_label_type&) {return 0;});
 
-    EXPECT_EQ(expected, as_vector(gen.events(0, 100.)));
-    gen.reset();
-    EXPECT_EQ(expected, as_vector(gen.events(0, 100.)));
-    gen.reset();
+    EXPECT_EQ(expected, as_vector(gen.events(0, 100.))); gen.reset();
+    EXPECT_EQ(expected, as_vector(gen.events(0, 100.))); gen.reset();
 
-    // Check reported sub-intervals against a smaller set of events.
-    in = {
-        {{"l0"}, 1.5, 4.0},
-        {{"l0"}, 2.3, 5.0},
-        {{"l0"}, 3.0, 6.0},
-        {{"l0"}, 3.5, 7.0},
-    };
-    expected.clear();
-    std::transform(in.begin(), in.end(), std::back_inserter(expected),
-        [lid_map](const auto& item) {return spike_event{lid_map.at(item.label.tag), item.time, item.weight};});
-
-    gen = explicit_generator(in);
-    gen.resolve_label([lid_map](const cell_local_label_type& item) {return lid_map.at(item.tag);});
-
-    auto draw = [](event_generator& gen, time_type t0, time_type t1) {
-        gen.reset();
-        return as_vector(gen.events(t0, t1));
-    };
-
-    auto events = [&expected] (int b, int e) {
-      return pse_vector(expected.begin()+b, expected.begin()+e);
-    };
+    auto draw = [](auto& gen, auto t0, auto t1) { gen.reset(); return as_vector(gen.events(t0, t1)); };
+    auto events = [&expected] (int b, int e) { auto beg = expected.begin(); return pse_vector(beg+b, beg+e); };
 
     // a range that includes all the events
-    EXPECT_EQ(expected, draw(gen, 0, 4));
+    EXPECT_EQ(expected, draw(gen, 0, 8));
 
     // a strict subset including the first event
     EXPECT_EQ(events(0, 2), draw(gen, 0, 3));

--- a/test/unit/test_probe.cpp
+++ b/test/unit/test_probe.cpp
@@ -1249,8 +1249,7 @@ void run_exact_sampling_probe_test(const context& ctx) {
 
         std::vector<event_generator> event_generators(cell_gid_type gid) const override {
             // Send a single event to cell i at 0.1*i milliseconds.
-            explicit_generator::lse_vector spikes = {{{"syn"}, 0.1*gid, 1.f}};
-            return {explicit_generator(spikes)};
+            return {explicit_generator({"syn"}, 1.0f, std::vector<float>{0.1f*gid})};
         }
 
         std::any get_global_properties(cell_kind k) const override {

--- a/test/unit/test_recipe.cpp
+++ b/test/unit/test_recipe.cpp
@@ -210,8 +210,7 @@ TEST(recipe, event_generators) {
         auto recipe_0 = custom_recipe({cell_0, cell_1}, {{}, {}}, {{}, {}},  {gens_0, gens_1});
         auto decomp_0 = partition_load_balance(recipe_0, context);
 
-        auto sim = simulation(recipe_0, context, decomp_0);
-        EXPECT_NO_THROW(sim.run(1, 0.1));
+        EXPECT_NO_THROW(simulation(recipe_0, context, decomp_0).run(1, 0.1));
     }
     {
         std::vector<arb::event_generator>
@@ -221,7 +220,6 @@ TEST(recipe, event_generators) {
         auto recipe_0 = custom_recipe({cell_0, cell_1}, {{}, {}}, {{}, {}},  {gens_0, gens_1});
         auto decomp_0 = partition_load_balance(recipe_0, context);
 
-        auto sim = simulation(recipe_0, context, decomp_0);
-        EXPECT_THROW(sim.run(1, 0.1), arb::bad_connection_label);
+        EXPECT_THROW(simulation(recipe_0, context, decomp_0), arb::bad_connection_label);
     }
 }

--- a/test/unit/test_simulation.cpp
+++ b/test/unit/test_simulation.cpp
@@ -124,7 +124,7 @@ struct lif_chain: public recipe {
             return {};
         }
         else {
-            return {schedule_generator({"tgt"}, weight_, triggers_)};
+            return {event_generator({"tgt"}, weight_, triggers_)};
         }
     }
 


### PR DESCRIPTION
- Remove the old, multi-target `event_generator` class in favour of `schedule_generator(tgt, weight, explicit_schedule)`
- Much simplification ensues, `event_generator` is no longer a type-erasing container, but just what 
   `schedule_generator` was before
- Make the label resolution in generators a bit more eager, no longer at simulation time, 
   but now during setup (bit give a wee bit of perf as well)

Closes #1488 