### PR TITLE
Catch symdiff errors.

### DIFF
--- a/modcc/error.hpp
+++ b/modcc/error.hpp
@@ -71,6 +71,3 @@ public:
 private:
     error_entry error_info_;
 };
-
-
-

--- a/modcc/expression.hpp
+++ b/modcc/expression.hpp
@@ -18,6 +18,7 @@
 class Visitor;
 
 class ARB_LIBMODCC_API Expression;
+struct ARB_LIBMODCC_API ErrorExpression;
 class ARB_LIBMODCC_API CallExpression;
 class ARB_LIBMODCC_API BlockExpression;
 class ARB_LIBMODCC_API IfExpression;
@@ -208,6 +209,20 @@ protected:
     Location location_;
     scope_ptr scope_;
 };
+
+struct ARB_LIBMODCC_API ErrorExpression : public Expression {
+    explicit ErrorExpression(Location location): Expression(location)
+    {}
+
+    std::string to_string() const override {
+        return "Error" + error_string_;
+    }
+
+    void accept(Visitor *) override {
+        throw compiler_exception{"Attempted to visit error expression.", location()};
+    }
+};
+
 
 class ARB_LIBMODCC_API Symbol : public Expression {
 public :

--- a/modcc/modcc.cpp
+++ b/modcc/modcc.cpp
@@ -25,12 +25,12 @@ using std::cerr;
 // Options and option parsing:
 
 int report_error(const std::string& message) {
-    cerr << red("error: ") << message << "\n";
+    cerr << red("error trace:\n") << message << "\n";
     return 1;
 }
 
 int report_ice(const std::string& message) {
-    cerr << red("internal compiler error: ") << message << "\n"
+    cerr << red("internal compiler error:\n") << message << "\n"
          << "\nPlease report this error to the modcc developers.\n";
     return 1;
 }
@@ -223,6 +223,7 @@ int main(int argc, char **argv) {
         emit_header("semantic analysis");
         m.semantic();
         if (m.has_warning()) {
+            cerr << yellow("Warnings:\n");
             cerr << m.warning_string() << "\n";
         }
         if (m.has_error()) {

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -119,7 +119,7 @@ std::string Module::error_string() const {
     std::string str;
     for (const error_entry& entry: errors()) {
         if (!str.empty()) str += '\n';
-        str += red("error   ");
+        str += red("  * ");
         str += white(pprintf("%:% ", source_name(), entry.location));
         str += entry.message;
     }
@@ -130,7 +130,7 @@ std::string Module::warning_string() const {
     std::string str;
     for (auto& entry: warnings()) {
         if (!str.empty()) str += '\n';
-        str += purple("warning   ");
+        str += purple("  * ");
         str += white(pprintf("%:% ", source_name(), entry.location));
         str += entry.message;
     }

--- a/modcc/symdiff.cpp
+++ b/modcc/symdiff.cpp
@@ -689,7 +689,7 @@ ARB_LIBMODCC_API linear_test_result linear_test(Expression* e, const std::vector
     ConstantSimplifyVisitor csimp_visitor;
     result.constant->accept(&csimp_visitor);
     result.constant = csimp_visitor.result();
-    if (result.constant.get() == nullptr) throw compiler_exception{"Simplify: linear has no constant term.", loc};
+    if (result.constant.get() == nullptr) throw compiler_exception{"Linear test: simplification of the constant term failed.", loc};
 
     // linearity test: take second order derivatives, test against zero.
     result.is_linear = true;

--- a/modcc/symdiff.hpp
+++ b/modcc/symdiff.hpp
@@ -81,7 +81,7 @@ inline expression_ptr substitute(const expression_ptr& e, const substitute_map& 
 
 // Linearity testing
 
-struct linear_test_result {
+struct linear_test_result: public error_stack {
     bool is_linear = false;
     bool is_homogeneous = false;
     expression_ptr constant;

--- a/test/unit-modcc/mod_files/bug-1893-bad.mod
+++ b/test/unit-modcc/mod_files/bug-1893-bad.mod
@@ -1,0 +1,28 @@
+NEURON {
+    POINT_PROCESS bug_1893
+}
+
+INITIAL {
+    c = 0
+    rho = 0
+    theta_p = 0
+}
+
+STATE {
+    c
+    rho
+    theta_p
+}
+
+PARAMETER {
+    tau_c = 150 (ms)
+}
+
+BREAKPOINT {
+    SOLVE state METHOD cnexp
+}
+
+DERIVATIVE state {
+    c' = -c/tau_c
+    rho' = (c - theta_p) > 0
+}

--- a/test/unit-modcc/mod_files/bug-1893.mod
+++ b/test/unit-modcc/mod_files/bug-1893.mod
@@ -1,0 +1,28 @@
+NEURON {
+    POINT_PROCESS bug_1893
+}
+
+INITIAL {
+    c = 0
+    rho = 0
+    theta_p = 0
+}
+
+STATE {
+    c
+    rho
+    theta_p
+}
+
+PARAMETER {
+    tau_c = 150 (ms)
+}
+
+BREAKPOINT {
+    SOLVE state METHOD sparse
+}
+
+DERIVATIVE state {
+    c' = -c/tau_c
+    rho' = (c - theta_p) > 0
+}

--- a/test/unit-modcc/test_module.cpp
+++ b/test/unit-modcc/test_module.cpp
@@ -122,3 +122,24 @@ TEST(Module, read_write_ion) {
     EXPECT_TRUE(p.parse());
     EXPECT_TRUE(m.semantic());
 }
+
+// Regression test in #1893 we found that the solver segfaults when handed a
+// naked comparison statement.
+TEST(Module, solver_bug_1893) {
+    {
+        Module m(io::read_all(DATADIR "/mod_files/bug-1893.mod"), "bug-1893.mod");
+        EXPECT_NE(m.buffer().size(), 0);
+
+        Parser p(m, false);
+        EXPECT_TRUE(p.parse());
+        EXPECT_TRUE(m.semantic());
+    }
+    {
+        Module m(io::read_all(DATADIR "/mod_files/bug-1893-bad.mod"), "bug-1893.mod");
+        EXPECT_NE(m.buffer().size(), 0);
+
+        Parser p(m, false);
+        EXPECT_TRUE(p.parse());
+        EXPECT_FALSE(m.semantic());
+    }
+}


### PR DESCRIPTION
- Make symbolic differentiation return a more refined type.
- Catch said error when trying to test for linearity
- Catch the propagated error in CNExp and recommend using a different one.
- Straighten out the error printing at top level
- Add regression tests

Closes #1893

New output show the full error stack
```
bin/modcc bug_1893/bug_1893.mod -N 'arb::allen_catalogue' -t cpu -t gpu
error trace:
  * bug_1893/bug_1893.mod:(line 27,col 26) symbolic differential of unrecognized binary expression
  * bug_1893/bug_1893.mod:(line 27,col 10) CNExp: Could not determine linearity, maybe use a different solver?
```