### PR TITLE
Add spike counts to pre-commit tests.

### DIFF
--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -75,6 +75,8 @@ Release
    
 #. Change ``VERSION``. Make sure does not end with ``-rc`` or ``-dev``.
 
+#. Update ``scripts/check-all-tags.sh`` to check the current tag.
+
 #. Tag
 
    - commit and open a PR for the above changes.

--- a/scripts/check-all-tags.sh
+++ b/scripts/check-all-tags.sh
@@ -62,7 +62,12 @@ do
         echo " * SIMD=$simd"
         check brunel 6998
         check bench 972
-        check ring 19
+        if [[ "$tag" < "v0.7" ]]
+        then
+            check ring 19
+        else
+            check ring 94
+        fi
         check gap_junctions 30
     done
 done

--- a/scripts/check-all-tags.sh
+++ b/scripts/check-all-tags.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Runs all C++ examples
+
+set -Eeuo pipefail
+
+if [[ "$#" -gt 1 ]]; then
+    echo "usage: run_cpp_examples.sh <prefix, e.g., mpirun -n 4 -oversubscribe>"
+	exit 1
+fi
+
+PREFIX="${1:-} `pwd`/build/bin"
+
+cxx=/usr/local/opt/llvm/bin/clang++
+cc=/usr/local/opt/llvm/bin/clang
+
+for tag in v0.4 v0.5.2 v0.6 v0.7
+do
+    echo "Version=$tag"
+    rm -rf ext/*
+    git checkout $tag
+    git checkout $tag -- ext/
+    git submodule update --init
+    for simd in ON OFF
+    do
+        echo " * simd=$simd"
+        out=results/$tag-`git rev-parse --short HEAD`/cpp/simd=$simd
+        cd build
+        cmake .. -DARB_USE_BUNDLED_LIBS=ON -DCMAKE_CXX_COMPILER=$cxx -DCMAKE_C_COMPILER=$cc -DCMAKE_BUILD_TYPE=release -DARB_VECTORIZE=$simd -DARB_ARCH=native
+        ninja install examples
+        cd -
+        for ex in bench brunel gap_junctions generators lfp ring single-cell "probe-demo v"
+        do
+            echo "   - $ex"
+            dir=`echo $ex | tr ' ' '_'`
+            mkdir -p $out/$dir
+            cd $out/$dir
+            $PREFIX/$ex > stdout.txt 2> stderr.txt
+            cd -
+        done
+    done
+done
+
+ok=0
+check () {
+    prog=$1
+    expected="$2 spikes"
+    actual=$(/usr/bin/grep -Eo '\d+ spikes' results/$tag/cpp/SIMD=$simd/$prog/stdout.txt || echo "N/A")
+    if [ "$expected" == "$actual" ]
+    then
+        echo "   - $prog: OK"
+    else
+        echo "   - $prog: ERROR wrong number of spikes: $expected ./. $actual"
+        ok=1
+    fi
+}
+
+for tag in "v0.4-79855b66" "v0.5.2-51e35898" "v0.6-930c23eb" "v0.7-d0e424b4"
+do
+    echo "Version=$tag"
+    for simd in ON OFF
+    do
+        echo " * SIMD=$simd"
+        check brunel 6998
+        check bench 972
+        check ring 19
+        check gap_junctions 30
+    done
+done
+exit $ok

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -18,9 +18,9 @@ check () {
     expected="$2 spikes"
     pwd
     ls $out/$prog/stdout.txt
-    which grep
-    grep -Eo '\d+ spikes' $out/$prog/stdout.txt
-    actual=$(grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
+    cat $out/$prog/stdout.txt
+    /usr/bin/grep -Eo '\d+ spikes' $out/$prog/stdout.txt
+    actual=$(/usr/bin/grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then
         echo "   - $prog: OK"

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -16,7 +16,7 @@ ok=0
 check () {
     prog=$1
     expected="$2 spikes"
-    actual=$(/usr/bin/grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
+    actual=$(grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then
         echo "   - $prog: OK"

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -9,14 +9,14 @@ if [[ "$#" -gt 1 ]]; then
 fi
 
 PREFIX="${1:-} `pwd`/build/bin"
-
 tag=dev-`git rev-parse --short HEAD`
+out="results/$tag/cpp/"
 
 ok=0
 check () {
     prog=$1
     expected="$2 spikes"
-    actual=$(/usr/bin/grep -Eo '\d+ spikes' results/$tag/cpp/SIMD=$simd/$prog/stdout.txt || echo "N/A")
+    actual=$(/usr/bin/grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then
         echo "   - $prog: OK"
@@ -29,6 +29,7 @@ check () {
 for ex in bench brunel gap_junctions generators lfp ring single-cell "probe-demo v"
 do
     echo "   - $ex"
+    "results/$tag/cpp/$prog"
     dir=`echo $ex | tr ' ' '_'`
     mkdir -p $out/$dir
     cd $out/$dir

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -21,7 +21,7 @@ check () {
     cat $out/$prog/stdout.txt
     which grep
     grep -Eo '\d+ spikes' $out/$prog/stdout.txt
-    actual=$(grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
+    actual=$(grep -Eo '[0-9]+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then
         echo "   - $prog: OK"

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -16,11 +16,6 @@ ok=0
 check () {
     prog=$1
     expected="$2 spikes"
-    pwd
-    ls $out/$prog/stdout.txt
-    cat $out/$prog/stdout.txt
-    which grep
-    grep -Eo '[0-9]+ spikes' $out/$prog/stdout.txt
     actual=$(grep -Eo '[0-9]+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -16,6 +16,11 @@ ok=0
 check () {
     prog=$1
     expected="$2 spikes"
+    pwd
+    ls
+    ls $out
+    ls $out/$prog
+
     actual=$(grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -17,10 +17,8 @@ check () {
     prog=$1
     expected="$2 spikes"
     pwd
-    ls
-    ls $out
-    ls $out/$prog
-
+    ls $out/$prog/stdout.txt
+    grep -Eo '\d+ spikes' $out/$prog/stdout.txt
     actual=$(grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -29,7 +29,6 @@ check () {
 for ex in bench brunel gap_junctions generators lfp ring single-cell "probe-demo v"
 do
     echo "   - $ex"
-    "results/$tag/cpp/$prog"
     dir=`echo $ex | tr ' ' '_'`
     mkdir -p $out/$dir
     cd $out/$dir

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -8,14 +8,15 @@ if [[ "$#" -gt 1 ]]; then
 	exit 1
 fi
 
-PREFIX=${1:-}
+PREFIX="${1:-} `pwd`/build/bin"
+out=results/`git rev-parse HEAD`/cpp
 
-$PREFIX build/bin/bench
-$PREFIX build/bin/brunel
-$PREFIX build/bin/dryrun
-$PREFIX build/bin/gap_junctions
-$PREFIX build/bin/generators
-$PREFIX build/bin/lfp
-$PREFIX build/bin/probe-demo v
-$PREFIX build/bin/ring
-$PREFIX build/bin/single-cell
+for ex in bench brunel gap_junctions generators lfp ring single-cell "probe-demo v"
+do
+    echo "Running: $ex"
+    dir=`echo $ex | tr ' ' '_'`
+    mkdir -p $out/$dir
+    cd $out/$dir
+    $PREFIX/$ex > stdout.txt 2> stderr.txt
+    cd -
+done

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -19,8 +19,9 @@ check () {
     pwd
     ls $out/$prog/stdout.txt
     cat $out/$prog/stdout.txt
-    /usr/bin/grep -Eo '\d+ spikes' $out/$prog/stdout.txt
-    actual=$(/usr/bin/grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
+    which grep
+    grep -Eo '\d+ spikes' $out/$prog/stdout.txt
+    actual=$(grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then
         echo "   - $prog: OK"

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -18,6 +18,7 @@ check () {
     expected="$2 spikes"
     pwd
     ls $out/$prog/stdout.txt
+    which grep
     grep -Eo '\d+ spikes' $out/$prog/stdout.txt
     actual=$(grep -Eo '\d+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -20,7 +20,7 @@ check () {
     ls $out/$prog/stdout.txt
     cat $out/$prog/stdout.txt
     which grep
-    grep -Eo '\d+ spikes' $out/$prog/stdout.txt
+    grep -Eo '[0-9]+ spikes' $out/$prog/stdout.txt
     actual=$(grep -Eo '[0-9]+ spikes' $out/$prog/stdout.txt || echo "N/A")
     if [ "$expected" == "$actual" ]
     then


### PR DESCRIPTION
- Enhance `run_cpp_examples.sh` to do some very basic checking of spikes counts
- Add a script to check all releases
- The former must succeed for all commits to master

Here's the expected spike counts as of 0.7
- brunel 6998
- bench 972
- ring 94 (19 pre-v0.7)
- gap_junctions 30