### PR TITLE
🦑  Excise `time`

### DIFF
--- a/arbor/backends/event.hpp
+++ b/arbor/backends/event.hpp
@@ -13,7 +13,7 @@ namespace arb {
 struct target_handle {
     cell_local_size_type mech_id;    // mechanism type identifier (per cell group).
     cell_local_size_type mech_index; // instance of the mechanism
-    cell_size_type intdom_index;     // which integration domain (acts as index into e.g. vec_t)
+    cell_size_type intdom_index;     // which integration domain (acts as index into arrays)
 
     target_handle() = default;
     target_handle(cell_local_size_type mech_id, cell_local_size_type mech_index, cell_size_type intdom_index):

--- a/arbor/backends/gpu/shared_state.cpp
+++ b/arbor/backends/gpu/shared_state.cpp
@@ -284,9 +284,6 @@ void shared_state::instantiate(mechanism& m, unsigned id, const mechanism_overri
     bool mult_in_place = !pos_data.multiplicity.empty();
     bool peer_indices = !pos_data.peer_cv.empty();
 
-    // Set internal variables
-    m.time_ptr_ptr   = &time_ptr;
-
     auto width        = pos_data.cv.size();
     auto width_padded = math::round_up(pos_data.cv.size(), alignment);
 

--- a/arbor/backends/gpu/shared_state.hpp
+++ b/arbor/backends/gpu/shared_state.hpp
@@ -151,8 +151,6 @@ struct ARB_ARBOR_API shared_state {
     array time_since_spike;   // Stores time since last spike on any detector, organized by cell.
     iarray src_to_spike;      // Maps spike source index to spike index
 
-    arb_value_type* time_ptr;
-
     istim_state stim_data;
     std::unordered_map<std::string, ion_state> ion_data;
     deliverable_event_stream deliverable_events;

--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -226,8 +226,6 @@ shared_state::shared_state(
     src_to_spike(src_to_spike.begin(), src_to_spike.end(), pad(alignment)),
     deliverable_events(n_intdom)
 {
-    time_ptr = time.data();
-
     // For indices in the padded tail of cv_to_intdom, set index to last valid intdom index.
     if (n_cv>0) {
         std::copy(cv_to_intdom_vec.begin(), cv_to_intdom_vec.end(), cv_to_intdom.begin());
@@ -493,9 +491,6 @@ void shared_state::instantiate(arb::mechanism& m, unsigned id, const mechanism_o
 
     util::padded_allocator<> pad(m.data_alignment());
 
-    // Set internal variables
-    m.time_ptr_ptr   = &time_ptr;
-
     // Assign non-owning views onto shared state:
     m.ppack_ = {0};
     m.ppack_.width            = pos_data.cv.size();
@@ -511,7 +506,6 @@ void shared_state::instantiate(arb::mechanism& m, unsigned id, const mechanism_o
     m.ppack_.time_since_spike = time_since_spike.data();
     m.ppack_.n_detectors      = n_detector;
     m.ppack_.events           = {};
-    m.ppack_.vec_t            = nullptr;
 
     bool mult_in_place = !pos_data.multiplicity.empty();
     bool peer_indices = !pos_data.peer_cv.empty();

--- a/arbor/backends/multicore/shared_state.hpp
+++ b/arbor/backends/multicore/shared_state.hpp
@@ -155,8 +155,6 @@ struct ARB_ARBOR_API shared_state {
     array time_since_spike;   // Stores time since last spike on any detector, organized by cell.
     iarray src_to_spike;      // Maps spike source index to spike index
 
-    arb_value_type* time_ptr;
-
     istim_state stim_data;
     std::unordered_map<std::string, ion_state> ion_data;
     deliverable_event_stream deliverable_events;

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -307,7 +307,6 @@ fvm_integration_result fvm_lowered_cell_impl<Backend>::integrate(
         PL();
 
         std::swap(state_->time_to, state_->time);
-        state_->time_ptr = state_->time.data();
 
         // Check for non-physical solutions:
 

--- a/arbor/include/arbor/mechanism.hpp
+++ b/arbor/include/arbor/mechanism.hpp
@@ -58,12 +58,12 @@ public:
     mechanism_ptr clone() const { return std::make_unique<mechanism>(mech_, iface_); }
 
     // Forward to interface methods
-    void initialize()     { ppack_.vec_t = *time_ptr_ptr; iface_.init_mechanism(&ppack_); }
-    void update_current() { prof_enter(current_prof_id); ppack_.vec_t = *time_ptr_ptr; iface_.compute_currents(&ppack_); prof_exit(); }
-    void update_state()   { prof_enter(state_prof_id);   ppack_.vec_t = *time_ptr_ptr; iface_.advance_state(&ppack_);    prof_exit(); }
-    void update_ions()    { ppack_.vec_t = *time_ptr_ptr; iface_.write_ions(&ppack_); }
-    void post_event()     { ppack_.vec_t = *time_ptr_ptr; iface_.post_event(&ppack_); }
-    void deliver_events(arb_deliverable_event_stream& stream) { ppack_.vec_t  = *time_ptr_ptr; iface_.apply_events(&ppack_, &stream); }
+    void initialize()     { iface_.init_mechanism(&ppack_); }
+    void update_current() { prof_enter(current_prof_id); iface_.compute_currents(&ppack_); prof_exit(); }
+    void update_state()   { prof_enter(state_prof_id);   iface_.advance_state(&ppack_);    prof_exit(); }
+    void update_ions()    { iface_.write_ions(&ppack_); }
+    void post_event()     { iface_.post_event(&ppack_); }
+    void deliver_events(arb_deliverable_event_stream& stream) { iface_.apply_events(&ppack_, &stream); }
 
     // Per-cell group identifier for an instantiated mechanism.
     unsigned mechanism_id() const { return ppack_.mechanism_id; }
@@ -71,7 +71,6 @@ public:
     arb_mechanism_type  mech_;
     arb_mechanism_interface iface_;
     arb_mechanism_ppack ppack_;
-    arb_value_type** time_ptr_ptr = nullptr;
 
 private:
 #ifdef ARB_PROFILE_ENABLED

--- a/arbor/include/arbor/mechanism_abi.h
+++ b/arbor/include/arbor/mechanism_abi.h
@@ -85,7 +85,6 @@ typedef struct arb_mechanism_ppack {
     arb_index_type  n_detectors;                 // Number of spike detectors.
     arb_index_type* vec_ci;
     arb_index_type* vec_di;
-    const arb_value_type* vec_t;
     arb_value_type* vec_dt;
     arb_value_type* vec_v;
     arb_value_type* vec_i;

--- a/doc/dev/mechanism_abi.rst
+++ b/doc/dev/mechanism_abi.rst
@@ -187,10 +187,6 @@ fully formed to the interface. At this point:
 
     [Array] Map
 
-  .. c:member:: const arb_value_type* vec_t
-
-    [Array] time value
-
   .. c:member:: arb_value_type* vec_dt
 
     [Array] time step

--- a/doc/fileformat/nmodl.rst
+++ b/doc/fileformat/nmodl.rst
@@ -39,7 +39,6 @@ quantities and their expected units.
 quantity                                         identifier                                           unit
 ===============================================  ===================================================  ==========
 voltage                                          v / v_peer                                           mV
-time                                             t                                                    ms
 temperature                                      celsius                                              °C
 diameter (cross-sectional)                       diam                                                 µm
 
@@ -94,15 +93,14 @@ Special variables
 -----------------
 
 * Arbor exposes some parameters from the simulation to the NMODL mechanisms.
-  These include ``v``, ``diam``, ``celsius`` and ``t`` in addition to the previously
+  These include ``v``, ``diam``, and ``celsius`` in addition to the previously
   mentioned ion parameters.
 * These special variables should not be ``ASSIGNED`` or ``CONSTANT``, they are
   ``PARAMETER``. This is different from NEURON where a built-in variable is
   declared ``ASSIGNED`` to make it accessible.
 * ``diam`` and ``celsius`` are set from the simulation side.
 * ``v`` is a reserved variable name and can be read but not written in NMODL.
-* ``dt`` is not exposed to NMODL mechanisms.
-* ``area`` is not exposed to NMODL mechanisms.
+* ``dt``, ``time``, and ``area`` are not exposed to NMODL mechanisms.
 * ``NONSPECIFIC_CURRENTS`` should not be ``PARAMETER``, ``ASSIGNED`` or ``CONSTANT``.
   They just need to be declared in the NEURON block.
 
@@ -122,7 +120,8 @@ Unsupported features
   units, which are just ignored).
 * Unit declaration is not supported (ex: ``FARADAY = (faraday)  (10000 coulomb)``).
   They can be replaced by declaring them and setting their values in ``CONSTANT``.
-* ``FROM`` - ``TO`` clamping of variables is not supported. The tokens are parsed and ignored.
+* ``FROM`` - ``TO`` clamping of variables is not supported. The tokens are
+  parsed, and reported through the ``mechanism_info``, but otherwise ignored.
   However, ``CONSERVE`` statements are supported.
 * ``TABLE`` is not supported, calculations are exact.
 * ``derivimplicit`` solving method is not supported, use ``cnexp`` instead.

--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -247,7 +247,6 @@ ARB_LIBMODCC_API std::string emit_cpp_source(const Module& module_, const printe
                                    "[[maybe_unused]] auto  {0}n_detectors       = pp->n_detectors;\\\n"
                                    "[[maybe_unused]] auto* {0}vec_ci            = pp->vec_ci;\\\n"
                                    "[[maybe_unused]] auto* {0}vec_di            = pp->vec_di;\\\n"
-                                   "[[maybe_unused]] auto* {0}vec_t             = pp->vec_t;\\\n"
                                    "[[maybe_unused]] auto* {0}vec_dt            = pp->vec_dt;\\\n"
                                    "[[maybe_unused]] auto* {0}vec_v             = pp->vec_v;\\\n"
                                    "[[maybe_unused]] auto* {0}vec_i             = pp->vec_i;\\\n"

--- a/modcc/printer/gpuprinter.cpp
+++ b/modcc/printer/gpuprinter.cpp
@@ -136,7 +136,6 @@ ARB_LIBMODCC_API std::string emit_gpu_cu_source(const Module& module_, const pri
                                    "auto  {0}n_detectors       __attribute__((unused)) = params_.n_detectors;\\\n"
                                    "auto* {0}vec_ci            __attribute__((unused)) = params_.vec_ci;\\\n"
                                    "auto* {0}vec_di            __attribute__((unused)) = params_.vec_di;\\\n"
-                                   "auto* {0}vec_t             __attribute__((unused)) = params_.vec_t;\\\n"
                                    "auto* {0}vec_dt            __attribute__((unused)) = params_.vec_dt;\\\n"
                                    "auto* {0}vec_v             __attribute__((unused)) = params_.vec_v;\\\n"
                                    "auto* {0}vec_i             __attribute__((unused)) = params_.vec_i;\\\n"

--- a/modcc/printer/printerutil.cpp
+++ b/modcc/printer/printerutil.cpp
@@ -186,12 +186,6 @@ ARB_LIBMODCC_API indexed_variable_info decode_indexed_variable(IndexedVariable* 
         v.data_var = "vec_dt";
         v.readonly = true;
         break;
-    case sourceKind::time:
-        v.data_var = "vec_t";
-        v.cell_index_var = "vec_di";
-        v.index_var_kind = index_kind::cell;
-        v.readonly = true;
-        break;
     case sourceKind::ion_current_density:
         v.data_var = ion_pfx+".current_density";
         v.scale = 0.1;


### PR DESCRIPTION
Excises `time` from NMODL as per our policies not to let users peek behind the curtain.

Closes #1252 