### PR TITLE
Heaviside step

### DIFF
--- a/arbor/iexpr.cpp
+++ b/arbor/iexpr.cpp
@@ -285,7 +285,7 @@ struct step: public iexpr_interface {
     step(iexpr_ptr v): value(std::move(v)) {}
 
     double eval(const mprovider& p, const mcable& c) const override {
-        return value->eval(p, c) >= 0.0 ? 1.0 : 0.0;
+        return value->eval(p, c) > 0.0 ? 1.0 : 0.0;
     }
 
     iexpr_ptr value;

--- a/arbor/iexpr.cpp
+++ b/arbor/iexpr.cpp
@@ -596,6 +596,10 @@ std::ostream& operator<<(std::ostream& o, const iexpr& e) {
         o << "exp " << std::get<0>(std::any_cast<const std::tuple<iexpr>&>(e.args()));
         break;
     }
+    case iexpr_type::step: {
+        o << "step " << std::get<0>(std::any_cast<const std::tuple<iexpr>&>(e.args()));
+        break;
+    }
     case iexpr_type::log: {
         o << "log " << std::get<0>(std::any_cast<const std::tuple<iexpr>&>(e.args()));
         break;

--- a/arbor/iexpr.cpp
+++ b/arbor/iexpr.cpp
@@ -281,6 +281,16 @@ struct exp: public iexpr_interface {
     iexpr_ptr value;
 };
 
+struct step: public iexpr_interface {
+    step(iexpr_ptr v): value(std::move(v)) {}
+
+    double eval(const mprovider& p, const mcable& c) const override {
+        return value->eval(p, c) >= 0.0 ? 1.0 : 0.0;
+    }
+
+    iexpr_ptr value;
+};
+
 struct log: public iexpr_interface {
     log(iexpr_ptr v): value(std::move(v)) {}
 
@@ -402,6 +412,8 @@ iexpr iexpr::div(iexpr left, iexpr right) {
 
 iexpr iexpr::exp(iexpr value) { return iexpr(iexpr_type::exp, std::make_tuple(std::move(value))); }
 
+iexpr iexpr::step(iexpr value) { return iexpr(iexpr_type::step, std::make_tuple(std::move(value))); }
+
 iexpr iexpr::log(iexpr value) { return iexpr(iexpr_type::log, std::make_tuple(std::move(value))); }
 
 iexpr iexpr::named(std::string name) {
@@ -487,6 +499,9 @@ iexpr_ptr thingify(const iexpr& expr, const mprovider& m) {
             thingify(std::get<1>(std::any_cast<const std::tuple<iexpr, iexpr>&>(expr.args())), m)));
     case iexpr_type::exp:
         return iexpr_ptr(new iexpr_impl::exp(
+            thingify(std::get<0>(std::any_cast<const std::tuple<iexpr>&>(expr.args())), m)));
+    case iexpr_type::step:
+        return iexpr_ptr(new iexpr_impl::step(
             thingify(std::get<0>(std::any_cast<const std::tuple<iexpr>&>(expr.args())), m)));
     case iexpr_type::log:
         return iexpr_ptr(new iexpr_impl::log(

--- a/arbor/iexpr.cpp
+++ b/arbor/iexpr.cpp
@@ -286,13 +286,10 @@ struct step: public iexpr_interface {
 
     double eval(const mprovider& p, const mcable& c) const override {
         double x = value->eval(p, c);
-        if (x > 0) {
-            return 1.0;
-        } else if (x < 0) {
-            return 0.0;
-        } else {
-            return 0.5;
-        }
+        // x <  0:  0
+        // x == 0:  0.5
+        // x >  0:  1
+        return 0.5*((0. < x) - (x < 0.) + 1);
     }
 
     iexpr_ptr value;

--- a/arbor/iexpr.cpp
+++ b/arbor/iexpr.cpp
@@ -285,7 +285,14 @@ struct step: public iexpr_interface {
     step(iexpr_ptr v): value(std::move(v)) {}
 
     double eval(const mprovider& p, const mcable& c) const override {
-        return value->eval(p, c) > 0.0 ? 1.0 : 0.0;
+        double x = value->eval(p, c);
+        if (x > 0) {
+            return 1.0;
+        } else if (x < 0) {
+            return 0.0;
+        } else {
+            return 0.5;
+        }
     }
 
     iexpr_ptr value;

--- a/arbor/include/arbor/iexpr.hpp
+++ b/arbor/include/arbor/iexpr.hpp
@@ -29,6 +29,7 @@ enum class iexpr_type {
     mul,
     div,
     exp,
+    step,
     log,
     named
 };
@@ -96,6 +97,8 @@ struct ARB_SYMBOL_VISIBLE iexpr {
     static iexpr div(iexpr left, iexpr right);
 
     static iexpr exp(iexpr value);
+
+    static iexpr step(iexpr value);
 
     static iexpr log(iexpr value);
 

--- a/arborio/label_parse.cpp
+++ b/arborio/label_parse.cpp
@@ -163,6 +163,9 @@ std::unordered_multimap<std::string, evaluator> eval_map {
     {"exp", make_call<arb::iexpr>(arb::iexpr::exp, "iexpr with 1 argument: (value:iexpr)")},
     {"exp", make_call<double>(arb::iexpr::exp, "iexpr with 1 argument: (value:double)")},
 
+    {"step", make_call<arb::iexpr>(arb::iexpr::step, "iexpr with 1 argument: (value:iexpr)")},
+    {"step", make_call<double>(arb::iexpr::step, "iexpr with 1 argument: (value:double)")},
+
     {"log", make_call<arb::iexpr>(arb::iexpr::log, "iexpr with 1 argument: (value:iexpr)")},
     {"log", make_call<double>(arb::iexpr::log, "iexpr with 1 argument: (value:double)")},
 

--- a/doc/concepts/labels.rst
+++ b/doc/concepts/labels.rst
@@ -764,7 +764,7 @@ Inhomogeneous Expressions
 
 .. label:: (step value:(iexpr | real))
 
-    The Heaviside step function of the inhomogeneous expression or real ``value``, with `(step 0.0)` evaluating to 0.
+    The Heaviside step function of the inhomogeneous expression or real ``value``, with `(step 0.0)` evaluating to 0.5.
 
 .. label:: (log value:(iexpr | real))
 

--- a/doc/concepts/labels.rst
+++ b/doc/concepts/labels.rst
@@ -762,6 +762,10 @@ Inhomogeneous Expressions
 
     The exponential function of the inhomogeneous expression or real ``value``.
 
+.. label:: (step value:(iexpr | real))
+
+    The Heaviside step function of the inhomogeneous expression or real ``value``, with `(step 0.0)` evaluating to 0.
+
 .. label:: (log value:(iexpr | real))
 
     The logarithm of the inhomogeneous expression or real ``value``.

--- a/test/unit/test_iexpr.cpp
+++ b/test/unit/test_iexpr.cpp
@@ -398,6 +398,17 @@ TEST(iexpr, exp) {
     EXPECT_DOUBLE_EQ(e->eval(prov, {0, 0.0, 1.0}), std::exp(3.0 * 10.0));
 }
 
+TEST(iexpr, step) {
+    segment_tree tree;
+    tree.append(mnpos, {0, 0, 0, 10}, {0, 0, 10, 10}, 1);
+
+    arb::mprovider prov(arb::morphology(std::move(tree)));
+    auto root_dist = arb::iexpr::distance(1.0, arb::mlocation{0, 0.0});
+    auto e = thingify(arb::iexpr::step(root_dist-5.0), prov);
+    EXPECT_DOUBLE_EQ(e->eval(prov, {0, 0.0, 0.5}), 0.0f); /* step(2.5-5) == 0 */
+    EXPECT_DOUBLE_EQ(e->eval(prov, {0, 0.5, 1.0}), 1.0f); /* step(7.5-5) == 1 */
+}
+
 TEST(iexpr, log) {
     segment_tree tree;
     tree.append(mnpos, {0, 0, 0, 10}, {0, 0, 10, 10}, 1);

--- a/test/unit/test_s_expr.cpp
+++ b/test/unit/test_s_expr.cpp
@@ -269,6 +269,7 @@ TEST(iexpr, round_tripping) {
         "(radius 2.1)",
         "(diameter 2.1)",
         "(exp (scalar 2.1))",
+        "(step (scalar 2.1))",
         "(log (scalar 2.1))",
         "(add (scalar 2.1) (radius 3.2))",
         "(sub (scalar 2.1) (radius 3.2))",
@@ -281,7 +282,7 @@ TEST(iexpr, round_tripping) {
     }
 
     // check double values for input instead of explicit scalar iexpr
-    auto mono_iexpr = {std::string("exp"), std::string("log")};
+    auto mono_iexpr = {std::string("exp"), std::string("step"), std::string("log")};
     auto duo_iexpr = {std::string("add"), std::string("sub"), std::string("mul"), std::string("div")};
     constexpr auto v1 = "1.2";
     constexpr auto v2 = "1.2";


### PR DESCRIPTION
This PR adds the Heaviside step function to Arbor's iexpr, needed for some inhomogeneous density mechanism like the ones in [this model](https://raw.githubusercontent.com/OpenSourceBrain/L5bPyrCellHayEtAl2011/master/neuroConstruct/generatedNeuroML2/L5PC.cell.nml). Arguable, one could also use segment groups but this makes automated translation of an existing model using NeuroML's `H()` much much easier.

The implementation returns

```python
def step(x):
    if x > 0:
        return 1
    else:
        return 0
```

which makes sense to me, but does not have to be the semantics that we follow.

For example the [NeuroML/LEMS implementation](https://github.com/LEMS/jLEMS/blob/554803b3ebfc444cfc7b044fe71d69fc933b6b13/src/main/java/org/lemsml/jlems/core/expression/FunctionNode.java#L83) uses the half-maximum convention

```java
ret = 0.5*(Math.signum(arg)+1.);
```

which has `H(0.0) == 0.5`.

