### PR TITLE
Optimize CPU-side solvers

### DIFF
--- a/arbor/backends/multicore/cable_solver.hpp
+++ b/arbor/backends/multicore/cable_solver.hpp
@@ -19,19 +19,13 @@ struct cable_solver {
 
     iarray parent_index;
     iarray cell_cv_divs;
-
-    array d;     // [μS]
-    array u;     // [μS]
-    array rhs;   // [nA]
-
-    array cv_capacitance;      // [pF]
-    array face_conductance;    // [μS]
-    array cv_area;             // [μm^2]
-
     iarray cell_to_intdom;
 
-    // the invariant part of the matrix diagonal
-    array invariant_d;         // [μS]
+    array d;              // [μS]
+    array u;              // [μS]
+    array cv_capacitance; // [pF]
+    array cv_area;        // [μm^2]
+    array invariant_d;    // [μS] invariant part of matrix diagonal
 
     cable_solver() = default;
     cable_solver(const cable_solver&) = default;
@@ -48,11 +42,11 @@ struct cable_solver {
                  const std::vector<index_type>& cell_to_intdom):
         parent_index(p.begin(), p.end()),
         cell_cv_divs(cell_cv_divs.begin(), cell_cv_divs.end()),
-        d(size(), 0), u(size(), 0), rhs(size()),
+        cell_to_intdom(cell_to_intdom.begin(), cell_to_intdom.end()),
+        d(size(), 0), u(size(), 0),
         cv_capacitance(cap.begin(), cap.end()),
-        face_conductance(cond.begin(), cond.end()),
         cv_area(area.begin(), area.end()),
-        cell_to_intdom(cell_to_intdom.begin(), cell_to_intdom.end())
+        invariant_d(size(), 0)
     {
         // Sanity check
         arb_assert(cap.size() == size());
@@ -60,11 +54,9 @@ struct cable_solver {
         arb_assert(cell_cv_divs.back() == (index_type)size());
 
         // Build invariant parts
-        const auto n = size();
-        invariant_d = array(n, 0);
-        if (n >= 1) { // skip empty matrix, ie cell with empty morphology
-            for (auto i: util::make_span(1u, n)) {
-                const auto gij = face_conductance[i];
+        if (size() >= 1) {
+            for (auto i: util::make_span(1u, size())) {
+                const auto gij = cond[i];
                 u[i] = -gij;
                 invariant_d[i] += gij;
                 if (p[i]!=-1) { // root
@@ -74,69 +66,80 @@ struct cable_solver {
         }
     }
 
-    const_view solution() const {
-        // In this back end the solution is a simple view of the rhs, which
-        // contains the solution after the matrix_solve is performed.
-        return rhs;
-    }
+    // Setup and solve the cable equation
+    // * expects the voltage from its first argument
+    // * will likewise overwrite the first argument with the soluction
+    template<typename T>
+    void solve(T& rhs, const_view dt_intdom, const_view current, const_view conductivity) {
+        value_type * const __restrict__ d_ = d.data();
+        value_type * const __restrict__ r_ = rhs.data();
 
-    // Assemble the matrix
-    // Afterwards the diagonal and RHS will have been set given dt, voltage and current.
-    //   dt_intdom       [ms]      (per integration domain)
-    //   voltage         [mV]      (per control volume)
-    //   current density [A.m^-2]  (per control volume)
-    //   conductivity    [kS.m^-2] (per control volume)
-    void assemble(const_view dt_intdom, const_view voltage, const_view current, const_view conductivity) {
+        const value_type * const __restrict__ i_ = current.data();
+        const value_type * const __restrict__ inv_ = invariant_d.data();
+        const value_type * const __restrict__ c_ = cv_capacitance.data();
+        const value_type * const __restrict__ g_ = conductivity.data();
+        const value_type * const __restrict__ a_ = cv_area.data();
+
         const auto cell_cv_part = util::partition_view(cell_cv_divs);
         const index_type ncells = cell_cv_part.size();
-        // loop over submatrices
+        // Assemble; loop over submatrices
+        // Afterwards the diagonal and RHS will have been set given dt, voltage and current.
+        //   dt_intdom       [ms]      (per integration domain)
+        //   voltage         [mV]      (per control volume)
+        //   current density [A.m^-2]  (per control volume)
+        //   conductivity    [kS.m^-2] (per control volume)
         for (auto m: util::make_span(0, ncells)) {
-            const auto dt = dt_intdom[cell_to_intdom[m]];
-            if (dt>0) {
-                const value_type oodt_factor = 1e-3/dt; // [1/µs]
-                for (auto i: util::make_span(cell_cv_part[m])) {
-                    const auto area_factor = 1e-3*cv_area[i]; // [1e-9·m²]
-                    const auto gi = oodt_factor*cv_capacitance[i] + area_factor*conductivity[i]; // [μS]
-                    d[i] = gi + invariant_d[i];
-                    // convert current to units nA
-                    rhs[i] = gi*voltage[i] - area_factor*current[i];
+            const auto dt = dt_intdom[cell_to_intdom[m]];    // [ms]
+            if (dt > 0) {
+                const value_type oodt = 1e-3/dt;             // [1/µs]
+                const auto& [lo, hi] = cell_cv_part[m];
+                for(int i = lo; i < hi; ++i) {
+                    const auto area = 1e-3*a_[i];            // [1e-9·m²]
+                    const auto gi = oodt*c_[i] + area*g_[i]; // [μS]
+                    d_[i] = gi + inv_[i];                    // [μS]
+                    r_[i] = gi*r_[i] - area*i_[i];           // [nA]
                 }
             }
             else {
-                for (auto i: util::make_span(cell_cv_part[m])) {
-                    d[i] = 0;
-                    rhs[i] = voltage[i];
+                const auto& [lo, hi] = cell_cv_part[m];
+                for(int i = lo; i < hi; ++i) {
+                    d_[i] = 0.0;
                 }
             }
         }
+        solve(rhs);
     }
 
-    void solve() {
-        // loop over submatrices
-        for (const auto& [first, last]: util::partition_view(cell_cv_divs)) {
-            if (first >= last) continue; // skip cell with no CVs
-            if (d[first]!=0) {
+    // Solve; loop over submatrices
+    // Afterwards rhs will contain the solution.
+    // NOTE: This exists separately only to cater to the tests
+    template<typename T>
+    void solve(T& rhs) {
+        value_type * const __restrict__ r_ = rhs.data();
+        value_type * const __restrict__ d_ = d.data();
+
+        const value_type * const __restrict__ u_ = u.data();
+        const index_type * const __restrict__ p_ = parent_index.data();
+
+        const auto cell_cv_part = util::partition_view(cell_cv_divs);
+        for (const auto& [first, last]: cell_cv_part) {
+            if (first < last && d_[first] != 0) {  // skip vacuous cells
                 // backward sweep
-                for(auto i=last-1; i>first; --i) {
-                    const auto factor = u[i] / d[i];
-                    d[parent_index[i]]   -= factor * u[i];
-                    rhs[parent_index[i]] -= factor * rhs[i];
+                for(int i = last - 1; i > first; --i) {
+                    const auto factor = u_[i] / d_[i];
+                    const auto pi = p_[i];
+                    d_[pi] -= factor * u_[i];
+                    r_[pi] -= factor * r_[i];
                 }
                 // solve root
-                rhs[first] /= d[first];
+                r_[first] /= d_[first];
                 // forward sweep
-                for(auto i=first+1; i<last; ++i) {
-                    rhs[i] -= u[i] * rhs[parent_index[i]];
-                    rhs[i] /= d[i];
+                for(int i = first + 1; i < last; ++i) {
+                    r_[i] -= u_[i] * r_[p_[i]];
+                    r_[i] /= d_[i];
                 }
             }
         }
-    }
-
-    template<typename VTo>
-    void solve(VTo& to) {
-        solve();
-        memory::copy(rhs, to);
     }
 
     std::size_t num_cells() const { return cell_cv_divs.size() - 1; }

--- a/arbor/backends/multicore/cable_solver.hpp
+++ b/arbor/backends/multicore/cable_solver.hpp
@@ -68,17 +68,17 @@ struct cable_solver {
 
     // Setup and solve the cable equation
     // * expects the voltage from its first argument
-    // * will likewise overwrite the first argument with the soluction
+    // * will likewise overwrite the first argument with the solction
     template<typename T>
     void solve(T& rhs, const_view dt_intdom, const_view current, const_view conductivity) {
-        value_type * const __restrict__ d_ = d.data();
-        value_type * const __restrict__ r_ = rhs.data();
+        value_type * const ARB_NO_ALIAS d_ = d.data();
+        value_type * const ARB_NO_ALIAS r_ = rhs.data();
 
-        const value_type * const __restrict__ i_ = current.data();
-        const value_type * const __restrict__ inv_ = invariant_d.data();
-        const value_type * const __restrict__ c_ = cv_capacitance.data();
-        const value_type * const __restrict__ g_ = conductivity.data();
-        const value_type * const __restrict__ a_ = cv_area.data();
+        const value_type * const ARB_NO_ALIAS i_ = current.data();
+        const value_type * const ARB_NO_ALIAS inv_ = invariant_d.data();
+        const value_type * const ARB_NO_ALIAS c_ = cv_capacitance.data();
+        const value_type * const ARB_NO_ALIAS g_ = conductivity.data();
+        const value_type * const ARB_NO_ALIAS a_ = cv_area.data();
 
         const auto cell_cv_part = util::partition_view(cell_cv_divs);
         const index_type ncells = cell_cv_part.size();
@@ -115,11 +115,11 @@ struct cable_solver {
     // NOTE: This exists separately only to cater to the tests
     template<typename T>
     void solve(T& rhs) {
-        value_type * const __restrict__ r_ = rhs.data();
-        value_type * const __restrict__ d_ = d.data();
+        value_type * const ARB_NO_ALIAS r_ = rhs.data();
+        value_type * const ARB_NO_ALIAS d_ = d.data();
 
-        const value_type * const __restrict__ u_ = u.data();
-        const index_type * const __restrict__ p_ = parent_index.data();
+        const value_type * const ARB_NO_ALIAS u_ = u.data();
+        const index_type * const ARB_NO_ALIAS p_ = parent_index.data();
 
         const auto cell_cv_part = util::partition_view(cell_cv_divs);
         for (const auto& [first, last]: cell_cv_part) {

--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -243,20 +243,19 @@ shared_state::shared_state(
 }
 
 void shared_state::integrate_voltage() {
-    solver.assemble(dt_intdom, voltage, current_density, conductivity);
-    solver.solve(voltage);
+    solver.solve(voltage, dt_intdom, current_density, conductivity);
 }
 
 void shared_state::integrate_diffusion() {
     for (auto& [ion, data]: ion_data) {
         if (data.solver) {
-            data.solver->assemble(dt_intdom,
-                                  data.Xd_,
-                                  voltage,
-                                  data.iX_,
-                                  data.gX_,
-                                  data.charge[0]);
-            data.solver->solve(data.Xd_);
+            data.solver->solve(data.Xd_,
+                               dt_intdom,
+                               voltage,
+                               data.iX_,
+                               data.gX_,
+                               data.charge[0]);
+
         }
     }
 }

--- a/arbor/include/arbor/mechanism_abi.h
+++ b/arbor/include/arbor/mechanism_abi.h
@@ -7,6 +7,19 @@
 extern "C" {
 #endif
 
+// Marker for non-overlapping arrays/pointers
+#ifdef __cplusplus
+#if defined ( __GNUC__ ) || defined ( __clang__ )
+#define ARB_NO_ALIAS __restrict__
+#else
+#error "Unknown compiler, please add support."
+#endif
+#else
+#define ARB_NO_ALIAS restrict
+#endif
+
+
+
 // Version
 #define ARB_MECH_ABI_VERSION_MAJOR 0
 #define ARB_MECH_ABI_VERSION_MINOR 2


### PR DESCRIPTION
# Description
* remove storage of RHS and face-conductance from cable solver
* remove RHS from diffusion solver
* elide copy RHS->U and RHS->Xd respectively
* solve will now directly mangle its inputs U / Xd
* assembly is now part of solve
* fix tests accordingly
* add `__restrict__` in the assembly part to encourage auto-vectorization

# Analysis
* these tricks do _not_ work for GPU, as we pack memory there
* further manual vectorisation found no speed-up
  - likely this means the explicit vectorisation in shared state is likewise redundant; might be subject to removal soon
  - experiments done on AVX2
* we save quite a bit of memory
  - cable_solver: `rhs + face_conductance = 2*#CV doubles`
  - diffusion_solver: `rhs = #CV doubles` per diffusive species
* and some copies: one for the cable solver and one per diffusive species
  - these are redundant, since we only ever call into `solver::solve<T>(T& to)` 
