### PR TITLE
missing std namespace

### DIFF
--- a/arbor/include/arbor/math.hpp
+++ b/arbor/include/arbor/math.hpp
@@ -36,7 +36,7 @@ T constexpr area_circle(T r) {
 // with length L, end radii r1, r2.
 template <typename T>
 T constexpr area_frustrum(T L, T r1, T r2) {
-    return pi<T> * (r1+r2) * sqrt(square(L) + square(r1-r2));
+    return pi<T> * (r1+r2) * std::sqrt(square(L) + square(r1-r2));
 }
 
 // Volume of conic frustrum of length L, end radii r1, r2.

--- a/modcc/symdiff.cpp
+++ b/modcc/symdiff.cpp
@@ -175,7 +175,7 @@ public:
         expression_ptr dlhs = std::move(result_);
 
         e->rhs()->accept(this);
-        result_ = make_expression<SubBinaryExpression>(loc, move(dlhs), result());
+        result_ = make_expression<SubBinaryExpression>(loc, std::move(dlhs), result());
     }
 
     void visit(MulBinaryExpression* e) override {


### PR DESCRIPTION
tiny fix: use std variants of `sqrt` and `move` (removes warnings, and is safer)