### PR TITLE
Do not restrict SWC record identifier

### DIFF
--- a/arborio/swcio.cpp
+++ b/arborio/swcio.cpp
@@ -46,7 +46,7 @@ swc_mismatched_tags::swc_mismatched_tags(int record_id):
 {}
 
 swc_unsupported_tag::swc_unsupported_tag(int record_id):
-    swc_error("Only SWC record identifiers of 1, 2, 3 or 4 are supported.", record_id)
+    swc_error("Unsupported SWC record identifier.", record_id)
 {}
 
 // Record I/O:
@@ -225,11 +225,6 @@ ARB_ARBORIO_API arb::segment_tree load_swc_neuron_raw(const swc_data& data) {
             throw swc_mismatched_tags(it->id);
         }
 
-        // No soma: fall back to Arbor interpretation.
-        // Check for tags unsupported by NEURON beforehand.
-        if (auto it=std::find_if(R.begin(), R.end(), [](const auto& r) {return r.tag<1 || r.tag>4;}); it!=R.end()) {
-            throw swc_unsupported_tag(R[std::distance(R.begin(), it)].id);
-        }
         return load_swc_arbor_raw(data);
     }
 


### PR DESCRIPTION
All integers do occur in the wild according to:

http://www.neuronland.org/NLMorphologyConverter/MorphologyFormats/SWC/Spec.html

Standardized swc files (www.neuromorpho.org) -
0 - undefined
1 - soma
2 - axon
3 - (basal) dendrite
4 - apical dendrite
5+ - custom

A lot of data does not conform exactly to this standard however e.g.

CNIC data -
0 - undefined
1 - soma
2 - axon
3 - (basal) dendrite
4 - apical dendrite
5 - fork point
6 - end point
7 - custom

VNED data -  seems to be standard, but uses
10 - related to soma ?

Gulyas data - each number represents structure with same diameter.

Other data has been observed with
-1 -  also possibly related to soma ?

<!-- Please make sure your PR follows our [contribution guidelines](https://github.com/arbor-sim/arbor/tree/master/doc/contrib) and agree to the terms outlined in the [PR procedure](https://github.com/arbor-sim/arbor/tree/master/doc/contrib/pr.rst). -->
