### PR TITLE
Remove cscs-ci badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![ci](https://github.com/arbor-sim/arbor/actions/workflows/test-everything.yml/badge.svg)](https://github.com/arbor-sim/arbor/actions/workflows/test-everything.yml)
-[![hpcci](https://gitlab.com/cscs-ci/arbor-sim/arbor/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/arbor-sim/arbor/-/commits/master)
 [![pythonwheels](https://github.com/arbor-sim/arbor/actions/workflows/ciwheel.yml/badge.svg)](https://github.com/arbor-sim/arbor/actions/workflows/ciwheel.yml)
 [![gitpod](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/arbor-sim/arbor)
 [![docs](https://readthedocs.org/projects/arbor/badge/?version=latest)](https://docs.arbor-sim.org/en/latest/)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,13 +1,10 @@
 Arbor
 =====
 
-|ci| |hpcci| |pythonwheels| |zlatest| |gitter|
+|ci| |pythonwheels| |zlatest| |gitter|
 
 .. |ci| image:: https://github.com/arbor-sim/arbor/actions/workflows/test-everything.yml/badge.svg
     :target: https://github.com/arbor-sim/arbor/actions/workflows/test-everything.yml
-
-.. |hpcci| image:: https://gitlab.com/cscs-ci/arbor-sim/arbor/badges/master/pipeline.svg
-    :target: https://gitlab.com/cscs-ci/arbor-sim/arbor/-/commits/master
 
 .. |pythonwheels| image:: https://github.com/arbor-sim/arbor/actions/workflows/ciwheel.yml/badge.svg
     :target: https://github.com/arbor-sim/arbor/actions/workflows/ciwheel.yml


### PR DESCRIPTION
The Github hook is removed already, we can leave `ci/` in place whenever we get around to a solution for the problems running this test reliably. 