### PR TITLE
Bump CI workflow to GH standards.

### DIFF
--- a/.github/workflows/check-submodules.yml
+++ b/.github/workflows/check-submodules.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone w/ submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8
       - name: Clone w/ submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Python Formatting

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -20,11 +20,11 @@ jobs:
         ASAN_OPTIONS: detect_leaks=1
     steps:
       - name: Set up cmake
-        uses: jwlawson/actions-setup-cmake@v1.7
+        uses: jwlawson/actions-setup-cmake@v1.13
         with:
           cmake-version: 3.19.x
       - name: Clone w/ submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Update pip

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -15,12 +15,12 @@ jobs:
         python-version: [3.8]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
             path: arbor
 
       - name: Spack cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.spack-cache
           key: arbor-cache-${{ github.run_id }}

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -93,12 +93,12 @@ jobs:
         # See https://github.com/open-mpi/ompi/issues/6518
         OMPI_MCA_btl: "self,tcp"
     steps:
-      - name: "Linux: get libxml2"
+      - name: "Linux: get build dependencies"
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev
-      - name: "MacOS: get libxml2"
+          sudo apt-get install -y libxml2-dev ${{ matrix.config.cc }}
+      - name: "MacOS: get build dependencies"
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         run: |
           brew install libxml2 

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -103,11 +103,11 @@ jobs:
         run: |
           brew install libxml2 
       - name: Set up cmake
-        uses: jwlawson/actions-setup-cmake@latest
+        uses: jwlawson/actions-setup-cmake@v1.13
         with:
           cmake-version: ${{ matrix.config.cmake }}
       - name: Set up Python
-        uses: actions/setup-python@latest
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.config.py }}
       - name: Update pip

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -15,7 +15,7 @@ jobs:
         config:
         - {
             name:  "Linux Min GCC",
-            os:    "ubuntu-18.04",
+            os:    "ubuntu-20.04",
             cc:    "gcc-8",
             cxx:   "g++-8",
             py:    "3.7",
@@ -25,7 +25,7 @@ jobs:
           }
         - {
             name:  "Linux Min Clang",
-            os:    "ubuntu-18.04",
+            os:    "ubuntu-20.04",
             cc:    "clang-8",
             cxx:   "clang++-8",
             py:    "3.7",
@@ -98,27 +98,22 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libxml2-dev
-      - name: "Linux-Min: get clang/gcc 8"
-        if: ${{ startsWith(matrix.config.os, 'ubuntu-18') }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y "clang-8" "lldb-8" "lld-8" "clang-format-8" g++-8
       - name: "MacOS: get libxml2"
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         run: |
           brew install libxml2 
       - name: Set up cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@latest
         with:
           cmake-version: ${{ matrix.config.cmake }}
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@latest
         with:
           python-version: ${{ matrix.config.py }}
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: OpenMPI cache
-        uses: actions/cache@v2
+        uses: actions/cache@latest
         id:   cache-ompi
         with:
           path: ~/openmpi-4.0.2
@@ -146,7 +141,7 @@ jobs:
       - name: Install Python packages
         run:  pip install numpy sphinx svgwrite sphinx-rtd-theme mpi4py pandas seaborn
       - name: Clone w/ submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@latest
         with:
           submodules: recursive
       - name: Check config
@@ -208,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone w/ submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@latest
         with:
           submodules: recursive
       - name: Build and install Arbor using pip + build flags

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -16,8 +16,8 @@ jobs:
         - {
             name:  "Linux Min GCC",
             os:    "ubuntu-20.04",
-            cc:    "gcc-8",
-            cxx:   "g++-8",
+            cc:    "gcc-9",
+            cxx:   "g++-9",
             py:    "3.7",
             cmake: "3.19.x",
             mpi:   "ON",
@@ -26,8 +26,8 @@ jobs:
         - {
             name:  "Linux Min Clang",
             os:    "ubuntu-20.04",
-            cc:    "clang-8",
-            cxx:   "clang++-8",
+            cc:    "clang-9",
+            cxx:   "clang++-9",
             py:    "3.7",
             cmake: "3.19.x",
             mpi:   "ON",
@@ -113,7 +113,7 @@ jobs:
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: OpenMPI cache
-        uses: actions/cache@latest
+        uses: actions/cache@v3
         id:   cache-ompi
         with:
           path: ~/openmpi-4.0.2
@@ -141,7 +141,7 @@ jobs:
       - name: Install Python packages
         run:  pip install numpy sphinx svgwrite sphinx-rtd-theme mpi4py pandas seaborn
       - name: Clone w/ submodules
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Check config
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone w/ submodules
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Build and install Arbor using pip + build flags


### PR DESCRIPTION
Github bumps its CI environment

- Upgrade actions to latest
  - cache
  - checkout
  - cmake 
- Bump minimal tested versions of clang and GCC to 9
  - #1815 should do the rest, so we won't do it here. 
- Remove Ubuntu 18.04 LTS and use 20.04 LTS a the new minimum.
  - GH drops support for 18.04 


