### PR TITLE
Remove a global data-structure

### DIFF
--- a/arbor/CMakeLists.txt
+++ b/arbor/CMakeLists.txt
@@ -27,7 +27,7 @@ set(arbor_sources
     io/serialize_hex.cpp
     label_resolution.cpp
     lif_cell_group.cpp
-    mc_cell_group.cpp
+    cable_cell_group.cpp
     mechcat.cpp
     mechinfo.cpp
     memory/gpu_wrappers.cpp

--- a/arbor/benchmark_cell_group.cpp
+++ b/arbor/benchmark_cell_group.cpp
@@ -15,6 +15,12 @@
 
 namespace arb {
 
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const benchmark_cell& c) {
+    src.add_cell();
+    src.add_label(c.source, {0, 1});
+    return 1;
+}
+
 benchmark_cell_group::benchmark_cell_group(const std::vector<cell_gid_type>& gids,
                                            const recipe& rec,
                                            cell_label_range& cg_sources,
@@ -29,14 +35,11 @@ benchmark_cell_group::benchmark_cell_group(const std::vector<cell_gid_type>& gid
 
     cells_.reserve(gids_.size());
     for (auto gid: gids_) {
-        cells_.push_back(util::any_cast<benchmark_cell>(rec.get_cell_description(gid)));
-    }
-
-    for (const auto& c: cells_) {
-        cg_sources.add_cell();
+        auto cell = util::any_cast<benchmark_cell>(rec.get_cell_description(gid));
+        cells_.push_back(cell);
         cg_targets.add_cell();
-        cg_sources.add_label(c.source, {0, 1});
-        cg_targets.add_label(c.target, {0, 1});
+        cg_targets.add_label(cell.target, {0, 1});
+        get_sources(cg_sources, cell);
     }
 
     benchmark_cell_group::reset();

--- a/arbor/benchmark_cell_group.hpp
+++ b/arbor/benchmark_cell_group.hpp
@@ -40,5 +40,7 @@ private:
     std::vector<cell_gid_type> gids_;
 };
 
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const benchmark_cell& c);
+
 } // namespace arb
 

--- a/arbor/cable_cell_group.cpp
+++ b/arbor/cable_cell_group.cpp
@@ -16,7 +16,7 @@
 #include "event_binner.hpp"
 #include "fvm_lowered_cell.hpp"
 #include "label_resolution.hpp"
-#include "mc_cell_group.hpp"
+#include "cable_cell_group.hpp"
 #include "profile/profiler_macro.hpp"
 #include "sampler_map.hpp"
 #include "util/filter.hpp"
@@ -30,7 +30,17 @@ namespace arb {
 ARB_DEFINE_LEXICOGRAPHIC_ORDERING(arb::target_handle,(a.mech_id,a.mech_index,a.intdom_index),(b.mech_id,b.mech_index,b.intdom_index))
 ARB_DEFINE_LEXICOGRAPHIC_ORDERING(arb::deliverable_event,(a.time,a.handle,a.weight),(b.time,b.handle,b.weight))
 
-mc_cell_group::mc_cell_group(const std::vector<cell_gid_type>& gids,
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const cable_cell& c) {
+    src.add_cell();
+    cell_size_type count = 0;
+    for (const auto& [label, range]: c.detector_ranges()) {
+        src.add_label(label, range);
+        count += range.end - range.begin;
+    }
+    return count;
+}
+
+cable_cell_group::cable_cell_group(const std::vector<cell_gid_type>& gids,
                              const recipe& rec,
                              cell_label_range& cg_sources,
                              cell_label_range& cg_targets,
@@ -38,7 +48,7 @@ mc_cell_group::mc_cell_group(const std::vector<cell_gid_type>& gids,
     gids_(gids), lowered_(std::move(lowered))
 {
     // Default to no binning of events
-    mc_cell_group::set_binning_policy(binning_kind::none, 0);
+    cable_cell_group::set_binning_policy(binning_kind::none, 0);
 
     // Build lookup table for gid to local index.
     for (auto i: util::count_along(gids_)) {
@@ -70,7 +80,7 @@ mc_cell_group::mc_cell_group(const std::vector<cell_gid_type>& gids,
     spike_sources_.shrink_to_fit();
 }
 
-void mc_cell_group::reset() {
+void cable_cell_group::reset() {
     spikes_.clear();
 
     sample_events_.clear();
@@ -85,7 +95,7 @@ void mc_cell_group::reset() {
     lowered_->reset();
 }
 
-void mc_cell_group::set_binning_policy(binning_kind policy, time_type bin_interval) {
+void cable_cell_group::set_binning_policy(binning_kind policy, time_type bin_interval) {
     binners_.clear();
     binners_.resize(gids_.size(), event_binner(policy, bin_interval));
 }
@@ -389,7 +399,7 @@ void run_samples(
     std::visit([&](auto& x) {run_samples(x, sc, raw_times, raw_samples, sample_records, scratch); }, sc.pdata_ptr->info);
 }
 
-void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& event_lanes) {
+void cable_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& event_lanes) {
     time_type tstart = lowered_->time();
 
     // Bin and collate deliverable events from event lanes.
@@ -555,7 +565,7 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
     }
 }
 
-void mc_cell_group::add_sampler(sampler_association_handle h, cell_member_predicate probeset_ids,
+void cable_cell_group::add_sampler(sampler_association_handle h, cell_member_predicate probeset_ids,
                                 schedule sched, sampler_function fn, sampling_policy policy)
 {
     std::lock_guard<std::mutex> guard(sampler_mex_);
@@ -569,17 +579,17 @@ void mc_cell_group::add_sampler(sampler_association_handle h, cell_member_predic
     }
 }
 
-void mc_cell_group::remove_sampler(sampler_association_handle h) {
+void cable_cell_group::remove_sampler(sampler_association_handle h) {
     std::lock_guard<std::mutex> guard(sampler_mex_);
     sampler_map_.erase(h);
 }
 
-void mc_cell_group::remove_all_samplers() {
+void cable_cell_group::remove_all_samplers() {
     std::lock_guard<std::mutex> guard(sampler_mex_);
     sampler_map_.clear();
 }
 
-std::vector<probe_metadata> mc_cell_group::get_probe_metadata(cell_member_type probeset_id) const {
+std::vector<probe_metadata> cable_cell_group::get_probe_metadata(cell_member_type probeset_id) const {
     // Probe associations are fixed after construction, so we do not need to grab the mutex.
 
     std::optional<probe_tag> maybe_tag = util::value_by_key(probe_map_.tag, probeset_id);

--- a/arbor/cable_cell_group.hpp
+++ b/arbor/cable_cell_group.hpp
@@ -12,6 +12,7 @@
 #include <arbor/recipe.hpp>
 #include <arbor/sampling.hpp>
 #include <arbor/spike.hpp>
+#include <arbor/cable_cell.hpp>
 
 #include "backends/event.hpp"
 #include "cell_group.hpp"
@@ -24,11 +25,11 @@
 
 namespace arb {
 
-class ARB_ARBOR_API mc_cell_group: public cell_group {
+class ARB_ARBOR_API cable_cell_group: public cell_group {
 public:
-    mc_cell_group() = default;
+    cable_cell_group() = default;
 
-    mc_cell_group(const std::vector<cell_gid_type>& gids,
+    cable_cell_group(const std::vector<cell_gid_type>& gids,
                   const recipe& rec,
                   cell_label_range& cg_sources,
                   cell_label_range& cg_targets,
@@ -104,5 +105,7 @@ private:
     // Lookup table for target ids -> local target handle indices.
     std::vector<std::size_t> target_handle_divisions_;
 };
+
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const cable_cell& c);
 
 } // namespace arb

--- a/arbor/cell_group_factory.cpp
+++ b/arbor/cell_group_factory.cpp
@@ -9,7 +9,7 @@
 #include "execution_context.hpp"
 #include "fvm_lowered_cell.hpp"
 #include "lif_cell_group.hpp"
-#include "mc_cell_group.hpp"
+#include "cable_cell_group.hpp"
 #include "spike_source_cell_group.hpp"
 
 namespace arb {
@@ -27,7 +27,7 @@ ARB_ARBOR_API cell_group_factory cell_kind_implementation(
     switch (ck) {
     case cell_kind::cable:
         return [bk, ctx, seed](const gid_vector& gids, const recipe& rec, cell_label_range& cg_sources, cell_label_range& cg_targets) {
-            return make_cell_group<mc_cell_group>(gids, rec, cg_sources, cg_targets, make_fvm_lowered_cell(bk, ctx, seed));
+            return make_cell_group<cable_cell_group>(gids, rec, cg_sources, cg_targets, make_fvm_lowered_cell(bk, ctx, seed));
         };
 
     case cell_kind::spike_source:

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -31,7 +31,7 @@ communicator::communicator(const recipe& rec,
                                                      distributed_{ctx.distributed},
                                                      thread_pool_{ctx.thread_pool} {}
 
-void communicator::update_connections(const connectivity& rec,
+void communicator::update_connections(const recipe& rec,
                                       const domain_decomposition& dom_dec,
                                       const label_resolution_map& source_resolution_map,
                                       const label_resolution_map& target_resolution_map) {

--- a/arbor/communication/communicator.hpp
+++ b/arbor/communication/communicator.hpp
@@ -70,7 +70,6 @@ public:
 
     void update_connections(const recipe& rec,
                             const domain_decomposition& dom_dec,
-                            const label_resolution_map& source_resolution_map,
                             const label_resolution_map& target_resolution_map);
 
 private:

--- a/arbor/communication/communicator.hpp
+++ b/arbor/communication/communicator.hpp
@@ -68,7 +68,7 @@ public:
 
     void reset();
 
-    void update_connections(const connectivity& rec,
+    void update_connections(const recipe& rec,
                             const domain_decomposition& dom_dec,
                             const label_resolution_map& source_resolution_map,
                             const label_resolution_map& target_resolution_map);

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -35,6 +35,7 @@
 #include "util/rangeutil.hpp"
 #include "util/strprintf.hpp"
 #include "util/transform.hpp"
+#include "cable_cell_group.hpp"
 
 namespace arb {
 
@@ -402,18 +403,12 @@ fvm_initialization_data fvm_lowered_cell_impl<Backend>::initialize(
         auto gid = gids[i];
         const auto& c = cells[i];
 
-        fvm_info.source_data.add_cell();
         fvm_info.target_data.add_cell();
         fvm_info.gap_junction_data.add_cell();
 
-        unsigned count = 0;
-        for (const auto& [label, range]: c.detector_ranges()) {
-            fvm_info.source_data.add_label(label, range);
-            count+=(range.end - range.begin);
-        }
-        fvm_info.num_sources[gid] = count;
+        fvm_info.num_sources[gid] = get_sources(fvm_info.source_data, c);
 
-        count = 0;
+        unsigned count = 0;
         for (const auto& [label, range]: c.synapse_ranges()) {
             fvm_info.target_data.add_label(label, range);
             count+=(range.end - range.begin);

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -45,7 +45,7 @@ public:
 
     static simulation_builder create(recipe const &);
 
-    void update(const connectivity& rec);
+    void update(const recipe& rec);
 
     void reset();
 

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -114,7 +114,7 @@ struct ARB_ARBOR_API resolver {
     resolver(const label_resolution_map* label_map): label_map_(label_map) {}
     cell_lid_type resolve(const cell_global_label_type& iden);
 
-private:
+// private:
     using state_variant = std::variant<round_robin_state, round_robin_halt_state, assert_univalent_state>;
 
     state_variant construct_state(lid_selection_policy pol);

--- a/arbor/lif_cell_group.cpp
+++ b/arbor/lif_cell_group.cpp
@@ -6,7 +6,13 @@
 #include "util/rangeutil.hpp"
 #include "util/span.hpp"
 
-using namespace arb;
+namespace arb {
+
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const lif_cell& c) {
+    src.add_cell();
+    src.add_label(c.source, {0, 1});
+    return 1;
+}
 
 // Constructor containing gid of first cell in a group and a container of all cells.
 lif_cell_group::lif_cell_group(const std::vector<cell_gid_type>& gids, const recipe& rec, cell_label_range& cg_sources, cell_label_range& cg_targets):
@@ -24,14 +30,11 @@ lif_cell_group::lif_cell_group(const std::vector<cell_gid_type>& gids, const rec
     last_time_updated_.resize(gids_.size());
 
     for (auto lid: util::make_span(gids_.size())) {
-        cells_.push_back(util::any_cast<lif_cell>(rec.get_cell_description(gids_[lid])));
-    }
-
-    for (const auto& c: cells_) {
-        cg_sources.add_cell();
+        auto cell = util::any_cast<lif_cell>(rec.get_cell_description(gids_[lid]));
+        cells_.push_back(cell);
+        get_sources(cg_sources, cell);
         cg_targets.add_cell();
-        cg_sources.add_label(c.source, {0, 1});
-        cg_targets.add_label(c.target, {0, 1});
+        cg_targets.add_label(cell.target, {0, 1});
     }
 }
 
@@ -120,3 +123,5 @@ void lif_cell_group::advance_cell(time_type tfinal, time_type dt, cell_gid_type 
     // This is the last time a cell was updated.
     last_time_updated_[lid] = t;
 }
+
+} // namespace arb

--- a/arbor/lif_cell_group.hpp
+++ b/arbor/lif_cell_group.hpp
@@ -55,4 +55,6 @@ private:
     std::vector<time_type> last_time_updated_;
 };
 
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const lif_cell& c);
+
 } // namespace arb

--- a/arbor/spike_source_cell_group.cpp
+++ b/arbor/spike_source_cell_group.cpp
@@ -13,6 +13,12 @@
 
 namespace arb {
 
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const spike_source_cell& c) {
+    src.add_cell();
+    src.add_label(c.source, {0, 1});
+    return 1;
+}
+
 spike_source_cell_group::spike_source_cell_group(
     const std::vector<cell_gid_type>& gids,
     const recipe& rec,
@@ -28,16 +34,10 @@ spike_source_cell_group::spike_source_cell_group(
 
     time_sequences_.reserve(gids.size());
     for (auto gid: gids_) {
-        cg_sources.add_cell();
+        auto cell = util::any_cast<spike_source_cell>(rec.get_cell_description(gid));
         cg_targets.add_cell();
-        try {
-            auto cell = util::any_cast<spike_source_cell>(rec.get_cell_description(gid));
-            time_sequences_.emplace_back(cell.seqs);
-            cg_sources.add_label(cell.source, {0, 1});
-        }
-        catch (std::bad_any_cast& e) {
-            throw bad_cell_description(cell_kind::spike_source, gid);
-        }
+        get_sources(cg_sources, cell);
+        time_sequences_.emplace_back(cell.seqs);
     }
 }
 

--- a/arbor/spike_source_cell_group.hpp
+++ b/arbor/spike_source_cell_group.hpp
@@ -8,6 +8,7 @@
 #include <arbor/sampling.hpp>
 #include <arbor/schedule.hpp>
 #include <arbor/spike.hpp>
+#include <arbor/spike_source_cell.hpp>
 
 #include "cell_group.hpp"
 #include "epoch.hpp"
@@ -42,6 +43,8 @@ private:
     std::vector<cell_gid_type> gids_;
     std::vector<std::vector<schedule>> time_sequences_;
 };
+
+cell_size_type ARB_ARBOR_API get_sources(cell_label_range& src, const spike_source_cell& c);
 
 } // namespace arb
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -94,7 +94,7 @@ set(unit_sources
     test_math.cpp
     test_matrix.cpp
     test_mcable_map.cpp
-    test_mc_cell_group.cpp
+    test_cable_cell_group.cpp
     test_mechanisms.cpp
     test_mech_temp_diam.cpp
     test_mechcat.cpp

--- a/test/unit/test_cable_cell_group.cpp
+++ b/test/unit/test_cable_cell_group.cpp
@@ -6,7 +6,7 @@
 
 #include "epoch.hpp"
 #include "fvm_lowered_cell.hpp"
-#include "mc_cell_group.hpp"
+#include "cable_cell_group.hpp"
 #include "util/rangeutil.hpp"
 
 #include "common.hpp"
@@ -36,19 +36,19 @@ namespace {
 }
 
 ACCESS_BIND(
-    std::vector<cell_member_type> mc_cell_group::*,
+    std::vector<cell_member_type> cable_cell_group::*,
     private_spike_sources_ptr,
-    &mc_cell_group::spike_sources_)
+    &cable_cell_group::spike_sources_)
 
-TEST(mc_cell_group, get_kind) {
+TEST(cable_cell_group, get_kind) {
     cable_cell cell = make_cell();
     cell_label_range srcs, tgts;
-    mc_cell_group group{{0}, cable1d_recipe({cell}), srcs, tgts, lowered_cell()};
+    cable_cell_group group{{0}, cable1d_recipe({cell}), srcs, tgts, lowered_cell()};
 
     EXPECT_EQ(cell_kind::cable, group.get_cell_kind());
 }
 
-TEST(mc_cell_group, test) {
+TEST(cable_cell_group, test) {
     cable_cell cell = make_cell();
     auto rec = cable1d_recipe({cell});
     rec.nernst_ion("na");
@@ -56,7 +56,7 @@ TEST(mc_cell_group, test) {
     rec.nernst_ion("k");
 
     cell_label_range srcs, tgts;
-    mc_cell_group group{{0}, rec, srcs, tgts, lowered_cell()};
+    cable_cell_group group{{0}, rec, srcs, tgts, lowered_cell()};
     group.advance(epoch(0, 0., 50.), 0.01, {});
 
     // Model is expected to generate 4 spikes as a result of the
@@ -64,7 +64,7 @@ TEST(mc_cell_group, test) {
     EXPECT_EQ(4u, group.spikes().size());
 }
 
-TEST(mc_cell_group, sources) {
+TEST(cable_cell_group, sources) {
     // Make twenty cells, with an extra detector on gids 0, 3 and 17
     // to make things more interesting.
     std::vector<cable_cell> cells;
@@ -86,7 +86,7 @@ TEST(mc_cell_group, sources) {
     rec.nernst_ion("k");
 
     cell_label_range srcs, tgts;
-    mc_cell_group group{gids, rec, srcs, tgts, lowered_cell()};
+    cable_cell_group group{gids, rec, srcs, tgts, lowered_cell()};
 
     // Expect group sources to be lexicographically sorted by source id
     // with gids in cell group's range and indices starting from zero.


### PR DESCRIPTION
# Introduction
Our label resolution scheme concatenates a global vector of all source labels across all MPI tasks.
In my recent experiments, this exhausts the node-local memory (512GB) at around 150M cells,
with only a few ($O(10)$) labels per cell. 

# Fix
In each cell group, build a lazy map of the GIDs we are connected to and the associated source
labels. This reduces the required memory to the actual high-water-mark, but incurs the cost
of instantiating cells multiple times.

If this still not enough, we can proceed to minimize the memory consumption even more by
- (simple) evict labels from the cache if we are close to the limit. Costs more instantiations, but
   saves memory
- (optimal) observing which cells connect to a given source GID, instantiating the cell for only as 
   long as needed. Now memory is O(1), but we need to fiddle with construction order all the while
   keeping the connectivity stable. Which might be complicated

# Linked

Fixes #1969 

# TODO

- [ ] observe this is actually a fix
- [ ] benchmark the runtime cost of the new scheme
