### PR TITLE
Use HTTPS access instead of ssh/git for gtest.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,5 @@
 	path = ext/googletest
 	url = git@github.com:google/googletest.git
 	branch = release-1.12.1
+[submodule "ext/googletest/"]
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
Cause certain constrained/fortified systems to fail to build/clone arbor.