### PR TITLE
Bump versions

### DIFF
--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -112,32 +112,6 @@ jobs:
           python-version: ${{ matrix.config.py }}
       - name: Update pip
         run: python -m pip install --upgrade pip
-      # - name: OpenMPI cache
-        # uses: actions/cache@v3
-        # id:   cache-ompi
-        # with:
-          # path: ~/openmpi-4.1.4
-          # key:  ${{ matrix.config.os }}-openmpi-4.1.4-${{ matrix.config.cxx }}
-      # - name: Build OpenMPI
-        # if: ${{ steps.cache-ompi.outputs.cache-hit != 'true' }}
-        # run: |
-           # echo cache-hit='${{ steps.cache-ompi.outputs.cache-hit }}'
-           # cd ~
-           # wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.gz
-           # tar -xvf ./openmpi-4.1.4.tar.gz
-           # cd openmpi-4.1.4
-           # ./configure --disable-mpi-fortran
-           # make -j4
-      # - name: Install OpenMPI
-        # run: |
-           # echo "Going to install ompi"
-           # cd ~
-           # cd openmpi-4.1.4
-           # sudo make install
-           # cd -
-      # - name: Update shared library cache
-        # if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
-        # run: sudo ldconfig
       - name: Install Python packages
         run:  pip install numpy sphinx svgwrite sphinx-rtd-theme mpi4py pandas seaborn
       - name: Clone w/ submodules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,11 +126,7 @@ if(ARB_GPU STREQUAL "cuda")
     set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
     enable_language(CUDA)
     find_package(CUDAToolkit)
-    if(CUDAToolkit_VERSION_MAJOR GREATER 10)
-        set(CMAKE_CUDA_ARCHITECTURES 60 70 80)
-    else()
-        set(CMAKE_CUDA_ARCHITECTURES 60 70)
-    endif()
+    set(CMAKE_CUDA_ARCHITECTURES 60 70 80)
     # We _still_ need this otherwise CUDA symbols will not be exported
     # from libarbor.a leading to linker errors when link external clients.
     # Unit tests are NOT external enough. Re-review this somewhere in the

--- a/doc/dependencies.csv
+++ b/doc/dependencies.csv
@@ -1,18 +1,18 @@
 Build option/target,Tool name,Minimum version,Notes,Update criteria
---,CMake,3.18,,"* Is available as a module on HPC systems
+--,CMake,3.19,,"* Is available as a module on HPC systems
 * When arbitrary changes in more recently released versions make supported"
 --,C++ compiler,,C++17 support. See below,
---,GCC,8.4.0,"Use of ``std::fs`` is prohibited, despite being included in major compilers with C++17, on account of MacOS 10.14 not having the required syscall. We might lift this.","* it is supported by the minimum version of CUDA.
+--,GCC,9.0.0,,"* it is supported by the minimum version of CUDA.
 * it is available either by default or can be installed using standard package manager on the supported Linux versions."
---,Clang,8.0,Needs GCC 8 or later for standard library.,
---,Apple Clang,9,Apple LLVM version 9.0.0 (clang-900.0.39.2),
+--,Clang,10.0,Needs GCC 9 or later for standard library.,
+--,Apple Clang,11,Apple LLVM version 11.0.0 (clang-1100.0.33.8),
 ARB_GPU,Hip Clang,ROCm 3.9,HIP support is currently experimental.,
-ARB_GPU,CUDA,10.0,,"* It is available on all of the target HPC systems (Piz Daint, Juwels Booster)"
+ARB_GPU,CUDA,11.0,,"* It is available on all of the target HPC systems (Piz Daint, Juwels Booster)"
 ARB_WITH_NEUROML,libxml2,,,
 ARB_WITH_MPI,MPI,,Many MPI implementations are supported.,
 "ARB_WITH_MPI, ARB_WITH_PYTHON ",mpi4py,3.1.0,Minimum version depends on compatiblity with your Python and MPI versions. 3.1.0 is the first release to support Python > 3.8.,
 html,     .. literalinclude:: ../requirements.txt,,See ``doc/requirements.txt``,
-unit,googletest,,source copy ``test/gtest.*``,
+unit,googletest,,source copy ``ext/gtest.*``,
 bench,Google-benchmark,,submodule ``ext/google-benchmark``,
 --,json,,source copy ``ext/json``,
 --,random123,,source copy ``ext/random123``,

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -670,6 +670,11 @@ The first thing to do is change this module, which by default is set to the Cray
 programming environment, to a compiler that can compile Arbor.
 For example, to use the GCC compilers, select the GNU programming environment:
 
+.. note::
+
+   While the specific versions mentioned here are outdated, the general workflow
+   is still correct.
+
 .. code-block:: bash
 
     module swap PrgEnv-cray PrgEnv-gnu

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -605,7 +605,7 @@ on your target system that are not covered here, please make an issue on the
 Arbor `Github issues <https://github.com/arbor-sim/arbor/issues>`_ page.
 We will do our best to help you directly, and update this guide to help other users.
 
-.. warn::
+.. warning::
 
    On many HPC systems a tool called ``module`` or ``ml`` is installed, which
    use the ``CPATH`` environment variable to set up include paths for building.

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -55,7 +55,7 @@ A full list of dependencies and minimum versions supported thereof is maintained
    :header-rows: 1
 
 Note, that while we consider these to be our minimally supported versions, Arbor
-might still compiler and work fine using older versions. We will, however, not
+might still compile and work fine using older versions. We will, however, not
 offer much support for these versions, nor will we fix issues specific to them.
 
 Minimum requirements

--- a/doc/install/build_install.rst
+++ b/doc/install/build_install.rst
@@ -54,6 +54,10 @@ A full list of dependencies and minimum versions supported thereof is maintained
    :widths: 10, 20, 10, 70, 1
    :header-rows: 1
 
+Note, that while we consider these to be our minimally supported versions, Arbor
+might still compiler and work fine using older versions. We will, however, not
+offer much support for these versions, nor will we fix issues specific to them.
+
 Minimum requirements
 --------------------
 
@@ -161,8 +165,8 @@ them to the base exception types ``arbor_exception`` and
 Documentation
 ~~~~~~~~~~~~~~
 
-To build a local copy of the html documentation that you are reading now, you will need to
-install ``Sphinx <http://www.sphinx-doc.org/en/master/>`_.
+To build a local copy of the html documentation that you are reading now, you
+will need to install `Sphinx <http://www.sphinx-doc.org/en/master/>`_.
 
 .. _install-downloading:
 


### PR DESCRIPTION
Bump versions as described in #1815 

- GCC: goes up to 9 from 8, needed by CUDA 11
- CUDA: goes up to 11 from 10
- Clang: 10 up from 8
- Python: stays at 3.7

Our minimally supported Ubuntu is 20.04 LTS as GH Actions deprecated 18.04. MacOS is minimally
at v11 by the same constraints. I changed the compiler versions to reflect this while staying within 
our policies: all of them were released in early 2020. I was tempted to raise Python to 3.8 (2019) or
even 3.9 (2020) by the same policy; but decided to be a bit more conservative there. That said, Python
will be bumped next.

Closes #1815 