### PR TITLE
Make LIF cells probeable.

### DIFF
--- a/arbor/include/arbor/lif_cell.hpp
+++ b/arbor/include/arbor/lif_cell.hpp
@@ -23,4 +23,11 @@ struct ARB_SYMBOL_VISIBLE lif_cell {
     lif_cell(cell_tag_type source, cell_tag_type  target): source(std::move(source)), target(std::move(target)) {}
 };
 
+// LIF probe metadata, to be passed to sampler callbacks. Intentionally left blank.
+struct ARB_SYMBOL_VISIBLE lif_probe_metadata {};
+
+// Voltage estimate [mV].
+// Sample value type: `double`
+struct ARB_SYMBOL_VISIBLE lif_probe_voltage {};
+
 } // namespace arb

--- a/arbor/lif_cell_group.cpp
+++ b/arbor/lif_cell_group.cpp
@@ -5,6 +5,8 @@
 #include "profile/profiler_macro.hpp"
 #include "util/rangeutil.hpp"
 #include "util/span.hpp"
+#include "util/filter.hpp"
+#include "util/maputil.hpp"
 
 using namespace arb;
 
@@ -13,8 +15,18 @@ lif_cell_group::lif_cell_group(const std::vector<cell_gid_type>& gids, const rec
     gids_(gids)
 {
     for (auto gid: gids_) {
-        if (!rec.get_probes(gid).empty()) {
-            throw bad_cell_probe(cell_kind::lif, gid);
+        auto probes = rec.get_probes(gid);
+        for (const auto lid: util::count_along(probes)) {
+            const auto& probe = probes[lid];
+            cell_member_type id = {gid, static_cast<cell_lid_type>(lid)};
+            probe_tags_[id] = probe.tag;
+            probe_meta_[id] = {};
+            if (probe.address.type() == typeid(lif_probe_voltage)) {
+                probe_kinds_[id] = lif_probe_kind::voltage;
+            }
+            else {
+                throw bad_cell_probe{cell_kind::lif, gid};
+            }
         }
     }
     // Default to no binning of events
@@ -22,6 +34,7 @@ lif_cell_group::lif_cell_group(const std::vector<cell_gid_type>& gids, const rec
 
     cells_.reserve(gids_.size());
     last_time_updated_.resize(gids_.size());
+    next_time_updatable_.resize(gids_.size());
 
     for (auto lid: util::make_span(gids_.size())) {
         cells_.push_back(util::any_cast<lif_cell>(rec.get_cell_description(gids_[lid])));
@@ -41,11 +54,9 @@ cell_kind lif_cell_group::get_cell_kind() const {
 
 void lif_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& event_lanes) {
     PE(advance:lif);
-    if (event_lanes.size() > 0) {
-        for (auto lid: util::make_span(gids_.size())) {
-            // Advance each cell independently.
-            advance_cell(ep.t1, dt, lid, event_lanes[lid]);
-        }
+    for (auto lid: util::make_span(gids_.size())) {
+        // Advance each cell independently.
+        advance_cell(ep.t1, dt, lid, event_lanes);
     }
     PL();
 }
@@ -59,10 +70,30 @@ void lif_cell_group::clear_spikes() {
 }
 
 // TODO: implement sampler
-void lif_cell_group::add_sampler(sampler_association_handle h, cell_member_predicate probeset_ids,
-                                    schedule sched, sampler_function fn, sampling_policy policy) {}
-void lif_cell_group::remove_sampler(sampler_association_handle h) {}
-void lif_cell_group::remove_all_samplers() {}
+void lif_cell_group::add_sampler(sampler_association_handle h,
+                                 cell_member_predicate probeset_ids,
+                                 schedule sched,
+                                 sampler_function fn,
+                                 sampling_policy policy) {
+    std::lock_guard<std::mutex> guard(sampler_mex_);
+    std::vector<cell_member_type> probeset =
+        util::assign_from(util::filter(util::keys(probe_tags_), probeset_ids));
+    auto assoc = arb::sampler_association{std::move(sched),
+                                          std::move(fn),
+                                          std::move(probeset),
+                                          policy};
+    auto result = samplers_.insert({h, std::move(assoc)});
+    arb_assert(result.second);
+}
+
+void lif_cell_group::remove_sampler(sampler_association_handle h) {
+    std::lock_guard<std::mutex> guard(sampler_mex_);
+    samplers_.erase(h);
+}
+void lif_cell_group::remove_all_samplers() {
+    std::lock_guard<std::mutex> guard(sampler_mex_);
+    samplers_.clear();
+}
 
 // TODO: implement binner_
 void lif_cell_group::set_binning_policy(binning_kind policy, time_type bin_interval) {
@@ -71,52 +102,134 @@ void lif_cell_group::set_binning_policy(binning_kind policy, time_type bin_inter
 void lif_cell_group::reset() {
     spikes_.clear();
     util::fill(last_time_updated_, 0.);
+    util::fill(next_time_updatable_, 0.);
 }
 
 // Advances a single cell (lid) with the exact solution (jumps can be arbitrary).
 // Parameter dt is ignored, since we make jumps between two consecutive spikes.
-void lif_cell_group::advance_cell(time_type tfinal, time_type dt, cell_gid_type lid, pse_vector& event_lane) {
-    // Current time of last update.
+void lif_cell_group::advance_cell(time_type tfinal, time_type dt, cell_gid_type lid, const event_lane_subrange& event_lanes) {
+    // our gid
+    const auto gid = gids_[lid];
+    // time of last update.
     auto t = last_time_updated_[lid];
     auto& cell = cells_[lid];
-    const auto n_events = event_lane.size();
-
-    // Integrate until tfinal using the exact solution of membrane voltage differential equation.
-    for (unsigned i=0; i<n_events; ++i ) {
-        auto& ev = event_lane[i];
-        const auto time = ev.time;
-        auto weight = ev.weight;
-
-        if (time < t) continue;        // skip event if a neuron is in refactory period
-        if (time >= tfinal) break;     // end of integration interval
-
-        // if there are events that happened at the same time as this event, process them as well
-        while (i + 1 < n_events && event_lane[i+1].time <= time) {
-            weight += event_lane[i+1].weight;
-            i++;
-        }
-
-        // Let the membrane potential decay.
-        auto decay = exp(-(time - t) / cell.tau_m);
-        cell.V_m *= decay;
-        auto update = weight / cell.C_m;
-        // Add jump due to spike.
-        cell.V_m += update;
-        t = time;
-        // If crossing threshold occurred
-        if (cell.V_m >= cell.V_th) {
-            cell_member_type spike_neuron_gid = {gids_[lid], 0};
-            spike s = {spike_neuron_gid, t};
-            spikes_.push_back(s);
-
-            // Advance the last_time_updated to account for the refractory period.
-            t += cell.t_ref;
-
-            // Reset the voltage to resting potential.
-            cell.V_m = cell.E_L;
+    // integrate until tfinal using the exact solution of membrane voltage differential equation.
+    // spikes to process
+    const auto n_events = event_lanes.size() ? event_lanes[lid].size() : 0;
+    int e_idx = 0;
+    // collected sampling data
+    std::unordered_map<sampler_association_handle,
+                       std::unordered_map<cell_member_type,
+                                          std::vector<sample_record>>> sampled;
+    // samples to process
+    std::vector<std::pair<time_type, sampler_association_handle>> samples;
+    std::size_t count = 0;
+    {
+        std::lock_guard<std::mutex> guard(sampler_mex_);
+        for (auto& [hdl, assoc]: samplers_) {
+            // Count up the samplers touching _our_ gid
+            std::size_t delta = 0;
+            for (const auto& pid: assoc.probeset_ids) delta += pid.gid == gid;
+            if (delta == 0) continue;
+            // Construct sampling times
+            const auto& times = util::make_range(assoc.sched.events(t, tfinal));
+            count += delta*times.size();
+            // We only ever use exact sampling, so we over-provision for lax and
+            // never look at the policy
+            for (auto t: times) samples.emplace_back(t, hdl);
         }
     }
-
+    std::sort(samples.begin(), samples.end());
+    const auto n_samples = samples.size();
+    int s_idx = 0;
+    // Now allocate some scratch space for the probed values, if we don't,
+    // re-alloc might move our data
+    std::vector<value_type> sampled_voltages;
+    sampled_voltages.reserve(count);
+    for (;;) {
+        const auto e_time = e_idx < n_events ? event_lanes[lid][e_idx].time : tfinal;
+        const auto s_time = s_idx < n_samples ? samples[s_idx].first : tfinal;
+        const auto time = std::min(e_time, s_time);
+        const auto next = next_time_updatable_[lid];
+        // bail at end of integration interval
+        if (time >= tfinal) break;
+        // Check what to do, we put events before samples, if they collide we'll
+        // see the update in sampling.
+        // We need to incorporate an event
+        if (time == e_time) {
+            const auto& event_lane = event_lanes[lid];
+            // process all events at time t
+            auto weight = 0;
+            for (; e_idx < n_events && event_lane[e_idx].time <= time; ++e_idx) {
+                weight += event_lane[e_idx].weight;
+            }
+            // skip event if a neuron is in refactory period
+            if (time >= next) {
+                // Let the membrane potential decay.
+                cell.V_m *= exp((t - time) / cell.tau_m);
+                // Add jump due to spike.
+                cell.V_m += weight / cell.C_m;
+                t = time;
+                // If crossing threshold occurred
+                if (cell.V_m >= cell.V_th) {
+                    // save spike
+                    spikes_.push_back({{gid, 0}, t});
+                    // Advance the last_time_updated to account for the refractory period.
+                    next_time_updatable_[lid] = t + cell.t_ref;
+                    // Reset the voltage to resting potential.
+                    cell.V_m = cell.E_L;
+                }
+            }
+        }
+        // We need to probe, so figure out what to do.
+        if (time == s_time) {
+            // Consume all sample events at this time
+            for (; s_idx < n_samples && samples[s_idx].first <= time; ++s_idx) {
+                const auto& [s_time, hdl] = samples[s_idx];
+                for (const auto& key: samplers_[hdl].probeset_ids) {
+                    const auto& kind = probe_kinds_[key];
+                    // This is the only thing we know how to do: Probing U(t)
+                    switch (kind) {
+                        case lif_probe_kind::voltage: {
+                            // Compute, but do not _set_ V_m
+                            auto U = cell.V_m;
+                            // Honour the refractory period
+                            if (time >= next) U *= exp((t - time) / cell.tau_m);
+                            // Store U for later use.
+                            sampled_voltages.push_back(U);
+                            // Set up reference to sampled value
+                            auto data_ptr = sampled_voltages.data() + sampled_voltages.size() - 1;
+                            sampled[hdl][key].push_back(sample_record{time, {data_ptr}});
+                            break;
+                        }
+                        default:
+                            throw arbor_internal_error{"Invalid LIF probe kind"};
+                    }
+                }
+            }
+        }
+        if ((time != s_time) && (time != e_time)) {
+            throw arbor_internal_error{"LIF cell group: Must select either sample or spike event; got neither."};
+        }
+    }
+    // Now we need to call all sampler callbacks with the data we have collected
+    {
+        std::lock_guard<std::mutex> guard(sampler_mex_);
+        for (const auto& [k, vs]: sampled) {
+            const auto& fun = samplers_[k].sampler;
+            for (const auto& [id, us]: vs) {
+                fun(probe_metadata{id, {}, 0, nullptr}, us.size(), us.data());
+            }
+        }
+    }
     // This is the last time a cell was updated.
     last_time_updated_[lid] = t;
+}
+
+std::vector<probe_metadata> lif_cell_group::get_probe_metadata(cell_member_type key) const {
+    if (probe_meta_.count(key)) {
+        return {probe_metadata{key, {}, 0, {&probe_meta_.at(key)}}};
+    } else {
+        return {};
+    }
 }

--- a/arbor/lif_cell_group.hpp
+++ b/arbor/lif_cell_group.hpp
@@ -9,6 +9,7 @@
 #include <arbor/sampling.hpp>
 #include <arbor/spike.hpp>
 
+#include "sampler_map.hpp"
 #include "cell_group.hpp"
 #include "label_resolution.hpp"
 
@@ -37,10 +38,15 @@ public:
     virtual void remove_sampler(sampler_association_handle) override;
     virtual void remove_all_samplers() override;
 
+    virtual std::vector<probe_metadata> get_probe_metadata(cell_member_type) const override;
+
 private:
+    enum class lif_probe_kind { voltage };
+
+
     // Advances a single cell (lid) with the exact solution (jumps can be arbitrary).
     // Parameter dt is ignored, since we make jumps between two consecutive spikes.
-    void advance_cell(time_type tfinal, time_type dt, cell_gid_type lid, pse_vector& event_lane);
+    void advance_cell(time_type tfinal, time_type dt, cell_gid_type lid, const event_lane_subrange& event_lane);
 
     // List of the gids of the cells in the group.
     std::vector<cell_gid_type> gids_;
@@ -53,6 +59,14 @@ private:
 
     // Time when the cell was last updated.
     std::vector<time_type> last_time_updated_;
+    // Time when the cell can _next_ be updated;
+    std::vector<time_type> next_time_updatable_;
+
+    std::mutex sampler_mex_;
+    sampler_association_map samplers_;
+    std::unordered_map<cell_member_type, probe_tag> probe_tags_;
+    std::unordered_map<cell_member_type, lif_probe_kind> probe_kinds_;
+    std::unordered_map<cell_member_type, lif_probe_metadata> probe_meta_;
 };
 
 } // namespace arb

--- a/doc/concepts/cable_cell.rst
+++ b/doc/concepts/cable_cell.rst
@@ -46,7 +46,6 @@ Once constructed, the cable cell can be queried for specific information about t
    labels
    mechanisms
    decor
-   probe_sample
 
 API
 ---

--- a/doc/concepts/index.rst
+++ b/doc/concepts/index.rst
@@ -42,3 +42,5 @@ of the model over the locally available computational resources.
 
 In order to visualize the result of detected spikes a spike recorder can be used, and to analyse Arbor's performance a
 meter manager is available.
+
+:ref:`probesample` shows how to extract data from simulations.

--- a/doc/concepts/lif_cell.rst
+++ b/doc/concepts/lif_cell.rst
@@ -19,6 +19,8 @@ cell is created. The labels are used to form connections to and from the cell.
 LIF cells do not support adding additional **sources** or **targets** to the description. They do not support
 **gap junctions**. They do not support adding density or point mechanisms.
 
+LIF cells can be probed to obtain their current membrane potential, see :ref:`probesample`.
+
 API
 ---
 

--- a/doc/concepts/probe_sample.rst
+++ b/doc/concepts/probe_sample.rst
@@ -1,7 +1,12 @@
 .. _probesample:
 
-Cable cell probing and sampling
-===============================
+Probing and Sampling
+====================
+
+Both cable cells and LIF cells can be probed, see here for more details on cells
+:ref:`modelcells`. The LIF cell, however, has a much smaller set of observable
+quantities and only offers scalar probes. Thus, the following discussion is
+tailored to the cable cell.
 
 Definitions
 ***********
@@ -63,7 +68,6 @@ Spiking
 
 Threshold detectors have a dual use: they can be used to record spike times, but are also used in propagating signals
 between cells. See also :term:`threshold detector` and :ref:`cablecell-threshold-detectors`.
-
 
 API
 ---

--- a/doc/cpp/probe_sample.rst
+++ b/doc/cpp/probe_sample.rst
@@ -660,3 +660,19 @@ call the *sampler* callback once for probe in *probe set*, with *n* sample value
 In addition to the ``lax`` sampling policy, ``mc_cell_group`` supports the ``exact``
 policy. Integration steps will be shortened such that any sample times associated
 with an ``exact`` policy can be satisfied precisely.
+
+LIF cell probing and sampling
+===============================
+
+Membrane voltage
+^^^^^^^^^^^^^^^^
+
+.. code::
+
+    struct lif_probe_voltage {};
+
+Queries cell membrane potential.
+
+* Sample value: ``double``. Membrane potential (mV).
+
+* Metadata: none

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -129,6 +129,7 @@ A full list of our software attributions can be found `here <https://github.com/
    concepts/lif_cell
    concepts/spike_source_cell
    concepts/benchmark_cell
+   concepts/probe_sample
 
 .. toctree::
    :caption: Modelling:

--- a/doc/python/probe_sample.rst
+++ b/doc/python/probe_sample.rst
@@ -298,3 +298,12 @@ Ionic external concentration
 
    Kind: :term:`vector probe`.
 
+LIF Cell probing
+================
+
+Membrane voltage
+   .. py:function:: lif_probe_voltage()
+
+   Current cell membrane potential (mV).
+
+   Metadata: none

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 set(pyarb_source
     cable_cell_io.cpp
-    cable_probes.cpp
+    probes.cpp
     cells.cpp
     config.cpp
     context.cpp

--- a/python/pyarb.hpp
+++ b/python/pyarb.hpp
@@ -57,7 +57,8 @@ struct recorder_factory_map {
             return map_.at(meta.type())(meta);
         }
         catch (std::out_of_range&) {
-            throw arb::arbor_internal_error("unrecognized probe metadata type");
+            std::string ty = meta.type().name();
+            throw arb::arbor_internal_error("unrecognized probe metadata type " + ty);
         }
     }
 };

--- a/python/test/unit/test_probes.py
+++ b/python/test/unit/test_probes.py
@@ -2,6 +2,7 @@
 
 import unittest
 import arbor as A
+import numpy as np
 
 """
 tests for cable probe wrappers
@@ -166,3 +167,60 @@ class TestCableProbes(unittest.TestCase):
         m = sim.probe_metadata((0, 16))
         self.assertEqual(1, len(m))
         self.assertEqual(all_cv_cables, m[0])
+
+
+class lif_recipe(A.recipe):
+    def __init__(self):
+        A.recipe.__init__(self)
+
+    def num_cells(self):
+        return 1
+
+    def cell_kind(self, gid):
+        return A.cell_kind.lif
+
+    def global_properties(self, kind):
+        return None
+
+    def probes(self, gid):
+        return [
+            # probe id (0, 0)
+            A.lif_probe_voltage(),
+        ]
+
+    def cell_description(self, gid):
+        cell = A.lif_cell("src", "tgt")
+        cell.E_L = -42
+        cell.V_m = -23
+        cell.V_reset = -21
+        cell.t_ref = 0.2
+        return cell
+
+
+class TestLifProbes(unittest.TestCase):
+    def test_probe_addr_metadata(self):
+        rec = lif_recipe()
+        sim = A.simulation(rec)
+
+        m = sim.probe_metadata((0, 0))
+        self.assertEqual(1, len(m))
+        self.assertTrue(all(isinstance(i, A.lif_probe_metadata) for i in m))
+
+    def test_probe_result(self):
+        rec = lif_recipe()
+        sim = A.simulation(rec)
+        hdl = sim.sample((0, 0), A.regular_schedule(0.1))
+        sim.run(1.0, 0.05)
+        smp = sim.samples(hdl)
+        exp = np.array([[  0.        , -23.        ],
+                        [  0.1       , -22.77114618],
+                        [  0.2       , -22.54456949],
+                        [  0.3       , -22.32024727],
+                        [  0.4       , -22.0981571 ],
+                        [  0.5       , -21.87827676],
+                        [  0.6       , -21.66058427],
+                        [  0.7       , -21.44505786],
+                        [  0.8       , -21.23167597],
+                        [  0.9       , -21.02041726]])
+        for d, _ in smp:
+            np.testing.assert_allclose(d, exp)


### PR DESCRIPTION
- Add probes for LIF cell potential
  - LIF probes are always exact
  - probing  never changes cell state
- Expose to Python
- Add docs
  - move sampling and probing to concepts, from cable cells 
  - add LIF probe API 
- Add tests for C++ and Python

Closes #1263 (note that the ISI can be obtained otherwise and we can also add it later) 