### PR TITLE
Yank v0.5 from Spack file, it does not build due to change in setting arch

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -36,11 +36,6 @@ class Arbor(CMakePackage, CudaPackage):
         sha256="290e2ad8ca8050db1791cabb6b431e7c0409c305af31b559e397e26b300a115d",
         url="https://github.com/arbor-sim/arbor/releases/download/v0.5.2/arbor-v0.5.2-full.tar.gz",
     )
-    version(
-        "0.5",
-        sha256="d0c8a4c7f97565d7c30493c66249be794d1dc424de266fc79cecbbf0e313df59",
-        url="https://github.com/arbor-sim/arbor/releases/download/v0.5/arbor-v0.5-full.tar.gz",
-    )
 
     variant(
         "assertions",


### PR DESCRIPTION
See [here](https://gitlab.ebrains.eu/technical-coordination/project-internal/devops/platform/ebrains-spack-builds/-/merge_requests/189). The logic was changed in v0.5.2, but not kept backwards compatible. Users who depend on v0.5 (of which none have come forward), can use v0.5.2 without changing their scripts.