### PR TITLE
Set Python to known version for all CI workflows

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04]
         python-version: [3.8]
     steps:
       - name: Checkout

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -18,7 +18,9 @@ jobs:
         uses: actions/checkout@v3
         with:
             path: arbor
-
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Spack cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -25,8 +25,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.spack-cache
-          key: arbor-cache-${{ github.run_id }}
-          restore-keys: arbor-cache-
+          key: arbor-cache-${{ matrix.os }}-${{ github.run_id }}
 
       - name: Build Arbor's Spack package against the develop branch
         run: arbor/scripts/build_spack_package.sh arbor develop

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04, ubuntu-22.04]
         python-version: [3.8]
     steps:
       - name: Checkout

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           path: ~/.spack-cache
           key: arbor-cache-${{ matrix.os }}-${{ github.run_id }}
+          restore-keys: arbor-cache-${{ matrix.os }}-
 
       - name: Build Arbor's Spack package against the develop branch
         run: arbor/scripts/build_spack_package.sh arbor develop

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -198,7 +198,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04, ubuntu-22.04]
         python-version: [3.7, 3.11]
     steps:
       - uses: actions/setup-python@v4

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -198,8 +198,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.11]
+        os: [ubuntu-20.04]
+        python-version: [3.7]
     steps:
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -46,8 +46,8 @@ jobs:
         - {
             name:  "Linux Max GCC",
             os:    "ubuntu-22.04",
-            cc:    "gcc-11",
-            cxx:   "g++-11",
+            cc:    "gcc-12",
+            cxx:   "g++-12",
             py:    "3.10",
             cmake: "3.22.x",
             mpi:   "ON",
@@ -56,8 +56,8 @@ jobs:
         - {
             name:  "Linux SIMD",
             os:    "ubuntu-22.04",
-            cc:    "gcc-11",
-            cxx:   "g++-11",
+            cc:    "gcc-12",
+            cxx:   "g++-12",
             py:    "3.10",
             cmake: "3.22.x",
             mpi:   "OFF",

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -183,10 +183,10 @@ jobs:
         run: scripts/run_cpp_examples.sh "mpirun -n 4 -oversubscribe"
       - name: Run python tests
         run: |
-          python3 -m unittest discover -v -s python
+          python -m unittest discover -v -s python
       - if:   ${{ matrix.config.mpi == 'ON' }}
         name: Run python+MPI tests
-        run:  mpirun -n 4 -oversubscribe python3 -m unittest discover -v -s python
+        run:  mpirun -n 4 -oversubscribe python -m unittest discover -v -s python
       # - name: Run Python examples (plotting leads to time outs on macos, the step under testpip is enough)
       #   run: scripts/run_python_examples.sh
       - name: Build and test a catalogue
@@ -195,18 +195,32 @@ jobs:
           ./scripts/test-catalogue.py ./default-catalogue.so
   testpip:
     name: "Pip build test + Python examples test"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.7, 3.11]
     steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Clone w/ submodules
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Debug info Python
+        run: |
+          which python
+          python --version
+          pip --version
       - name: Build and install Arbor using pip + build flags
-        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python3 -m pip install .
+        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python -m pip install .
       - name: Check that build flags match
         run: |
-          python3 -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"
+          python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"
       - name: Run Python tests
-        run: python3 -m unittest discover -v -s python
+        run: python -m unittest discover -v -s python
       - name: Run Python examples
         run: scripts/run_python_examples.sh

--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -148,8 +148,8 @@ Post Release
    - TC Wiki: https://wiki.ebrains.eu/bin/view/Collabs/technical-coordination/EBRAINS%20components/Arbor/
    - KG: https://search.kg.ebrains.eu/instances/5cf4e24b-b0eb-4d05-96e5-a7751134a061
  
-     - Update howto: https://github.com/bweyers/HBPVisCatalogue/wiki/How-to-start-software-meta-data-curation%3F#update-curated-software
-     - Previous update as template: https://github.com/bweyers/HBPVisCatalogue/issues/480
+     - Update howto: https://wiki.ebrains.eu/bin/view/Collabs/swc-guide#HHowtoupdateexistingSoftwareinstances
+     - tldr: shoot your ticket here: curation-support@humanbrainproject.eu
      - Supported file formats
  
        - ContentTypes: https://humanbrainproject.github.io/openMINDS/v3/core/v4/data/contentType.html
@@ -160,6 +160,15 @@ Post Release
 #. FZJ admin
 
    - https://juser.fz-juelich.de/submit
+
+GUI
+===
+
+Release automation is a bit more advanced for Arbor GUI: the act of pushing a new tag, auto-drafts a release with the relevant artifacts.
+The post release steps mentioned above are largely the same. A list of the places where an update must be entered:
+
+#. https://doi.org/10.5281/zenodo.7415129
+#. https://plus.humanbrainproject.eu/components/3178
 
 .. _GH tags: https://github.com/arbor-sim/arbor/tags
 .. _AUTOMATED: https://github.com/arbor-sim/arbor/blob/master/.github/workflows/ebrains.yml 


### PR DESCRIPTION
See the same jobs fail, which turn out to execute using different Python versions:
- https://github.com/arbor-sim/arbor/actions/runs/3618204857/jobs/6097794385
- https://github.com/arbor-sim/arbor/actions/runs/3630819640/jobs/6141257441
