### PR TITLE
Silence spurious unused variable warnings in generated code

### DIFF
--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -328,7 +328,7 @@ ARB_LIBMODCC_API std::string emit_cpp_source(const Module& module_, const printe
                                        "        auto end    = stream_ptr->events + stream_ptr->end[c];\n"
                                        "        for (auto p = begin; p<end; ++p) {{\n"
                                        "            auto i_     = p->mech_index;\n"
-                                       "            auto {1} = p->weight;\n"
+                                       "            [[maybe_unused]] auto {1} = p->weight;\n"
                                        "            if (p->mech_id=={0}mechanism_id) {{\n"),
                            pp_var_pfx,
                            net_receive_api->args().empty() ? "weight" : net_receive_api->args().front()->is_argument()->name());

--- a/modcc/printer/gpuprinter.cpp
+++ b/modcc/printer/gpuprinter.cpp
@@ -234,7 +234,7 @@ ARB_LIBMODCC_API std::string emit_gpu_cu_source(const Module& module_, const pri
                                        "        for (auto p = begin; p<end; ++p) {{\n"
                                        "            if (p->mech_id=={1}mechanism_id) {{\n"
                                        "                auto tid_ = p->mech_index;\n"
-                                       "                auto {0} = p->weight;\n"),
+                                       "                [[maybe_unused]] auto {0} = p->weight;\n"),
                            net_receive_api->args().empty() ? "weight" : net_receive_api->args().front()->is_argument()->name(),
                            pp_var_pfx);
         out << indent << indent << indent << indent;


### PR DESCRIPTION
`[[maybe_unused]]` in generated code to silence warnings for mechanisms with `net_receive` methods that do not use the connection weight.