### PR TITLE
Remove redundant sample events structure.

### DIFF
--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -73,7 +73,6 @@ mc_cell_group::mc_cell_group(const std::vector<cell_gid_type>& gids,
 void mc_cell_group::reset() {
     spikes_.clear();
 
-    sample_events_.clear();
     for (auto &entry: sampler_map_) {
         entry.second.sched.reset();
     }

--- a/arbor/mc_cell_group.hpp
+++ b/arbor/mc_cell_group.hpp
@@ -86,9 +86,6 @@ private:
     // List of events to deliver
     std::vector<deliverable_event> staged_events_;
 
-    // Pending samples to be taken.
-    event_queue<sample_event> sample_events_;
-
     // Handles for accessing lowered cell.
     std::vector<target_handle> target_handles_;
 


### PR DESCRIPTION
`mc_cell_group::sample_events_` was never used (except clearing it). It's gone now.
