### PR TITLE
Add some missing #include directives

### DIFF
--- a/arbor/include/arbor/morph/primitives.hpp
+++ b/arbor/include/arbor/morph/primitives.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cstdint>
 #include <ostream>
 #include <vector>
 

--- a/arbor/threading/threading.cpp
+++ b/arbor/threading/threading.cpp
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <stdexcept>
 
 #include <arbor/assert.hpp>
 #include <arbor/util/scope_exit.hpp>


### PR DESCRIPTION
Fixes failure to compile with GCC 13.

<!-- Please make sure your PR follows our [contribution guidelines](https://github.com/arbor-sim/arbor/tree/master/doc/contrib) and agree to the terms outlined in the [PR procedure](https://github.com/arbor-sim/arbor/tree/master/doc/contrib/pr.rst). -->
