### PR TITLE
Take less locks for shorter times when sampling.

### DIFF
--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -26,7 +26,7 @@ arbor_internal_error::arbor_internal_error(const std::string& what):
 domain_error::domain_error(const std::string& w): arbor_exception(w) {}
 
 bad_cell_probe::bad_cell_probe(cell_kind kind, cell_gid_type gid):
-    arbor_exception(pprintf("recipe::get_grobe() is not supported for cell with gid {} of kind {})", gid, kind)),
+    arbor_exception(pprintf("Probe kind is not supported for cell with gid {} of kind {}. Possibly the cell kind is not probeable at all.", gid, kind)),
     gid(gid),
     kind(kind)
 {}

--- a/arbor/lif_cell_group.cpp
+++ b/arbor/lif_cell_group.cpp
@@ -64,7 +64,6 @@ void lif_cell_group::clear_spikes() {
     spikes_.clear();
 }
 
-// TODO: implement sampler
 void lif_cell_group::add_sampler(sampler_association_handle h,
                                  cell_member_predicate probeset_ids,
                                  schedule sched,
@@ -123,9 +122,10 @@ void lif_cell_group::advance_cell(time_type tfinal, time_type dt, cell_gid_type 
     // samples to process
     std::size_t n_values = 0;
     std::vector<std::pair<time_type, sampler_association_handle>> samples;
-    {
+    if (!samplers_.empty()) {
         std::lock_guard<std::mutex> guard(sampler_mex_);
         for (auto& [hdl, assoc]: samplers_) {
+            if (assoc.probeset_ids.empty()) continue; // No need to generate events
             // Construct sampling times
             const auto& times = util::make_range(assoc.sched.events(t, tfinal));
             const auto n_times = times.size();

--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -460,38 +460,39 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
 
     std::vector<deliverable_event> exact_sampling_events;
 
-    {
+    if (!sampler_map_.empty()) { // NOTE: We avoid the lock here as often as possible
+        // SAFETY: We need the lock here, as _schedule_ is not reentrant.
         std::lock_guard<std::mutex> guard(sampler_mex_);
-
-        for (auto& sm_entry: sampler_map_) {
-            // Ignore sampler_association_handle, just need the association itself.
-            sampler_association& sa = sm_entry.second;
-
+        for (auto& [sk, sa]: sampler_map_) {
+            if (sa.probeset_ids.empty()) continue; // No need to make any schedule
             auto sample_times = util::make_range(sa.sched.events(tstart, ep.t1));
-            if (sample_times.empty()) {
-                continue;
-            }
-
             sample_size_type n_times = sample_times.size();
+            if (n_times == 0) continue;
             max_samples_per_call = std::max(max_samples_per_call, n_times);
-
-            for (cell_member_type pid: sa.probeset_ids) {
-                auto cell_index = gid_index_map_.at(pid.gid);
-
+            for (const cell_member_type& pid: sa.probeset_ids) {
+                cell_size_type cell_index = gid_index_map_.at(pid.gid);
+                cell_size_type intdom = cell_to_intdom_[cell_index];
                 probe_tag tag = probe_map_.tag.at(pid);
                 unsigned index = 0;
+                target_handle null_target{(cell_local_size_type)-1, 0, intdom};
                 for (const fvm_probe_data& pdata: probe_map_.data_on(pid)) {
-                    call_info.push_back({sa.sampler, pid, tag, index++, &pdata, n_samples, n_samples + n_times*pdata.n_raw()});
-                    auto intdom = cell_to_intdom_[cell_index];
-
+                    call_info.push_back({sa.sampler,
+                                         pid,
+                                         tag,
+                                         index,
+                                         &pdata,
+                                         n_samples,
+                                         n_samples + n_times*pdata.n_raw()});
+                    index++;
                     for (auto t: sample_times) {
                         for (probe_handle h: pdata.raw_handle_range()) {
-                            sample_event ev{t, (cell_gid_type)intdom, {h, n_samples++}};
-                            sample_events.push_back(ev);
+                            sample_events.push_back({t, intdom, raw_probe_info{h, n_samples}});
+                            n_samples++;
                         }
-                        if (sa.policy==sampling_policy::exact) {
-                            target_handle h(-1, 0, intdom);
-                            exact_sampling_events.push_back({t, h, 0.f});
+                        if (sa.policy == sampling_policy::exact) {
+                            exact_sampling_events.emplace_back(t,
+                                                               null_target,
+                                                               0.f);
                         }
                     }
                 }
@@ -501,7 +502,7 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
     }
 
     // Sort exact sampling events into staged events for delivery.
-    if (exact_sampling_events.size()) {
+    if (!exact_sampling_events.empty()) {
         auto event_less =
             [](const auto& a, const auto& b) {
                  auto ai = event_index(a);
@@ -521,8 +522,9 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
     }
 
     // Sample events must be ordered by time for the lowered cell.
-    util::sort_by(sample_events, [](const sample_event& ev) { return event_time(ev); });
-    util::stable_sort_by(sample_events, [](const sample_event& ev) { return event_index(ev); });
+    util::sort_by(sample_events,
+                  [](const sample_event& ev) { return std::make_tuple(event_index(ev),
+                                                                      event_time(ev)); });
     PL();
 
     // Run integration and collect samples, spikes.
@@ -550,7 +552,7 @@ void mc_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& e
     // global index for spike communication.
 
     for (auto c: result.crossings) {
-        spikes_.push_back({spike_sources_[c.index], time_type(c.time)});
+        spikes_.emplace_back(spike_sources_[c.index], time_type(c.time));
     }
 }
 


### PR DESCRIPTION
Title say almost all, locks to the sampler maps are taken even if said map is empty.
So, just don't do that. A sampling heavy experiment shows this delta; we sample
93 cells 10 times per `dt`.  Release build + Profiling + SIMD on a single thread.
## Before
```
Running simulation for 1s...
Simulation done, took: 3.344s
REGION               CALLS     WALL    THREAD        %
root                     -    3.185     3.185    100.0
  advance                -    3.116     3.116     97.8
    samplesetup       8000    2.147     2.147     67.4
    sampledeliver     8000    0.494     0.494     15.5
    integrate            -    0.457     0.457     14.3
      setup           8000    0.282     0.282      8.8
```
## After
```
Running simulation for 1s...
Simulation done, took: 1.878s
REGION               CALLS     WALL    THREAD        %
root                     -    1.725     1.725    100.0
  advance                -    1.656     1.656     96.0
    samplesetup       8000    0.938     0.938     54.4
    sampledeliver     8000    0.407     0.407     23.6
    integrate            -    0.293     0.293     17.0
```