### PR TITLE
The Initialisation Optimisation

### DIFF
--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -169,14 +169,13 @@ struct cable_cell_impl {
     }
 
     void paint(const region& reg, const scaled_mechanism<density>& prop) {
-        mextent cables = thingify(reg, provider);
-        auto& mm = get_region_map(prop.t_mech);
-
         std::unordered_map<std::string, iexpr_ptr> im;
         for (const auto& [fst, snd]: prop.scale_expr) {
             im.insert_or_assign(fst, thingify(snd, provider));
         }
 
+        auto& mm = get_region_map(prop.t_mech);
+        const auto& cables = thingify(reg, provider);
         for (const auto& c: cables) {
             // Skip zero-length cables in extent:
             if (c.prox_pos == c.dist_pos) continue;

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <utility>
 #include <vector>
 

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -96,7 +96,7 @@ void communicator::update_connections(const connectivity& rec,
         for (const auto cidx: util::make_span(part_connections[index], part_connections[index+1])) {
             const auto& conn = gid_connections[cidx];
             auto src_lid = source_resolver.resolve(conn.source);
-            auto tgt_lid = target_resolver.resolve({gid, conn.dest});
+            auto tgt_lid = target_resolver.resolve(gid, conn.dest);
             auto offset  = offsets[*src_domain]++;
             ++src_domain;
             connections_[offset] = {{conn.source.gid, src_lid}, tgt_lid, conn.weight, conn.delay, index};

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <utility>
 #include <vector>
 
@@ -35,24 +36,15 @@ void communicator::update_connections(const connectivity& rec,
                                       const domain_decomposition& dom_dec,
                                       const label_resolution_map& source_resolution_map,
                                       const label_resolution_map& target_resolution_map) {
+    PE(init:communicator:update:clear);
     // Forget all lingering information
     connections_.clear();
     connection_part_.clear();
     index_divisions_.clear();
+    PL();
 
-    // For caching information about each cell
-    struct gid_info {
-        using connection_list = decltype(std::declval<recipe>().connections_on(0));
-        cell_gid_type gid;              // global identifier of cell
-        cell_size_type index_on_domain; // index of cell in this domain
-        connection_list conns;          // list of connections terminating at this cell
-        gid_info() = default;           // so we can in a std::vector
-        gid_info(cell_gid_type g, cell_size_type di, connection_list c):
-            gid(g), index_on_domain(di), conns(std::move(c)) {}
-    };
-
-    // Make a list of local gid with their group index and connections
-    //   -> gid_infos
+    // Make a list of local cells' connections
+    //   -> gid_connections
     // Count the number of local connections (i.e. connections terminating on this domain)
     //   -> n_cons: scalar
     // Calculate and store domain id of the presynaptic cell on each local connection
@@ -61,65 +53,66 @@ void communicator::update_connections(const connectivity& rec,
     //   -> src_counts: array with one entry for each domain
 
     // Record all the gid in a flat vector.
-    // These are used to map from local index to gid in the parallel loop
-    // that populates gid_infos.
-    std::vector<cell_gid_type> gids;
-    gids.reserve(num_local_cells_);
-    for (auto g: dom_dec.groups()) {
-        util::append(gids, g.gids);
-    }
-    // Build the connection information for local cells in parallel.
-    std::vector<gid_info> gid_infos;
-    gid_infos.resize(num_local_cells_);
-    threading::parallel_for::apply(0, gids.size(), thread_pool_.get(),
-        [&](cell_size_type i) {
-            auto gid = gids[i];
-            gid_infos[i] = gid_info(gid, i, rec.connections_on(gid));
-        });
-    cell_local_size_type n_cons =
-        util::sum_by(gid_infos, [](const gid_info& g){ return g.conns.size(); });
-    std::vector<unsigned> src_domains;
-    src_domains.reserve(n_cons);
-    std::vector<cell_size_type> src_counts(num_domains_);
 
-    for (const auto& cell: gid_infos) {
-        for (auto c: cell.conns) {
-            auto sgid = c.source.gid;
-            if (sgid >= num_total_cells_) {
-                throw arb::bad_connection_source_gid(cell.gid, sgid, num_total_cells_);
-            }
+    PE(init:communicator:update:collect_gids);
+    std::vector<cell_gid_type> gids; gids.reserve(num_local_cells_);
+    for (const auto& g: dom_dec.groups()) util::append(gids, g.gids);
+    PL();
+
+    // Build the connection information for local cells.
+    PE(init:communicator:update:gid_connections);
+    std::vector<cell_connection> gid_connections;
+    std::vector<size_t> part_connections; part_connections.reserve(num_local_cells_);
+    part_connections.push_back(0);
+    std::vector<unsigned> src_domains;
+    std::vector<cell_size_type> src_counts(num_domains_);
+    for (const auto gid: gids) {
+        const auto& conns = rec.connections_on(gid);
+        for (const auto& conn: conns) {
+            const auto sgid = conn.source.gid;
+            if (sgid >= num_total_cells_) throw arb::bad_connection_source_gid(gid, sgid, num_total_cells_);
             const auto src = dom_dec.gid_domain(sgid);
             src_domains.push_back(src);
             src_counts[src]++;
+            gid_connections.emplace_back(conn);
         }
+        part_connections.push_back(gid_connections.size());
     }
-
-    // Construct the connections.
-    // The loop above gave the information required to construct in place
-    // the connections as partitioned by the domain of their source gid.
-    connections_.resize(n_cons);
     util::make_partition(connection_part_, src_counts);
+    std::size_t n_cons = gid_connections.size();
+    PL();
+
+    // Construct the connections. The loop above gave us the information needed
+    // to do this in place.
+    // NOTE: The connections are partitioned by the domain of their source gid.
+    PE(init:communicator:update:connections);
+    connections_.resize(n_cons);
     auto offsets = connection_part_; // Copy, as we use this as the list of current target indices to write into
     auto src_domain = src_domains.begin();
     auto target_resolver = resolver(&target_resolution_map);
-    for (const auto& cell: gid_infos) {
-        auto index = cell.index_on_domain;
+    for (const auto index: util::make_span(num_local_cells_)) {
+        const auto gid = gids[index];
         auto source_resolver = resolver(&source_resolution_map);
-        for (const auto& c: cell.conns) {
-            auto src_lid = source_resolver.resolve(c.source);
-            auto tgt_lid = target_resolver.resolve({cell.gid, c.dest});
+        for (const auto cidx: util::make_span(part_connections[index], part_connections[index+1])) {
+            const auto& conn = gid_connections[cidx];
+            auto src_lid = source_resolver.resolve(conn.source);
+            auto tgt_lid = target_resolver.resolve({gid, conn.dest});
             auto offset  = offsets[*src_domain]++;
             ++src_domain;
-            connections_[offset] = {{c.source.gid, src_lid}, tgt_lid, c.weight, c.delay, index};
+            connections_[offset] = {{conn.source.gid, src_lid}, tgt_lid, conn.weight, conn.delay, index};
         }
     }
+    PL();
 
+    PE(init:communicator:update:index);
     // Build cell partition by group for passing events to cell groups
     index_part_ = util::make_partition(index_divisions_,
         util::transform_view(
             dom_dec.groups(),
-            [](const group_description& g){return g.gids.size();}));
+            [](const group_description& g){ return g.gids.size(); }));
+    PL();
 
+    PE(init:communicator:update:sort_connections);
     // Sort the connections for each domain.
     // This is num_domains_ independent sorts, so it can be parallelized trivially.
     const auto& cp = connection_part_;
@@ -127,6 +120,7 @@ void communicator::update_connections(const connectivity& rec,
                                    [&](cell_size_type i) {
                                        util::sort(util::subrange_view(connections_, cp[i], cp[i+1]));
                                    });
+    PL();
 }
 
 std::pair<cell_size_type, cell_size_type> communicator::group_queue_range(cell_size_type i) {

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -1126,22 +1126,21 @@ make_voltage_mechanism_config(const std::unordered_map<std::string, int> ion_spe
         }
 
         std::vector<double> param_on_cv(n_param);
-
         for (auto cv: D.geometry.cell_cvs(cell_idx)) {
             double area = 0;
             util::fill(param_on_cv, 0.);
 
-            for (mcable c: D.geometry.cables(cv)) {
-                double area_on_cable = embedding.integrate_area(c.branch, pw_over_cable(support, c, 0.));
+            for (const auto& cable: D.geometry.cables(cv)) {
+                double area_on_cable = embedding.integrate_area(cable.branch, pw_over_cable(support, cable, 0.));
                 if (!area_on_cable) continue;
                 area += area_on_cable;
                 for (std::size_t i = 0; i<n_param; ++i) {
-                    auto map = param_maps[i];
+                    const auto& map = param_maps[i];
                     auto fun = [&](const auto& c, const auto& x) {
                         return x.first * x.second->eval(provider, c);
                     };
-                    auto pw = pw_over_cable(map, c, 0., fun);
-                    param_on_cv[i] += embedding.integrate_area(c.branch, pw);
+                    auto pw = pw_over_cable(map, cable, 0., fun);
+                    param_on_cv[i] += embedding.integrate_area(cable.branch, pw);
                 }
             }
 

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <utility>
 #include <memory>
+#include <string>
 
 #include <arbor/arbexcept.hpp>
 #include <arbor/cable_cell.hpp>

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -40,7 +40,6 @@ public:
     const auto& labels() const { return labels_; }
     const auto& ranges() const { return ranges_; }
 
-
 private:
     // The number of labels associated with each cell.
     std::vector<cell_size_type> sizes_;
@@ -80,8 +79,8 @@ public:
     label_resolution_map() = default;
     explicit label_resolution_map(const cell_labels_and_gids&);
 
-    const range_set& at(const cell_gid_type& gid, const cell_tag_type& tag) const;
-    std::size_t count(const cell_gid_type& gid, const cell_tag_type& tag) const;
+    const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const;
+    std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const;
 
 private:
     std::unordered_map<cell_gid_type, std::unordered_map<cell_tag_type, range_set>> map;
@@ -113,14 +112,17 @@ struct ARB_ARBOR_API assert_univalent_state {
 struct ARB_ARBOR_API resolver {
     resolver(const label_resolution_map* label_map): label_map_(label_map) {}
     cell_lid_type resolve(const cell_global_label_type& iden);
+    cell_lid_type resolve(cell_gid_type gid, const cell_local_label_type& lid);
 
-private:
     using state_variant = std::variant<round_robin_state, round_robin_halt_state, assert_univalent_state>;
 
+private:
+    template<typename K, typename V>
+    using map = std::unordered_map<K, V>;
     state_variant construct_state(lid_selection_policy pol);
     state_variant construct_state(lid_selection_policy pol, cell_lid_type state);
 
     const label_resolution_map* label_map_;
-    std::unordered_map<cell_gid_type, std::unordered_map<cell_tag_type, std::unordered_map <lid_selection_policy, state_variant>>> state_map_;
+    map<cell_gid_type, map<cell_tag_type, map<lid_selection_policy, state_variant>>> state_map_;
 };
 } // namespace arb

--- a/arbor/morph/embed_pwlin.cpp
+++ b/arbor/morph/embed_pwlin.cpp
@@ -97,6 +97,7 @@ struct embed_pwlin_data {
 // function is an interval [a, b] with 0 ≤ a ≤ pos ≤ b ≤ 1.
 
 template <unsigned p, unsigned q>
+inline constexpr
 double interpolate(double pos, const pw_ratpoly<p, q>& f) {
     auto [extent, poly] = f(pos);
     auto [left, right] = extent;
@@ -111,6 +112,7 @@ double interpolate(double pos, const pw_ratpoly<p, q>& f) {
 // an interval [r, s]: ∫[r,s] g(x) df(x) (where [r, s] is the domain of g).
 
 template <unsigned p, unsigned q>
+inline constexpr
 double integrate(const pw_constant_fn& g, const pw_ratpoly<p, q>& f) {
     double sum = 0;
     for (auto&& [extent, gval]: g) {

--- a/arbor/morph/embed_pwlin.cpp
+++ b/arbor/morph/embed_pwlin.cpp
@@ -97,7 +97,6 @@ struct embed_pwlin_data {
 // function is an interval [a, b] with 0 ≤ a ≤ pos ≤ b ≤ 1.
 
 template <unsigned p, unsigned q>
-inline constexpr
 double interpolate(double pos, const pw_ratpoly<p, q>& f) {
     auto [extent, poly] = f(pos);
     auto [left, right] = extent;
@@ -112,7 +111,6 @@ double interpolate(double pos, const pw_ratpoly<p, q>& f) {
 // an interval [r, s]: ∫[r,s] g(x) df(x) (where [r, s] is the domain of g).
 
 template <unsigned p, unsigned q>
-inline constexpr
 double integrate(const pw_constant_fn& g, const pw_ratpoly<p, q>& f) {
     double sum = 0;
     for (auto&& [extent, gval]: g) {

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -279,19 +279,24 @@ ARB_ARBOR_API mlocation canonical(const morphology& m, mlocation loc) {
 // Used by the mextent constructor.
 mcable_list build_mextent_cables(const mcable_list& cables) {
     arb_assert(arb::test_invariants(cables));
-
     mcable_list cs;
-    for (auto& c: cables) {
-        mcable* prev = cs.empty()? nullptr: &cs.back();
-
-        if (prev && prev->branch==c.branch && prev->dist_pos>=c.prox_pos) {
-            prev->dist_pos = std::max(prev->dist_pos, c.dist_pos);
+    if (cables.empty()) return cs;
+    cs.reserve(cables.size());
+    cs.push_back(cables[0]);
+    for (std::size_t ix = 1; ix < cables.size(); ++ix) {
+        const auto& cable = cables[ix];
+        // Extend the last entry, if overlapping and same branch
+        if (cs.back().branch == cable.branch
+         && cs.back().dist_pos >= cable.prox_pos) {
+            if (cs.back().dist_pos < cable.dist_pos) {
+                cs.back().dist_pos = cable.dist_pos;
+            }
         }
         else {
-            cs.push_back(c);
+            cs.emplace_back(cable);
         }
     }
-
+    cs.shrink_to_fit();
     return cs;
 }
 

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -151,11 +151,12 @@ mextent thingify_(const tagged_& reg, const mprovider& p) {
     for (msize_t i: util::make_span(nb)) {
         for (const auto& seg: m.branch_segments(i)) {
             if (seg.tag==reg.tag) {
-                cables.push_back(e.segment(seg.id));
+                cables.emplace_back(e.segment(seg.id));
             }
         }
     }
-    util::sort(cables);
+    // NOTE: this should always be true since we traverse things in order.
+    arb_assert(util::is_sorted(cables));
     return mextent(cables);
 }
 

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -204,25 +204,38 @@ simulation_state::simulation_state(
     std::vector<cell_labels_and_gids> cg_targets(num_groups);
     foreach_group_index(
         [&](cell_group_ptr& group, int i) {
+          PE(init:simulation:group:factory);
           const auto& group_info = decomp.group(i);
           cell_label_range sources, targets;
           auto factory = cell_kind_implementation(group_info.kind, group_info.backend, *ctx_, seed);
           group = factory(group_info.gids, rec, sources, targets);
-
+          PL();
+          PE(init:simulation:group:targets_and_sources);
           cg_sources[i] = cell_labels_and_gids(std::move(sources), group_info.gids);
           cg_targets[i] = cell_labels_and_gids(std::move(targets), group_info.gids);
+          PL();
         });
 
+    PE(init:simulation:sources);
     cell_labels_and_gids local_sources, local_targets;
     for(const auto& i: util::make_span(num_groups)) {
         local_sources.append(cg_sources.at(i));
         local_targets.append(cg_targets.at(i));
     }
-    auto global_sources = ctx->distributed->gather_cell_labels_and_gids(local_sources);
+    PL();
 
+    PE(init:simulation:source:MPI);
+    auto global_sources = ctx->distributed->gather_cell_labels_and_gids(local_sources);
+    PL();
+
+    PE(init:simulation:resolvers);
     source_resolution_map_ = label_resolution_map(std::move(global_sources));
     target_resolution_map_ = label_resolution_map(std::move(local_targets));
+    PL();
+
+    PE(init:simulation:comm);
     communicator_ = communicator(rec, ddc_, *ctx_);
+    PL();
     update(rec);
     epoch_.reset();
 }
@@ -240,6 +253,7 @@ void simulation_state::update(const connectivity& rec) {
     event_generators_.resize(num_local_cells);
     cell_size_type lidx = 0;
     cell_size_type grpidx = 0;
+    PE(init:simulation:update:generators);
     auto target_resolution_map_ptr = std::make_shared<label_resolution_map>(target_resolution_map_);
     for (const auto& group_info: ddc_.groups()) {
         for (auto gid: group_info.gids) {
@@ -260,6 +274,7 @@ void simulation_state::update(const connectivity& rec) {
         }
         ++grpidx;
     }
+    PL();
 
     // Create event lane buffers.
     // One buffer is consumed by cell group updates while the other is filled with events for

--- a/arbor/util/maputil.hpp
+++ b/arbor/util/maputil.hpp
@@ -78,7 +78,7 @@ namespace maputil_impl {
         typename Eq = std::equal_to<>,
         typename Ret = std::remove_reference_t<decltype(get<1>(*begin(std::declval<Seq&&>())))>
     >
-    Ret value_by_key_or(std::false_type, Seq&& seq, const Key& key, Ret def, Eq eq=Eq{}) {
+    Ret value_by_key_or(std::false_type, Seq&& seq, const Key& key, Ret&& def, Eq eq=Eq{}) {
         for (auto&& entry: seq) {
             if (eq(get<0>(entry), key)) {
                 return get<1>(entry);
@@ -123,7 +123,7 @@ namespace maputil_impl {
         typename FindRet = decltype(std::declval<Assoc&&>().find(std::declval<Key>())),
         typename Ret = std::remove_reference_t<decltype(get<1>(*std::declval<FindRet>()))>
     >
-    Ret value_by_key_or(std::true_type, Assoc&& map, const Key& key, Ret def) {
+    Ret value_by_key_or(std::true_type, Assoc&& map, const Key& key, Ret&& def) {
         auto it = map.find(key);
         if (it!=std::end(map)) {
             return get<1>(*it);
@@ -157,17 +157,17 @@ auto value_by_key(C&& c, const Key& k) {
         std::forward<C>(c), k);
 }
 
-// Return copy of value associated with key, wrapped in std::optional, or std::nullopt.
+// Return copy of value associated with key; if absent return default
 
 template <typename C, typename Key, typename Val, typename Eq>
-auto value_by_key_or(C&& c, const Key& k, Val v, Eq eq) {
+auto value_by_key_or(C&& c, const Key& k, Val&& v, Eq eq) {
     return maputil_impl::value_by_key_or(std::false_type{}, std::forward<C>(c), k, v, eq);
 }
 
 template <typename C,
           typename Key,
           typename Val = std::remove_reference_t<decltype(std::get<1>(*begin(std::declval<C&&>())))>>
-auto value_by_key_or(C&& c, const Key& k, Val v) {
+auto value_by_key_or(C&& c, const Key& k, Val&& v) {
     return maputil_impl::value_by_key_or(
         std::integral_constant<bool, is_associative_container<C>::value>{},
         std::forward<C>(c), k, v);

--- a/arbor/util/maputil.hpp
+++ b/arbor/util/maputil.hpp
@@ -78,7 +78,7 @@ namespace maputil_impl {
         typename Eq = std::equal_to<>,
         typename Ret = std::remove_reference_t<decltype(get<1>(*begin(std::declval<Seq&&>())))>
     >
-    Ret value_by_key_or(std::false_type, Seq&& seq, const Key& key, Ret&& def, Eq eq=Eq{}) {
+    Ret value_by_key_or(std::false_type, Seq&& seq, const Key& key, Ret def, Eq eq=Eq{}) {
         for (auto&& entry: seq) {
             if (eq(get<0>(entry), key)) {
                 return get<1>(entry);
@@ -123,7 +123,7 @@ namespace maputil_impl {
         typename FindRet = decltype(std::declval<Assoc&&>().find(std::declval<Key>())),
         typename Ret = std::remove_reference_t<decltype(get<1>(*std::declval<FindRet>()))>
     >
-    Ret value_by_key_or(std::true_type, Assoc&& map, const Key& key, Ret&& def) {
+    Ret value_by_key_or(std::true_type, Assoc&& map, const Key& key, Ret def) {
         auto it = map.find(key);
         if (it!=std::end(map)) {
             return get<1>(*it);

--- a/arbor/util/maputil.hpp
+++ b/arbor/util/maputil.hpp
@@ -71,6 +71,22 @@ namespace maputil_impl {
         return std::nullopt;
     }
 
+    // use linear search
+    template <
+        typename Seq,
+        typename Key,
+        typename Eq = std::equal_to<>,
+        typename Ret = std::remove_reference_t<decltype(get<1>(*begin(std::declval<Seq&&>())))>
+    >
+    Ret value_by_key_or(std::false_type, Seq&& seq, const Key& key, Ret def, Eq eq=Eq{}) {
+        for (auto&& entry: seq) {
+            if (eq(get<0>(entry), key)) {
+                return get<1>(entry);
+            }
+        }
+        return def;
+    }
+
     template <
         typename Seq,
         typename Key,
@@ -107,6 +123,20 @@ namespace maputil_impl {
         typename FindRet = decltype(std::declval<Assoc&&>().find(std::declval<Key>())),
         typename Ret = std::remove_reference_t<decltype(get<1>(*std::declval<FindRet>()))>
     >
+    Ret value_by_key_or(std::true_type, Assoc&& map, const Key& key, Ret def) {
+        auto it = map.find(key);
+        if (it!=std::end(map)) {
+            return get<1>(*it);
+        }
+        return def;
+    }
+
+    template <
+        typename Assoc,
+        typename Key,
+        typename FindRet = decltype(std::declval<Assoc&&>().find(std::declval<Key>())),
+        typename Ret = std::remove_reference_t<decltype(get<1>(*std::declval<FindRet>()))>
+    >
     Ret* ptr_by_key(std::true_type, Assoc&& map, const Key& key) {
         auto it = map.find(key);
         return it!=std::end(map)? &get<1>(*it): nullptr;
@@ -125,6 +155,22 @@ auto value_by_key(C&& c, const Key& k) {
     return maputil_impl::value_by_key(
         std::integral_constant<bool, is_associative_container<C>::value>{},
         std::forward<C>(c), k);
+}
+
+// Return copy of value associated with key, wrapped in std::optional, or std::nullopt.
+
+template <typename C, typename Key, typename Val, typename Eq>
+auto value_by_key_or(C&& c, const Key& k, Val v, Eq eq) {
+    return maputil_impl::value_by_key_or(std::false_type{}, std::forward<C>(c), k, v, eq);
+}
+
+template <typename C,
+          typename Key,
+          typename Val = std::remove_reference_t<decltype(std::get<1>(*begin(std::declval<C&&>())))>>
+auto value_by_key_or(C&& c, const Key& k, Val v) {
+    return maputil_impl::value_by_key_or(
+        std::integral_constant<bool, is_associative_container<C>::value>{},
+        std::forward<C>(c), k, v);
 }
 
 // Return pointer to value associated with key, or nullptr.

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -619,17 +619,15 @@ struct pw_elements<void> {
         auto vi = begin(vertices);
         auto ve = end(vertices);
 
-        if (vi==ve) {
-            clear();
-            return;
-        }
+        clear();
+        reserve(vertices.size());
+
+        if (vi==ve) return;
 
         double left = *vi++;
         if (vi==ve) {
             throw std::runtime_error("vertex list too short");
         }
-
-        clear();
 
         double right = *vi++;
         push_back(left, right);

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -98,6 +98,8 @@
 #include <type_traits>
 #include <vector>
 
+#include <arbor/assert.hpp>
+
 #include "util/iterutil.hpp"
 #include "util/transform.hpp"
 #include "util/meta.hpp"
@@ -418,6 +420,8 @@ struct pw_elements {
         using std::begin;
         using std::end;
 
+        clear();
+
         auto vi = begin(vertices);
         auto ve = end(vertices);
 
@@ -425,34 +429,23 @@ struct pw_elements {
         auto ee = end(values);
 
         if (ei==ee) { // empty case
-            if (vi!=ve) {
-                throw std::runtime_error("vertex list too long");
-            }
-            clear();
+            arb_assert(vi==ve);
             return;
         }
 
-        if (vi==ve) {
-            throw std::runtime_error("vertex list too short");
-        }
-
-        clear();
+        arb_assert(vi!=ve);
+        reserve(vertices.size());
 
         double left = *vi++;
         double right = *vi++;
         push_back(left, right, *ei++);
 
         while (ei!=ee) {
-            if (vi==ve) {
-                throw std::runtime_error("vertex list too short");
-            }
+            arb_assert(vi!=ve);
             double right = *vi++;
             push_back(right, *ei++);
         }
-
-        if (vi!=ve) {
-            throw std::runtime_error("vertex list too long");
-        }
+        arb_assert(vi==ve);
     }
 
 private:
@@ -867,6 +860,8 @@ template <typename A, typename B, typename Fn = pw_pairify>
 auto pw_zip_with(const pw_elements<A>& a, const pw_elements<B>& b, Fn&& fn = Fn{}) {
     using Out = decltype(fn(std::pair<double, double>{}, a.front(), b.front()));
     pw_elements<Out> out;
+
+    out.reserve(a.size());
 
     for (auto elem: pw_zip_range(a, b)) {
         if constexpr (std::is_void_v<Out>) {

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -420,32 +420,30 @@ struct pw_elements {
         using std::begin;
         using std::end;
 
-        clear();
-
         auto vi = begin(vertices);
         auto ve = end(vertices);
-
         auto ei = begin(values);
         auto ee = end(values);
 
-        if (ei==ee) { // empty case
-            arb_assert(vi==ve);
+        if (ei == ee) { // empty case
+            if (vi != ve) throw std::runtime_error{"Vertices and values need to have same length; values too long."};
+            clear();
             return;
         }
+        clear();
+        if (vi == ve) throw std::runtime_error{"Vertices and values need to have same length; values too short."};
 
-        arb_assert(vi!=ve);
         reserve(vertices.size());
-
         double left = *vi++;
         double right = *vi++;
         push_back(left, right, *ei++);
 
-        while (ei!=ee) {
-            arb_assert(vi!=ve);
+        while (ei != ee) {
+            if (vi == ve) throw std::runtime_error{"Vertices and values need to have same length; values too short."};
             double right = *vi++;
             push_back(right, *ei++);
         }
-        arb_assert(vi==ve);
+        if (vi != ve) throw std::runtime_error{"Vertices and values need to have same length; values too long."};
     }
 
 private:
@@ -600,10 +598,7 @@ struct pw_elements<void> {
     }
 
     void push_back(double right) {
-        if (empty()) {
-            throw std::runtime_error("require initial left vertex for element");
-        }
-
+        if (empty()) throw std::runtime_error("require initial left vertex for element");
         push_back(vertex_.back(), right);
     }
 
@@ -619,16 +614,16 @@ struct pw_elements<void> {
         auto vi = begin(vertices);
         auto ve = end(vertices);
 
-        clear();
         reserve(vertices.size());
 
-        if (vi==ve) return;
-
-        double left = *vi++;
-        if (vi==ve) {
-            throw std::runtime_error("vertex list too short");
+        if (vi == ve) {
+            clear();
+            return;
         }
 
+        double left = *vi++;
+        if (vi == ve) throw std::runtime_error("vertex list too short");
+        clear();
         double right = *vi++;
         push_back(left, right);
 

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -113,10 +113,7 @@ constexpr pw_size_type pw_npos = -1;
 
 template <typename X = void>
 struct pw_element {
-    pw_element():
-        extent(NAN, NAN),
-        value()
-    {}
+    pw_element(): pw_element{{NAN, NAN}, {}} {}
 
     pw_element(std::pair<double, double> extent, X value):
         extent(std::move(extent)),
@@ -138,10 +135,7 @@ struct pw_element {
 
 template <>
 struct pw_element<void> {
-    pw_element():
-        extent(NAN, NAN)
-    {}
-
+    pw_element(): pw_element{{NAN, NAN}} {}
     pw_element(std::pair<double, double> extent):
         extent(std::move(extent))
     {}

--- a/arbor/util/pw_over_cable.hpp
+++ b/arbor/util/pw_over_cable.hpp
@@ -23,7 +23,7 @@ util::pw_elements<U> pw_over_cable(const mcable_map<T>& mm, mcable cable, U dflt
     struct as_branch {
         msize_t value;
         as_branch(const value_type& x): value(x.first.branch) {}
-        as_branch(const msize_t& x): value(x) {}
+        as_branch(msize_t x): value(x) {}
     };
 
     auto map_on_branch = util::make_range(

--- a/arbor/util/pw_over_cable.hpp
+++ b/arbor/util/pw_over_cable.hpp
@@ -34,17 +34,18 @@ util::pw_elements<U> pw_over_cable(const mcable_map<T>& mm, mcable cable, U dflt
     }
 
     util::pw_elements<U> pw;
-    for (const auto& el: map_on_branch) {
-        double pw_right = pw.empty()? 0: pw.bounds().second;
-        if (el.first.prox_pos>pw_right) {
-            pw.push_back(pw_right, el.first.prox_pos, dflt_value);
+    pw.reserve(2*map_on_branch.size());
+    double pw_right = 0.0;
+    for (const auto& [elf, els]: map_on_branch) {
+        if (elf.prox_pos > pw_right) {
+            pw.push_back(pw_right, elf.prox_pos, dflt_value);
         }
-        pw.push_back(el.first.prox_pos, el.first.dist_pos, projection(el.first, el.second));
+        pw.push_back(elf.prox_pos, elf.dist_pos, projection(elf, els));
+        pw_right = pw.upper_bound();
     }
 
-    double pw_right = pw.empty()? 0: pw.bounds().second;
-    if (pw_right<1.) {
-        pw.push_back(pw_right, 1., dflt_value);
+    if (pw_right < 1.0) {
+        pw.push_back(pw_right, 1.0, dflt_value);
     }
 
     if (cable.prox_pos!=0 || cable.dist_pos!=1) {

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Example executable targets should be added to the 'examples' target as dependencies.
 add_custom_target(examples DEPENDS)
 
+add_subdirectory(busyring)
 add_subdirectory(drybench)
 add_subdirectory(dryrun)
 add_subdirectory(generators)

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -328,6 +328,7 @@ void add_subset(cell_gid_type gid,
         cell_gid_type val = dis(gen);
         if (!seen.count(val)) {
             conns.push_back({{val, src}, {tgt}, weight, delay});
+            seen.insert(val);
             m--;
         }
     }

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -194,7 +194,6 @@ int main(int argc, char** argv) {
 #endif
 
 #ifdef ARB_PROFILE_ENABLED
-        std::cout << "Generating Profile!\n";
         arb::profile::profiler_initialize(context);
 #endif
 

--- a/example/busyring/CMakeLists.txt
+++ b/example/busyring/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(busyring EXCLUDE_FROM_ALL ring.cpp)
+add_dependencies(examples busyring)
+
+target_link_libraries(busyring PRIVATE arbor arborio arborenv arbor-sup ${json_library_name})

--- a/example/busyring/complex-n-128-depth-10.json
+++ b/example/busyring/complex-n-128-depth-10.json
@@ -1,0 +1,25 @@
+{
+    "name": "run_n=128_d=10-complex=true",
+    "num-cells": 2048,
+    "synapses": 10,
+    "min-delay": 5,
+    "duration": 0.1,
+    "ring-size": 4,
+    "record": false,
+    "spikes": false,
+    "dt": 0.1,
+    "depth": 10,
+    "complex": true,
+    "branch-probs": [
+        1,
+        0.5
+    ],
+    "compartments": [
+        20,
+        2
+    ],
+    "lengths": [
+        200,
+        20
+    ]
+}

--- a/example/busyring/init-only-2048-complex.json
+++ b/example/busyring/init-only-2048-complex.json
@@ -1,0 +1,25 @@
+{
+    "name": "run_n=2045_d=10-complex=true",
+    "num-cells": 2048,
+    "synapses": 10,
+    "min-delay": 5,
+    "duration": 0.1,
+    "ring-size": 4,
+    "record": false,
+    "spikes": false,
+    "dt": 0.1,
+    "depth": 10,
+    "complex": true,
+    "branch-probs": [
+        1,
+        0.5
+    ],
+    "compartments": [
+        20,
+        2
+    ],
+    "lengths": [
+        200,
+        20
+    ]
+}

--- a/example/busyring/input.json.in
+++ b/example/busyring/input.json.in
@@ -1,0 +1,25 @@
+{
+    "name": "run_#cells#_#depth#",
+    "num-cells": 256,
+    "synapses": 10,
+    "min-delay": 5,
+    "duration": 200,
+    "ring-size": 4,
+    "record": false,
+    "spikes": false,
+    "dt": 0.025,
+    "depth": 10,
+    "complex": true,
+    "branch-probs": [
+        1,
+        0.5
+    ],
+    "compartments": [
+        20,
+        2
+    ],
+    "lengths": [
+        200,
+        20
+    ]
+}

--- a/example/busyring/json_params.hpp
+++ b/example/busyring/json_params.hpp
@@ -1,0 +1,42 @@
+#include <array>
+#include <exception>
+
+#include <optional>
+
+#include <nlohmann/json.hpp>
+
+namespace sup {
+
+// Search a json object for an entry with a given name.
+// If found, return the value and remove from json object.
+template <typename T>
+std::optional<T> find_and_remove_json(const char* name, nlohmann::json& j) {
+    auto it = j.find(name);
+    if (it==j.end()) {
+        return std::nullopt;
+    }
+    T value = std::move(*it);
+    j.erase(name);
+    return std::move(value);
+}
+
+template <typename T>
+void param_from_json(T& x, const char* name, nlohmann::json& j) {
+    if (auto o = find_and_remove_json<T>(name, j)) {
+        x = *o;
+    }
+}
+
+template <typename T, size_t N>
+void param_from_json(std::array<T, N>& x, const char* name, nlohmann::json& j) {
+    std::vector<T> y;
+    if (auto o = find_and_remove_json<std::vector<T>>(name, j)) {
+        y = *o;
+        if (y.size()!=N) {
+            throw std::runtime_error("parameter "+std::string(name)+" requires "+std::to_string(N)+" values");
+        }
+        std::copy(y.begin(), y.end(), x.begin());
+    }
+}
+
+} // namespace sup

--- a/example/busyring/parameters.hpp
+++ b/example/busyring/parameters.hpp
@@ -1,0 +1,102 @@
+#include <iostream>
+
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <random>
+
+#include "json_params.hpp"
+
+// Parameters used to generate the random cell morphologies.
+struct cell_parameters {
+    cell_parameters() = default;
+
+    // Use complex cell or generic cell
+    bool complex_cell = false;
+
+    //  Maximum number of levels in the cell (not including the soma)
+    unsigned max_depth = 5;
+
+    // The following parameters are described as ranges.
+    // The first value is at the soma, and the last value is used on the last level.
+    // Values at levels in between are found by linear interpolation.
+    std::array<double,2> branch_probs = {1.0, 0.5}; //  Probability of a branch occuring.
+    std::array<unsigned,2> compartments = {20, 2};  //  Compartment count on a branch.
+    std::array<double,2> lengths = {200, 20};       //  Length of branch in μm.
+
+    // The number of synapses per cell.
+    unsigned synapses = 1;
+};
+
+struct ring_params {
+    ring_params() = default;
+
+    std::string name = "default";
+    unsigned num_cells = 10;
+    unsigned ring_size = 10;
+    double min_delay = 10;
+    double duration = 100;
+    double dt = 0.025;
+    bool record_voltage = false;
+    bool record_spikes  = true;
+    std::string odir = ".";
+    cell_parameters cell;
+};
+
+ring_params read_options(int argc, char** argv) {
+    const char* usage = "Usage:  arbor-busyring [params [opath]]\n\n"
+                        "Driver for the Arbor busyring benchmark\n\n"
+                        "Options:\n"
+                        "   params: JSON file with model parameters.\n"
+                        "   opath: output path.\n";
+    using sup::param_from_json;
+
+    ring_params params;
+    if (argc<2) {
+        return params;
+    }
+    if (argc>3) {
+        std::cout << usage << std::endl;
+        throw std::runtime_error("More than two command line options is not permitted.");
+    }
+
+    // Assume that the first argument is a json parameter file
+    std::string fname = argv[1];
+    std::ifstream f(fname);
+
+    if (!f.good()) {
+        throw std::runtime_error("Unable to open input parameter file: "+fname);
+    }
+
+    nlohmann::json json;
+    f >> json;
+
+    param_from_json(params.name, "name", json);
+    param_from_json(params.num_cells, "num-cells", json);
+    param_from_json(params.ring_size, "ring-size", json);
+    param_from_json(params.duration, "duration", json);
+    param_from_json(params.dt, "dt", json);
+    param_from_json(params.min_delay, "min-delay", json);
+    param_from_json(params.record_voltage, "record", json);
+    param_from_json(params.record_spikes,  "spikes", json);
+    param_from_json(params.cell.complex_cell, "complex", json);
+    param_from_json(params.cell.max_depth, "depth", json);
+    param_from_json(params.cell.branch_probs, "branch-probs", json);
+    param_from_json(params.cell.compartments, "compartments", json);
+    param_from_json(params.cell.lengths, "lengths", json);
+    param_from_json(params.cell.synapses, "synapses", json);
+
+    if (!json.empty()) {
+        for (auto it=json.begin(); it!=json.end(); ++it) {
+            std::cout << "  Warning: unused input parameter: \"" << it.key() << "\"\n";
+        }
+        std::cout << "\n";
+    }
+
+    // Set optional output path if a second argument was passed
+    if (argc==3) {
+        params.odir = argv[2];
+    }
+
+    return params;
+}

--- a/example/busyring/readme.md
+++ b/example/busyring/readme.md
@@ -1,0 +1,3 @@
+# Ring Example
+
+A miniapp that demonstrates how to describe how to build a simple ring network.

--- a/example/busyring/readme.md
+++ b/example/busyring/readme.md
@@ -1,3 +1,10 @@
-# Ring Example
+# Busyring Benchmark
 
-A miniapp that demonstrates how to describe how to build a simple ring network.
+A simple benchmark of spiking cells in multiple rings. Each ring propagates a
+single spike indefinitely. Rings are interconnected using zero-weight synapses
+as to stress the MPI parts while not altering the ring steady-state. Cells come
+in two varieties: simple and complex. Complex cells are based on the Allen
+example and are extremely heavy on compute.
+
+Example configs show an initialization only benchmark with 2048 complex cells
+and one with a larger runtime with 128 complex cells.

--- a/example/busyring/ring.cpp
+++ b/example/busyring/ring.cpp
@@ -1,0 +1,505 @@
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <functional>
+
+#include <nlohmann/json.hpp>
+
+#include <arbor/assert_macro.hpp>
+#include <arbor/common_types.hpp>
+#include <arbor/context.hpp>
+#include <arbor/load_balance.hpp>
+#include <arbor/cable_cell.hpp>
+#include <arbor/profile/meter_manager.hpp>
+#include <arbor/profile/profiler.hpp>
+#include <arbor/simple_sampler.hpp>
+#include <arbor/simulation.hpp>
+#include <arbor/recipe.hpp>
+#include <arbor/version.hpp>
+
+#include <arborenv/default_env.hpp>
+#include <arborenv/gpu_env.hpp>
+
+#include <arborio/label_parse.hpp>
+
+#include "parameters.hpp"
+
+#ifdef ARB_MPI_ENABLED
+#include <mpi.h>
+#include <arborenv/with_mpi.hpp>
+#endif
+
+using arb::cell_gid_type;
+using arb::cell_lid_type;
+using arb::cell_size_type;
+using arb::cell_member_type;
+using arb::cell_kind;
+using arb::time_type;
+using arb::cable_probe_membrane_voltage;
+
+using namespace arborio::literals;
+
+// Writes voltage trace as a json file.
+void write_trace_json(std::string fname, const arb::trace_data<double>& trace);
+
+// Generate a cell.
+arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params);
+arb::cable_cell complex_cell(arb::cell_gid_type gid, const cell_parameters& params);
+
+class ring_recipe: public arb::recipe {
+public:
+    ring_recipe(ring_params params):
+        num_cells_(params.num_cells),
+        min_delay_(params.min_delay),
+        params_(params)
+    {
+        gprop.default_parameters = arb::neuron_parameter_defaults;
+        gprop.catalogue.import(arb::global_allen_catalogue(), "");
+
+        if (params.cell.complex_cell) {
+            gprop.default_parameters.reversal_potential_method["ca"] = "nernst/ca";
+            gprop.default_parameters.axial_resistivity = 100;
+            gprop.default_parameters.temperature_K = 34 + 273.15;
+            gprop.default_parameters.init_membrane_potential = -90;
+            event_weight_ = 0.2;
+            event_freq_ = 0.2;
+        }
+    }
+
+    std::any get_global_properties(cell_kind kind) const override { return gprop; }
+    cell_size_type num_cells() const override { return num_cells_; }
+    cell_kind get_cell_kind(cell_gid_type gid) const override { return cell_kind::cable; }
+    arb::util::unique_any get_cell_description(cell_gid_type gid) const override {
+        if (params_.cell.complex_cell) {
+            return complex_cell(gid, params_.cell);
+        }
+        return branch_cell(gid, params_.cell);
+    }
+
+    // Each cell has one incoming connection, from cell with gid-1,
+    // and fan_in-1 random connections with very low weight.
+    std::vector<arb::cell_connection> connections_on(cell_gid_type gid) const override {
+        std::vector<arb::cell_connection> cons;
+        const auto ncons = params_.cell.synapses;
+        cons.reserve(ncons);
+
+        const auto s = params_.ring_size;
+        const auto group = gid/s;
+        const auto group_start = s*group;
+        const auto group_end = std::min(group_start+s, num_cells_);
+        cell_gid_type src = gid==group_start? group_end-1: gid-1;
+        cons.push_back(arb::cell_connection({src, "d"}, {"p"}, event_weight_, min_delay_));
+
+        // Used to pick source cell for a connection.
+        std::uniform_int_distribution<cell_gid_type> dist(0, num_cells_-2);
+        // Used to pick delay for a connection.
+        std::uniform_real_distribution<float> delay_dist(0, 2*min_delay_);
+        auto src_gen = std::mt19937(gid);
+        for (unsigned i=1; i<ncons; ++i) {
+            // Make a connection with weight 0.
+            // The source is randomly picked, with no self connections.
+            src = dist(src_gen);
+            if (src==gid) ++src;
+            const float delay = min_delay_+delay_dist(src_gen);
+            cons.push_back(
+                arb::cell_connection({src, "d"}, {"p"}, 0.f, delay));
+        }
+        return cons;
+    }
+
+    // Return one event generator on the first cell of each ring.
+    // This generates a single event that will kick start the spiking on the sub-ring.
+    std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
+        if (gid%params_.ring_size == 0) {
+            return {arb::regular_generator({"p"}, event_weight_, 0.0, event_freq_)};
+        } else {
+            return {};
+        }
+    }
+
+    std::vector<arb::probe_info> get_probes(cell_gid_type gid) const override {
+        // Measure at the soma.
+        arb::mlocation loc{0, 0.0};
+        return {cable_probe_membrane_voltage{loc}};
+    }
+
+private:
+    cell_size_type num_cells_;
+    double min_delay_;
+    ring_params params_;
+    float event_weight_ = 0.025;
+    float event_freq_ = 1.0;
+
+    arb::cable_cell_global_properties gprop;
+};
+
+struct cell_stats {
+    using size_type = unsigned;
+    size_type ncells = 0;
+    size_type nbranch = 0;
+    size_type ncomp = 0;
+
+    cell_stats(arb::recipe& r) {
+#ifdef ARB_MPI_ENABLED
+        int nranks, rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+        ncells = r.num_cells();
+        size_type cells_per_rank = ncells/nranks;
+        size_type b = rank*cells_per_rank;
+        size_type e = (rank==nranks-1)? ncells: (rank+1)*cells_per_rank;
+        size_type nbranch_tmp = 0;
+        for (size_type i=b; i<e; ++i) {
+            auto c = arb::util::any_cast<arb::cable_cell>(r.get_cell_description(i));
+            nbranch_tmp += c.morphology().num_branches();
+            for (unsigned i = 0; i < c.morphology().num_branches(); ++i) {
+                ncomp += c.morphology().branch_segments(i).size();
+            }
+        }
+        MPI_Allreduce(&nbranch_tmp, &nbranch, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+#else
+        ncells = r.num_cells();
+        for (size_type i=0; i<ncells; ++i) {
+            auto c = arb::util::any_cast<arb::cable_cell>(r.get_cell_description(i));
+            nbranch += c.morphology().num_branches();
+            for (unsigned i = 0; i < c.morphology().num_branches(); ++i) {
+                ncomp += c.morphology().branch_segments(i).size();
+            }
+        }
+#endif
+    }
+
+    friend std::ostream& operator<<(std::ostream& o, const cell_stats& s) {
+        return o << "cell stats: "
+                 << s.ncells << " cells; "
+                 << s.nbranch << " branches; "
+                 << s.ncomp << " compartments; ";
+    }
+};
+
+int main(int argc, char** argv) {
+    try {
+        bool root = true;
+
+        auto params = read_options(argc, argv);
+
+        arb::proc_allocation resources;
+        resources.num_threads = arbenv::default_concurrency();
+
+#ifdef ARB_MPI_ENABLED
+        arbenv::with_mpi guard(argc, argv, false);
+        resources.gpu_id = arbenv::find_private_gpu(MPI_COMM_WORLD);
+        auto context = arb::make_context(resources, MPI_COMM_WORLD);
+        root = arb::rank(context) == 0;
+#else
+        resources.gpu_id = arbenv::default_gpu();
+        auto context = arb::make_context(resources);
+#endif
+
+#ifdef ARB_PROFILE_ENABLED
+        arb::profile::profiler_initialize(context);
+#endif
+
+        // Print a banner with information about hardware configuration
+        if (root) {
+            std::cout << "gpu:      " << (has_gpu(context)? "yes": "no") << "\n";
+            std::cout << "threads:  " << num_threads(context) << "\n";
+            std::cout << "mpi:      " << (has_mpi(context)? "yes": "no") << "\n";
+            std::cout << "ranks:    " << num_ranks(context) << "\n" << std::endl;
+        }
+
+        arb::profile::meter_manager meters;
+        meters.start(context);
+
+        // Create an instance of our recipe.
+        ring_recipe recipe(params);
+        cell_stats stats(recipe);
+        if (root) std::cout << stats << "\n";
+
+        // Construct the model.
+        arb::simulation sim(recipe, context);
+
+        // Set up the probe that will measure voltage in the cell.
+
+        // This is where the voltage samples will be stored as (time, value) pairs
+        arb::trace_vector<double> voltage;
+        if (params.record_voltage) {
+            // The id of the only probe on the cell:
+            // the cell_member type points to (cell 0, probe 0)
+            auto probe_id = cell_member_type{0, 0};
+            // The schedule for sampling is 10 samples every 1 ms.
+            auto sched = arb::regular_schedule(0.1);
+            // Now attach the sampler at probe_id, with sampling schedule sched, writing to voltage
+            sim.add_sampler(arb::one_probe(probe_id), sched, arb::make_simple_sampler(voltage));
+        }
+
+        // Set up recording of spikes to a vector on the root process.
+        std::vector<arb::spike> recorded_spikes;
+        if (root && params.record_spikes) {
+            sim.set_global_spike_callback(
+                [&recorded_spikes](const std::vector<arb::spike>& spikes) {
+                    recorded_spikes.insert(recorded_spikes.end(), spikes.begin(), spikes.end());
+                });
+        }
+
+        meters.checkpoint("model-init", context);
+
+        // Run the simulation.
+        if (root) std::cout << "running simulation" << std::endl;
+        sim.set_binning_policy(arb::binning_kind::regular, params.dt);
+        sim.run(params.duration, params.dt);
+
+        meters.checkpoint("model-run", context);
+
+        auto ns = sim.num_spikes();
+
+        // Write spikes to file
+        if (root) {
+            std::cout << "\n" << ns << " spikes generated at rate of "
+                      << params.duration/ns << " ms between spikes\n";
+            if (!recorded_spikes.empty()) {
+                std::ofstream fid(params.odir + "/" + params.name + "_spikes.gdf");
+                if (!fid.good()) {
+                    std::cerr << "Warning: unable to open file spikes.gdf for spike output\n";
+                }
+                else {
+                    char linebuf[45];
+                    for (auto spike: recorded_spikes) {
+                        auto n = std::snprintf(
+                            linebuf, sizeof(linebuf), "%u %.4f\n",
+                            unsigned{spike.source.gid}, float(spike.time));
+                        fid.write(linebuf, n);
+                    }
+                }
+            }
+        }
+
+        // Write the samples to a json file samples were stored on this rank.
+        if (voltage.size()>0u) {
+            std::string fname = params.odir + "/" + params.name + "_voltages.json";
+            write_trace_json(fname, voltage.at(0));
+        }
+
+        auto report = arb::profile::make_meter_report(meters, context);
+        if (root) {
+            std::cout << report << '\n'
+                      << arb::profile::profiler_summary() << "\n";
+        }
+    }
+    catch (std::exception& e) {
+        std::cerr << "exception caught in ring miniapp: " << e.what() << "\n";
+        return 1;
+    }
+
+    return 0;
+}
+
+void write_trace_json(std::string fname, const arb::trace_data<double>& trace) {
+    nlohmann::json json;
+    json["name"] = "ring demo";
+    json["units"] = "mV";
+    json["cell"] = "0.0";
+    json["probe"] = "0";
+
+    auto& jt = json["data"]["time"];
+    auto& jy = json["data"]["voltage"];
+
+    for (const auto& sample: trace) {
+        jt.push_back(sample.t);
+        jy.push_back(sample.v);
+    }
+
+    std::ofstream file(fname);
+    file << std::setw(1) << json << "\n";
+}
+
+// Helper used to interpolate in branch_cell.
+template <typename T>
+double interp(const std::array<T,2>& r, unsigned i, unsigned n) {
+    double p = i * 1./(n-1);
+    double r0 = r[0];
+    double r1 = r[1];
+    return r[0] + p*(r1-r0);
+}
+
+arb::cable_cell complex_cell (arb::cell_gid_type gid, const cell_parameters& params) {
+    using arb::reg::tagged;
+    using arb::reg::all;
+    using arb::ls::location;
+    using arb::ls::uniform;
+    using mech = arb::mechanism_desc;
+
+    arb::segment_tree tree;
+
+    double soma_radius = 12.6157/2.0;
+    int soma_tag = 1;
+    tree.append(arb::mnpos, {0, 0,-soma_radius, soma_radius}, {0, 0, soma_radius, soma_radius}, soma_tag); // For area of 500 μm².
+
+    std::vector<std::vector<unsigned>> levels;
+    levels.push_back({0});
+
+    // Standard mersenne_twister_engine seeded with gid.
+    std::mt19937 gen(gid);
+    std::uniform_real_distribution<double> dis(0, 1);
+
+    double dend_radius = 0.5; // Diameter of 1 μm for each cable.
+    int dend_tag = 3;
+
+    double dist_from_soma = soma_radius;
+    for (unsigned i=0; i<params.max_depth; ++i) {
+        // Branch prob at this level.
+        double bp = interp(params.branch_probs, i, params.max_depth);
+        // Length at this level.
+        double l = interp(params.lengths, i, params.max_depth);
+        // Number of compartments at this level.
+        unsigned nc = std::round(interp(params.compartments, i, params.max_depth));
+
+        std::vector<unsigned> sec_ids;
+        for (unsigned sec: levels[i]) {
+            for (unsigned j=0; j<2; ++j) {
+                if (dis(gen)<bp) {
+                    auto z = dist_from_soma;
+                    auto dz = l/nc;
+                    auto p = sec;
+                    for (unsigned k=1; k<nc; ++k) {
+                        p = tree.append(p, {0,0,z+(k+1)*dz, dend_radius}, dend_tag);
+                    }
+                    sec_ids.push_back(p);
+                }
+            }
+        }
+        if (sec_ids.empty()) {
+            break;
+        }
+        levels.push_back(sec_ids);
+
+        dist_from_soma += l;
+    }
+
+    using arb::reg::tagged;
+    auto rall  = arb::reg::all();
+    auto soma = tagged(1);
+    auto axon = tagged(2);
+    auto dend = tagged(3);
+    auto apic = tagged(4);
+    auto cntr = location(0, 0.5);
+    auto syns = arb::ls::uniform(rall, 0, params.synapses-2, gid);
+
+    arb::decor decor;
+
+    decor.paint(rall, arb::init_reversal_potential{"k",  -107.0});
+    decor.paint(rall, arb::init_reversal_potential{"na", 53.0});
+
+    decor.paint(soma, arb::axial_resistivity{133.577});
+    decor.paint(soma, arb::membrane_capacitance{4.21567e-2});
+
+    decor.paint(dend, arb::axial_resistivity{68.355});
+    decor.paint(dend, arb::membrane_capacitance{2.11248e-2});
+
+    decor.paint(soma, arb::density("pas/e=-76.4024", {{"g", 0.000119174}}));
+    decor.paint(soma, arb::density("NaV",            {{"gbar", 0.0499779}}));
+    decor.paint(soma, arb::density("SK",             {{"gbar", 0.000733676}}));
+    decor.paint(soma, arb::density("Kv3_1",          {{"gbar", 0.186718}}));
+    decor.paint(soma, arb::density("Ca_HVA",         {{"gbar", 9.96973e-05}}));
+    decor.paint(soma, arb::density("Ca_LVA",         {{"gbar", 0.00344495}}));
+    decor.paint(soma, arb::density("CaDynamics",     {{"gamma", 0.0177038}, {"decay", 42.2507}}));
+    decor.paint(soma, arb::density("Ih",             {{"gbar", 1.07608e-07}}));
+
+    decor.paint(dend, arb::density("pas/e=-88.2554", {{"g", 9.57001e-05}}));
+    decor.paint(dend, arb::density("NaV",            {{"gbar", 0.0472215}}));
+    decor.paint(dend, arb::density("Kv3_1",          {{"gbar", 0.186859}}));
+    decor.paint(dend, arb::density("Im_v2",          {{"gbar", 0.00132163}}));
+    decor.paint(dend, arb::density("Ih",             {{"gbar", 9.18815e-06}}));
+
+    decor.place(cntr, arb::synapse("expsyn"), "p");
+    if (params.synapses>1) {
+        // decor.place(syns, arb::synapse("expsyn"), "s");
+    }
+
+    decor.place(cntr, arb::threshold_detector{-20.0}, "d");
+
+    decor.set_default(arb::cv_policy_every_segment());
+
+    return {arb::morphology(tree), decor};
+}
+
+arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) {
+    arb::segment_tree tree;
+
+    // Add soma.
+    double soma_radius = 12.6157/2.0;
+    int soma_tag = 1;
+    tree.append(arb::mnpos, {0, 0,-soma_radius, soma_radius}, {0, 0, soma_radius, soma_radius}, soma_tag); // For area of 500 μm².
+
+    std::vector<std::vector<unsigned>> levels;
+    levels.push_back({0});
+
+    // Standard mersenne_twister_engine seeded with gid.
+    std::mt19937 gen(gid);
+    std::uniform_real_distribution<double> dis(0, 1);
+
+    double dend_radius = 0.5; // Diameter of 1 μm for each cable.
+    int dend_tag = 3;
+
+    double dist_from_soma = soma_radius;
+    for (unsigned i=0; i<params.max_depth; ++i) {
+        // Branch prob at this level.
+        double bp = interp(params.branch_probs, i, params.max_depth);
+        // Length at this level.
+        double l = interp(params.lengths, i, params.max_depth);
+        // Number of compartments at this level.
+        unsigned nc = std::round(interp(params.compartments, i, params.max_depth));
+
+        std::vector<unsigned> sec_ids;
+        for (unsigned sec: levels[i]) {
+            for (unsigned j=0; j<2; ++j) {
+                if (dis(gen)<bp) {
+                    auto z = dist_from_soma;
+                    auto dz = l/nc;
+                    auto p = sec;
+                    for (unsigned k=1; k<nc; ++k) {
+                        p = tree.append(p, {0,0,z+(k+1)*dz, dend_radius}, dend_tag);
+                    }
+                    sec_ids.push_back(p);
+                }
+            }
+        }
+        if (sec_ids.empty()) {
+            break;
+        }
+        levels.push_back(sec_ids);
+
+        dist_from_soma += l;
+    }
+
+    using arb::reg::tagged;
+    auto soma = tagged(1);
+    auto dnds = join(tagged(3), tagged(4));
+    auto syns = arb::ls::uniform(arb::reg::all(), 0, params.synapses-2, gid);
+
+    arb::decor decor;
+
+    decor.paint(soma, arb::density{"hh"});
+    decor.paint(dnds, arb::density{"pas"});
+    decor.set_default(arb::axial_resistivity{100}); // [Ω·cm]
+
+    // Add spike threshold detector at the soma.
+    decor.place(arb::mlocation{0,0}, arb::threshold_detector{10}, "d");
+
+    // Add a synapse to proximal end of first dendrite.
+    decor.place(arb::mlocation{1, 0}, arb::synapse{"expsyn"}, "p");
+
+    // Add additional synapses that will not be connected to anything.
+    if (params.synapses>1) {
+        decor.place(syns, arb::synapse{"expsyn"}, "s");
+    }
+
+    // Make a CV between every sample in the sample tree.
+    decor.set_default(arb::cv_policy_every_segment());
+
+    return {arb::morphology(tree), decor};
+}

--- a/example/busyring/ring.cpp
+++ b/example/busyring/ring.cpp
@@ -219,7 +219,6 @@ int main(int argc, char** argv) {
         ring_recipe recipe(params);
         cell_stats stats(recipe);
         if (root) std::cout << stats << "\n";
-
         // Construct the model.
         arb::simulation sim(recipe, context);
 
@@ -331,7 +330,6 @@ arb::cable_cell complex_cell (arb::cell_gid_type gid, const cell_parameters& par
     using arb::reg::all;
     using arb::ls::location;
     using arb::ls::uniform;
-    using mech = arb::mechanism_desc;
 
     arb::segment_tree tree;
 

--- a/python/example/brunel.py
+++ b/python/example/brunel.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
             print(f"{k} = {v}")
 
     context = arbor.context(threads=1)
-    if arbor.config()['profiling']:
+    if arbor.config()["profiling"]:
         arbor.profiler_initialize(context)
     print(context)
 
@@ -269,7 +269,7 @@ if __name__ == "__main__":
 
     # Print profiling information
     print(arbor.meter_report(meters, context))
-    if arbor.config()['profiling']:
+    if arbor.config()["profiling"]:
         print(arbor.profiler_summary())
 
     # Print spike times

--- a/python/example/brunel.py
+++ b/python/example/brunel.py
@@ -228,7 +228,8 @@ if __name__ == "__main__":
         for k, v in vars(opt).items():
             print(f"{k} = {v}")
 
-    context = arbor.context("avail_threads")
+    context = arbor.context(threads=1)
+    arbor.profiler_initialize(context)
     print(context)
 
     meters = arbor.meter_manager()
@@ -249,7 +250,7 @@ if __name__ == "__main__":
     meters.checkpoint("recipe-create", context)
 
     hint = arbor.partition_hint()
-    hint.cpu_group_size = opt.group_size
+    hint.cpu_group_size = 5000
     hints = {arbor.cell_kind.lif: hint}
     decomp = arbor.partition_load_balance(recipe, context, hints)
     print(decomp)
@@ -266,7 +267,8 @@ if __name__ == "__main__":
     meters.checkpoint("simulation-run", context)
 
     # Print profiling information
-    print(f"{arbor.meter_report(meters, context)}")
+    print(arbor.meter_report(meters, context))
+    print(arbor.profiler_summary())
 
     # Print spike times
     print(f"{len(sim.spikes())} spikes generated.")

--- a/python/example/brunel.py
+++ b/python/example/brunel.py
@@ -229,7 +229,8 @@ if __name__ == "__main__":
             print(f"{k} = {v}")
 
     context = arbor.context(threads=1)
-    arbor.profiler_initialize(context)
+    if arbor.config()['profiling']:
+        arbor.profiler_initialize(context)
     print(context)
 
     meters = arbor.meter_manager()
@@ -268,7 +269,8 @@ if __name__ == "__main__":
 
     # Print profiling information
     print(arbor.meter_report(meters, context))
-    print(arbor.profiler_summary())
+    if arbor.config()['profiling']:
+        print(arbor.profiler_summary())
 
     # Print spike times
     print(f"{len(sim.spikes())} spikes generated.")

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -195,8 +195,9 @@ void register_recipe(pybind11::module& m) {
             "gid"_a,
             "A list of all the event generators that are attached to gid, [] by default.")
         .def("connections_on", &py_recipe::connections_on,
-            "gid"_a,
-            "A list of all the incoming connections to gid, [] by default.")
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             "gid"_a,
+             "A list of all the incoming connections to gid, [] by default.")
         .def("gap_junctions_on", &py_recipe::gap_junctions_on,
             "gid"_a,
             "A list of the gap junctions connected to gid, [] by default.")

--- a/test/unit/test_piecewise.cpp
+++ b/test/unit/test_piecewise.cpp
@@ -11,25 +11,25 @@ using util::pw_element;
 using util::pw_npos;
 
 TEST(piecewise, eq) {
-    pw_elements<int> p1((double[3]){1., 1.5, 2.}, (int[2]){3, 4});
+    pw_elements<int> p1(std::array<double, 3>{1., 1.5, 2.}, (int[2]){3, 4});
     pw_elements<int> p2(p1);
     EXPECT_EQ(p2, p1);
 
-    pw_elements<int> p3((double[3]){1., 1.7, 2.}, (int[2]){3, 4});
+    pw_elements<int> p3(std::array<double, 3>{1., 1.7, 2.}, (int[2]){3, 4});
     EXPECT_NE(p3, p1);
 
-    pw_elements<int> p4((double[3]){1., 1.5, 2.}, (int[2]){3, 5});
+    pw_elements<int> p4(std::array<double, 3>{1., 1.5, 2.}, (int[2]){3, 5});
     EXPECT_NE(p4, p1);
 
     pw_elements<int> p5(p1);
     p5.push_back(2., 7);
     EXPECT_NE(p5, p1);
 
-    pw_elements<> v1((double[3]){1., 1.5, 2.});
+    pw_elements<> v1(std::array<double, 3>{1., 1.5, 2.});
     pw_elements<> v2(v1);
     EXPECT_EQ(v2, v1);
 
-    pw_elements<> v3((double[3]){1., 1.7, 2.});
+    pw_elements<> v3(std::array<double, 3>{1., 1.7, 2.});
     EXPECT_NE(v3, v1);
 
     pw_elements<> v5(v1);
@@ -76,7 +76,7 @@ TEST(piecewise, size) {
 TEST(piecewise, assign) {
     pw_elements<int> p;
 
-    double v[5] = {1., 1.5, 2., 2.5, 3.};
+    std::array<double, 5> v{1., 1.5, 2., 2.5, 3.};
     int x[4] = {10, 8, 9, 4};
     p.assign(v, x);
 
@@ -125,7 +125,7 @@ TEST(piecewise, assign) {
 TEST(piecewise, assign_void) {
     pw_elements<> p;
 
-    double v[5] = {1., 1.5, 2., 2.5, 3.};
+    std::array<double, 5> v{1., 1.5, 2., 2.5, 3.};
     p.assign(v);
 
     ASSERT_EQ(4u, p.size());
@@ -163,7 +163,7 @@ TEST(piecewise, assign_void) {
 TEST(piecewise, access) {
     pw_elements<int> p;
 
-    double v[5] = {1., 1.5, 2., 2.5, 3.};
+    std::array<double, 5> v{1., 1.5, 2., 2.5, 3.};
     int x[4] = {10, 8, 9, 4};
     p.assign(v, x);
 
@@ -367,7 +367,7 @@ TEST(piecewise, mutate) {
 }
 
 TEST(piecewise, map) {
-    double xx[5] = {1, 2.25, 3.25, 3.5, 4.};
+    std::array<double, 5> xx{1, 2.25, 3.25, 3.5, 4.};
     pw_elements<int> p(xx, (int [4]){3, 4, 5, 6});
 
     auto void_fn = [](auto) {};
@@ -381,10 +381,10 @@ TEST(piecewise, map) {
 
 TEST(piecewise, zip) {
     pw_elements<int> p03;
-    p03.assign((double [3]){0., 1.5, 3.}, (int [2]){10, 11});
+    p03.assign(std::array<double, 3>{0., 1.5, 3.}, (int [2]){10, 11});
 
     pw_elements<int> p14;
-    p14.assign((double [5]){1, 2.25, 3.25, 3.5, 4.}, (int [4]){3, 4, 5, 6});
+    p14.assign(std::array<double, 5>{1, 2.25, 3.25, 3.5, 4.}, (int [4]){3, 4, 5, 6});
 
     using ii = std::pair<int, int>;
     using pipi = std::pair<pw_element<int>, pw_element<int>>;
@@ -416,7 +416,7 @@ TEST(piecewise, zip) {
     EXPECT_EQ(p03_14.values(), flipped);
 
     pw_elements<> v03;
-    v03.assign((double [3]){0., 1.5, 3.});
+    v03.assign((std::array<double, 3>){0., 1.5, 3.});
 
     EXPECT_EQ((std::vector<int>{3, 3, 4}), pw_zip_with(v03, p14).values());
     EXPECT_EQ((std::vector<int>{3, 3, 4}), pw_zip_with(p14, v03).values());
@@ -431,7 +431,7 @@ TEST(piecewise, zip) {
     };
 
     pw_elements<void> vxx; // elements cover bounds of p14
-    vxx.assign((double [6]){0.2, 1.7, 1.95, 2.325, 2.45, 4.9});
+    vxx.assign(std::array<double, 6>{0.2, 1.7, 1.95, 2.325, 2.45, 4.9});
 
     pw_elements<double> pxx = pw_zip_with(vxx, p14, project);
 
@@ -442,16 +442,16 @@ TEST(piecewise, zip) {
 
 TEST(piecewise, zip_zero_length_elements) {
     pw_elements<int> p03a;
-    p03a.assign((double [5]){0, 0, 1.5, 3, 3}, (int [4]){10, 11, 12, 13});
+    p03a.assign(std::array<double, 5>{0, 0, 1.5, 3, 3}, (int [4]){10, 11, 12, 13});
 
     pw_elements<int> p03b;
-    p03b.assign((double [7]){0, 0, 0, 1, 3, 3, 3.}, (int [6]){20, 21, 22, 23, 24, 25});
+    p03b.assign(std::array<double, 7>{0, 0, 0, 1, 3, 3, 3.}, (int [6]){20, 21, 22, 23, 24, 25});
 
     pw_elements<int> p33;
-    p33.assign((double [3]){3, 3, 3}, (int [2]){30, 31});
+    p33.assign(std::array<double, 3>{3, 3, 3}, (int [2]){30, 31});
 
     pw_elements<int> p14;
-    p14.assign((double [3]){1, 2, 4}, (int [2]){40, 41});
+    p14.assign(std::array<double, 3>{1, 2, 4}, (int [2]){40, 41});
 
     auto flip = [](auto& pairs) { for (auto& [l, r]: pairs) std::swap(l, r); };
     using ii = std::pair<int, int>;


### PR DESCRIPTION
# What?

- Add profiler mark-up to initialisation
- Brunel
    - Fix a bug in the example if we cannot add enough connections
    - Eliminate data movement in `connections_on`
- Do some minor optimisations in label resolution and then ...
- ... replace `std::visit` w/ `std::get`/`std::holds_alternative`. I'll the numbers do the talking
- Add busyring from NSUITE to examples
  - Add example workloads for different scenarios
  - This is mainly to use these for profilining.
-  Go nuts and refactor `fvm_layout.cpp` :/
- Notice that much time in initialise is lost due minuscule allocations for piecewise push_back
  - Cause:  Many, many calls to `pw_zip_with` due to `integrate`
  - Add `reserve`/`resize` where we can.
  - Slate problem to be fixed once we get better access to `std::pmr`. GCC has it, Clang 16 will have it.
# Impact

## Before
```
✦ ❯ bin/brunel -m 5000 -n 5000 -t 10 -G 10000
==========================================
  Brunel model miniapp
  - distributed : 1 (mpi)
  - threads     : 8
  - gpus        : no
==========================================
REGION                           CALLS     WALL    THREAD        %
root                                 -    5.019    40.148    100.0
  init                               -    3.510    28.082     69.9

    communicator                     -    3.492    27.940     69.6
      update                         -    3.492    27.940     69.6
        connections                  1    2.796    22.365     55.7
        gid_connections              1    0.367     2.938      7.3
        sort_connections             1    0.330     2.636      6.6
        collect_gids                 1    0.000     0.000      0.0
        index                        1    0.000     0.000      0.0
        clear                        1    0.000     0.000      0.0
    simulation                       -    0.018     0.142      0.4
      update                         -    0.012     0.099      0.2
        generators                   1    0.012     0.099      0.2
      resolvers                      1    0.004     0.030      0.1
      group                          -    0.001     0.007      0.0
        factory                      1    0.001     0.007      0.0
        targets_and_sources          1    0.000     0.000      0.0
      source                         -    0.000     0.003      0.0
        MPI                          1    0.000     0.003      0.0
      sources                        1    0.000     0.002      0.0
      comm                           1    0.000     0.000      0.0
  communication                      -    1.370    10.957     27.3
    enqueue                          -    1.343    10.742     26.8
      setup                    4000000    0.537     4.299     10.7
      tree                     2000000    0.479     3.831      9.5
      sort                     2000000    0.214     1.715      4.3
      merge                    2000000    0.112     0.898      2.2
    walkspikes                     200    0.026     0.212      0.5
    exchange                         -    0.000     0.002      0.0
      gather                       200    0.000     0.001      0.0
      sort                         200    0.000     0.001      0.0
      gatherlocal                  200    0.000     0.001      0.0
    spikeio                        200    0.000     0.000      0.0
  advance                            -    0.139     1.110      2.8
    lif                            200    0.139     1.109      2.8
    spikes                         200    0.000     0.000      0.0


There were 10000 spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
setup                           0.000
model-init                     28.245
model-simulate                  2.672
meter-total                    30.918
```

## After
```
✦ ❯ bin/brunel -m 5000 -n 5000 -t 10 -G 10000
==========================================
  Brunel model miniapp
  - distributed : 1 (mpi)
  - threads     : 8
  - gpus        : no
==========================================
REGION                           CALLS     WALL    THREAD        %
root                                 -    0.450     3.601    100.0
  communication                      -    0.236     1.886     52.4
    enqueue                          -    0.231     1.849     51.4
      setup                    4000000    0.110     0.883     24.5
      tree                     2000000    0.072     0.576     16.0
      sort                     2000000    0.030     0.239      6.6
      merge                    2000000    0.019     0.152      4.2
    walkspikes                     200    0.005     0.036      1.0
    exchange                         -    0.000     0.000      0.0
      gather                       200    0.000     0.000      0.0
      gatherlocal                  200    0.000     0.000      0.0
      sort                         200    0.000     0.000      0.0
    spikeio                        200    0.000     0.000      0.0
  init                               -    0.198     1.588     44.1
    communicator                     -    0.195     1.564     43.4
      update                         -    0.195     1.564     43.4
        connections                  1    0.122     0.977     27.1
        gid_connections              1    0.048     0.381     10.6
        sort_connections             1    0.026     0.206      5.7
        collect_gids                 1    0.000     0.000      0.0
        clear                        1    0.000     0.000      0.0
        index                        1    0.000     0.000      0.0
    simulation                       -    0.003     0.024      0.7
      update                         -    0.003     0.021      0.6
        generators                   1    0.003     0.021      0.6
      resolvers                      1    0.000     0.002      0.0
      group                          -    0.000     0.001      0.0
        factory                      1    0.000     0.001      0.0
        targets_and_sources          1    0.000     0.000      0.0
      source                         -    0.000     0.000      0.0
        MPI                          1    0.000     0.000      0.0
      sources                        1    0.000     0.000      0.0
      comm                           1    0.000     0.000      0.0
  advance                            -    0.016     0.127      3.5
    lif                            200    0.016     0.127      3.5
    spikes                         200    0.000     0.000      0.0


There were 10000 spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
setup                           0.000
model-init                      1.613
model-simulate                  1.427
meter-total                     3.040
```

# How?
See here
https://stackoverflow.com/questions/57726401/stdvariant-vs-inheritance-vs-other-ways-performance
`std::visit` has _horrible_ performance.

