### PR TITLE
📊 Make a simpler merge.

### DIFF
--- a/arbor/merge_events.hpp
+++ b/arbor/merge_events.hpp
@@ -16,41 +16,43 @@ namespace arb {
 
 using event_span = util::range<const spike_event*>;
 
-void tree_merge_events(std::vector<event_span>& sources, pse_vector& out);
+void tree_merge_events(std::vector<event_span>&& sources, pse_vector& out);
 
 namespace impl {
     // The tournament tree is used internally by the merge_events method, and
     // it is not intended for use elsewhere. It is exposed here for unit testing
     // of its functionality.
-    class ARB_ARBOR_API tourney_tree {
-        using key_val = std::pair<unsigned, spike_event>;
+    class ARB_ARBOR_API tourney_tree final {
+        using key = unsigned;
+        using val = spike_event;
 
     public:
-        tourney_tree(std::vector<event_span>& input);
+        tourney_tree(std::vector<event_span>&& input);
         bool empty() const;
         spike_event head() const;
-        void pop();
+        spike_event pop();
         friend std::ostream& operator<<(std::ostream&, const tourney_tree&);
-
+        std::size_t size() const;
     private:
-        void setup(unsigned i);
-        void merge_up(unsigned i);
-        void update_lane(unsigned lane);
-        unsigned parent(unsigned i) const;
-        unsigned left(unsigned i) const;
-        unsigned right(unsigned i) const;
-        unsigned leaf(unsigned i) const;
-        bool is_leaf(unsigned i) const;
-        const unsigned& id(unsigned i) const;
-        spike_event& event(unsigned i);
-        const spike_event& event(unsigned i) const;
-        unsigned next_power_2(unsigned x) const;
+        inline void setup(unsigned i);
+        inline void merge_up(unsigned i);
+        inline void update_lane(unsigned lane);
+        inline unsigned parent(unsigned i) const;
+        inline unsigned left(unsigned i) const;
+        inline unsigned right(unsigned i) const;
+        inline unsigned leaf(unsigned i) const;
+        inline bool is_leaf(unsigned i) const;
+        inline const unsigned& id(unsigned i) const;
+        inline spike_event& event(unsigned i);
+        inline const spike_event& event(unsigned i) const;
+        inline unsigned next_power_2(unsigned x) const;
 
-        std::vector<key_val> heap_;
+        std::vector<key> heap_keys_;
+        std::vector<val> heap_vals_;
         std::vector<event_span>& input_;
+        unsigned n_lanes_;
         unsigned leaves_;
         unsigned nodes_;
-        unsigned n_lanes_;
     };
 }
 

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -72,7 +72,7 @@ ARB_ARBOR_API void merge_cell_events(
         PL();
 
         PE(communication:enqueue:tree);
-        tree_merge_events(spanbuf, new_events);
+        tree_merge_events(std::move(spanbuf), new_events);
         PL();
 
         old_events = old_split.second;

--- a/test/unit/test_merge_events.cpp
+++ b/test/unit/test_merge_events.cpp
@@ -4,7 +4,6 @@
 
 #include <arbor/event_generator.hpp>
 #include <arbor/spike_event.hpp>
-
 #include "merge_events.hpp"
 #include "util/rangeutil.hpp"
 
@@ -209,7 +208,7 @@ TEST(merge_events, tourney_seq)
 
     std::vector<event_span> spans = {g1.events(0, terminal_time),
                                      g2.events(0, terminal_time)};
-    impl::tourney_tree tree(spans);
+    impl::tourney_tree tree(std::move(spans));
 
     pse_vector lf;
     while (!tree.empty()) {
@@ -265,7 +264,7 @@ TEST(merge_events, tourney_poisson)
     for (auto& gen: generators) {
         spans.emplace_back(gen.events(t0, tfinal));
     }
-    impl::tourney_tree tree(spans);
+    impl::tourney_tree tree(std::move(spans));
     pse_vector lf;
     while (!tree.empty()) {
         lf.push_back(tree.head());


### PR DESCRIPTION
Replace the complex tournament tree merge by a simple linear merge.
After:
```
❯ ARBENV_NUM_THREADS=1 hyperfine --warmup=2 'bin/brunel -G 10 -m 1000 -n 1000 -t 200'
Benchmark 1: bin/brunel -G 10 -m 1000 -n 1000 -t 200
  Time (mean ± σ):      2.083 s ±  0.024 s    [User: 2.041 s, System: 0.038 s]
  Range (min … max):    2.060 s …  2.140 s    10 runs
```
Before
```
❯ ARBENV_NUM_THREADS=1 hyperfine --warmup=2 'bin/brunel -G 10 -m 1000 -n 1000 -t 200'
Benchmark 1: bin/brunel -G 10 -m 1000 -n 1000 -t 200
  Time (mean ± σ):      2.607 s ±  0.007 s    [User: 2.564 s, System: 0.041 s]
  Range (min … max):    2.593 s …  2.617 s    10 runs
```
20% speed-up on an event-heavy setting by removing complex code ¯\_(ツ)_/¯

Dear review, please check on a different machine by toggling `#if 0` in `merge_events.cpp`.