### PR TITLE
Add LTO and M1 arch to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Have LTO where possible, ie add -flto
 check_ipo_supported(RESULT HAVE_LTO OUTPUT ERR_LTO)
-if(HAVE_LTO)
+if(HAVE_LTO AND NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
   message (STATUS "LTO support found, enabling")
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 include(CMakeDependentOption)
+include(CheckIPOSupported)
 
 # Make CUDA support throw errors if architectures remain unclear
 cmake_policy(SET CMP0104 NEW)
@@ -16,6 +17,14 @@ include(GNUInstallDirs)
 # Effectively adds '-fpic' flag to CXX_FLAGS. Needed for dynamic catalogues.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Have LTO where possible, ie add -flto
+check_ipo_supported(RESULT HAVE_LTO OUTPUT ERR_LTO)
+if(HAVE_LTO)
+  message (STATUS "LTO support found, enabling")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+  message(STATUS "No LTO: ${ERR_LTO}")
+endif()
 
 # Turn on this option to force the compilers to produce color output when output is
 # redirected from the terminal (e.g. when using ninja or a pager).

--- a/arbor/backends/multicore/threshold_watcher.hpp
+++ b/arbor/backends/multicore/threshold_watcher.hpp
@@ -58,7 +58,7 @@ public:
     /// Crossing events are recorded for each threshold that
     /// is crossed since the last call to test
     void test(array& time_since_spike, const arb_value_type& t_before, const arb_value_type& t_after) {
-        if (cv_index_.empty()) return;
+        if (cv_index_.empty() || n_detectors_ == 0) return;
         arb_assert(values_!=nullptr);
 
         // Reset all spike times to -1.0 indicating no spike has been recorded on the detector

--- a/arbor/backends/multicore/threshold_watcher.hpp
+++ b/arbor/backends/multicore/threshold_watcher.hpp
@@ -58,6 +58,7 @@ public:
     /// Crossing events are recorded for each threshold that
     /// is crossed since the last call to test
     void test(array& time_since_spike, const arb_value_type& t_before, const arb_value_type& t_after) {
+        if (cv_index_.empty) return;
         arb_assert(values_!=nullptr);
 
         // Reset all spike times to -1.0 indicating no spike has been recorded on the detector

--- a/arbor/backends/multicore/threshold_watcher.hpp
+++ b/arbor/backends/multicore/threshold_watcher.hpp
@@ -58,7 +58,7 @@ public:
     /// Crossing events are recorded for each threshold that
     /// is crossed since the last call to test
     void test(array& time_since_spike, const arb_value_type& t_before, const arb_value_type& t_after) {
-        if (cv_index_.empty) return;
+        if (cv_index_.empty()) return;
         arb_assert(values_!=nullptr);
 
         // Reset all spike times to -1.0 indicating no spike has been recorded on the detector

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -110,12 +110,11 @@ function(set_arch_target optvar arch)
         endforeach(line)
         string(REGEX REPLACE "-.*" "" target_model "${target}")
 
-        # Use -mcpu for all supported targets _except_ for x86, where it should be -march.
-
-        if("${target}" MATCHES "aarch64-apple-darwin")
-            set(arch_opt "-mcpu=${arch}")
+        # Use -mcpu for all supported targets _except_ for x86 and Apple arm64, where it should be -march.
+        if("${target}" MATCHES "aarch64-apple-darwin" OR "${target}" MATCHES "arm64-apple-darwin")
+            set(arch_opt "-march=${arch} -mtune=${arch}")
         elseif(target_model MATCHES "x86|i[3456]86" OR target_model MATCHES "amd64" OR target_model MATCHES "aarch64")
-            set(arch_opt "-march=${arch}")
+            set(arch_opt "-march=${arch} -mtune=${arch}")
         else()
             set(arch_opt "-mcpu=${arch}")
         endif()


### PR DESCRIPTION
Tweak CMake to set up Link Time Optimisations (helps pybind11) and set arch/tune for Arm Macs (M1 for now).
