### PR TITLE
Add zero'ing

### DIFF
--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -90,8 +90,8 @@ void ion_state::init_concentration() {
 }
 
 void ion_state::zero_current() {
-    util::fill(gX_, 0);
-    util::fill(iX_, 0);
+    util::zero(gX_);
+    util::zero(iX_);
 }
 
 void ion_state::reset() {
@@ -143,7 +143,7 @@ istim_state::istim_state(const fvm_stimulus_config& stim, unsigned align):
 }
 
 void istim_state::zero_current() {
-    util::fill(accu_stim_, 0);
+    util::zero(accu_stim_);
 }
 
 void istim_state::reset() {
@@ -237,8 +237,8 @@ shared_state::shared_state(task_system_handle,    // ignored in mc backend
 
 void shared_state::reset() {
     std::copy(init_voltage.begin(), init_voltage.end(), voltage.begin());
-    util::fill(current_density, 0);
-    util::fill(conductivity, 0);
+    util::zero(current_density);
+    util::zero(conductivity);
     time = 0;
     util::fill(time_since_spike, -1.0);
 
@@ -250,11 +250,9 @@ void shared_state::reset() {
 }
 
 void shared_state::zero_currents() {
-    util::fill(current_density, 0);
-    util::fill(conductivity, 0);
-    for (auto& i: ion_data) {
-        i.second.zero_current();
-    }
+    util::zero(current_density);
+    util::zero(conductivity);
+    for (auto& [i_, d]: ion_data) d.zero_current();
     stim_data.zero_current();
 }
 

--- a/arbor/tree.cpp
+++ b/arbor/tree.cpp
@@ -278,8 +278,8 @@ tree::iarray tree::minimize_depth() {
 
     auto u = front;
 
-    // find the furhtest node from this node
-    std::fill(seen.begin(), seen.end(), 0);
+    // find the furthest node from this node
+    util::zero(seen);
     queue.push(u);
     seen[u] = 1;
     front = queue.front();

--- a/arbor/util/rangeutil.hpp
+++ b/arbor/util/rangeutil.hpp
@@ -86,7 +86,9 @@ void fill(Seq&& seq, const V& value) {
 // Zero a container, specialised for contiguous sequences
 // i.e.: Array, Vector, String.
 
-template <typename Seq, typename = std::enable_if_t<sequence_traits<Seq&&>::is_contiguous>>
+template <typename Seq,
+          typename = std::enable_if_t<sequence_traits<Seq&&>::is_contiguous>,
+          typename = std::is_trivially_copyable<typename sequence_traits<Seq&&>::value_type>>
 void zero(Seq& vs) {
     // NOTE: All contiguous containers have `data` and `size` methods.
     using T = typename sequence_traits<Seq&&>::value_type;

--- a/arbor/util/rangeutil.hpp
+++ b/arbor/util/rangeutil.hpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <ostream>
 #include <numeric>
+#include <cstring>
 
 #include "util/meta.hpp"
 #include "util/range.hpp"

--- a/arbor/util/rangeutil.hpp
+++ b/arbor/util/rangeutil.hpp
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <numeric>
 #include <cstring>
+#include <type_traits>
 
 #include "util/meta.hpp"
 #include "util/range.hpp"

--- a/arbor/util/rangeutil.hpp
+++ b/arbor/util/rangeutil.hpp
@@ -87,8 +87,8 @@ void fill(Seq&& seq, const V& value) {
 // i.e.: Array, Vector, String.
 
 template <typename Seq,
-          typename = std::enable_if_t<sequence_traits<Seq&&>::is_contiguous>,
-          typename = std::is_trivially_copyable<typename sequence_traits<Seq&&>::value_type>>
+          typename = std::enable_if_t<std::is_trivially_copyable_v<typename sequence_traits<Seq&&>::value_type>
+                                  && sequence_traits<Seq&&>::is_contiguous>>
 void zero(Seq& vs) {
     // NOTE: All contiguous containers have `data` and `size` methods.
     using T = typename sequence_traits<Seq&&>::value_type;

--- a/arbor/util/rangeutil.hpp
+++ b/arbor/util/rangeutil.hpp
@@ -82,6 +82,16 @@ void fill(Seq&& seq, const V& value) {
     std::fill(canon.begin(), canon.end(), value);
 }
 
+// Zero a container, specialised for contiguous sequences
+// i.e.: Array, Vector, String.
+
+template <typename Seq, typename = std::enable_if_t<sequence_traits<Seq&&>::is_contiguous>>
+void zero(Seq& vs) {
+    // NOTE: All contiguous containers have `data` and `size` methods.
+    using T = typename sequence_traits<Seq&&>::value_type;
+    std::memset(vs.data(), 0x0, vs.size()*sizeof(T));
+}
+
 // Append sequence to a container
 
 template <typename Container, typename Seq>

--- a/test/unit/test_event_stream.cpp
+++ b/test/unit/test_event_stream.cpp
@@ -9,8 +9,6 @@
 using namespace arb;
 
 namespace {
-    auto evtime = [](deliverable_event e) { return event_time(e); };
-
     constexpr cell_local_size_type mech = 13u;
 
     target_handle handle[4] = {


### PR DESCRIPTION
# Add specialised zero method to rangeutils.

Zeroing current arrays can take substantial amounts of time in simple models. Thus
add zero leveraging memset which is slightly faster and communicates intentions
a bit better.