### PR TITLE
CV area exposed to NMODL.

### DIFF
--- a/arbor/backends/gpu/shared_state.cpp
+++ b/arbor/backends/gpu/shared_state.cpp
@@ -174,6 +174,7 @@ shared_state::shared_state(task_system_handle tp,
                            const std::vector<arb_value_type>& init_membrane_potential,
                            const std::vector<arb_value_type>& temperature_K,
                            const std::vector<arb_value_type>& diam,
+                           const std::vector<arb_value_type>& area,
                            const std::vector<arb_index_type>& src_to_spike_,
                            const fvm_detector_info& detector,
                            unsigned, // align parameter ignored
@@ -188,6 +189,7 @@ shared_state::shared_state(task_system_handle tp,
     init_voltage(make_const_view(init_membrane_potential)),
     temperature_degC(make_const_view(temperature_K)),
     diam_um(make_const_view(diam)),
+    area_um2(make_const_view(area)),
     time_since_spike(n_cell*n_detector),
     src_to_spike(make_const_view(src_to_spike_)),
     cbprng_seed(cbprng_seed_),
@@ -237,6 +239,7 @@ void shared_state::instantiate(mechanism& m,
     m.ppack_.vec_g            = conductivity.data();
     m.ppack_.temperature_degC = temperature_degC.data();
     m.ppack_.diam_um          = diam_um.data();
+    m.ppack_.area_um2         = area_um2.data();
     m.ppack_.time_since_spike = time_since_spike.data();
     m.ppack_.n_detectors      = n_detector;
 
@@ -393,26 +396,25 @@ void shared_state::take_samples() {
 ARB_ARBOR_API std::ostream& operator<<(std::ostream& o, shared_state& s) {
     using io::csv;
 
-    o << " n_cv         " << s.n_cv << "\n";
-    o << " time         " << s.time << "\n";
-    o << " time_to      " << s.time_to << "\n";
-    o << " voltage      " << s.voltage << "\n";
-    o << " init_voltage " << s.init_voltage << "\n";
-    o << " temperature  " << s.temperature_degC << "\n";
-    o << " diameter     " << s.diam_um << "\n";
-    o << " current      " << s.current_density << "\n";
-    o << " conductivity " << s.conductivity << "\n";
-    for (auto& ki: s.ion_data) {
-        auto& kn = ki.first;
-        auto& i = ki.second;
-        o << " " << kn << "/current_density        " << csv(i.iX_) << "\n";
-        o << " " << kn << "/reversal_potential     " << csv(i.eX_) << "\n";
-        o << " " << kn << "/internal_concentration " << csv(i.Xi_) << "\n";
-        o << " " << kn << "/external_concentration " << csv(i.Xo_) << "\n";
-        o << " " << kn << "/intconc_initial        " << csv(i.init_Xi_) << "\n";
-        o << " " << kn << "/extconc_initial        " << csv(i.init_Xo_) << "\n";
-        o << " " << kn << "/revpot_initial         " << csv(i.init_eX_) << "\n";
-        o << " " << kn << "/node_index             " << csv(i.node_index_) << "\n";
+    o << " n_cv         " << s.n_cv << "\n"
+      << " time         " << s.time << "\n"
+      << " time_to      " << s.time_to << "\n"
+      << " voltage      " << s.voltage << "\n"
+      << " init_voltage " << s.init_voltage << "\n"
+      << " temperature  " << s.temperature_degC << "\n"
+      << " diameter     " << s.diam_um << "\n"
+      << " area         " << s.area_um2 << "\n"
+      << " current      " << s.current_density << "\n"
+      << " conductivity " << s.conductivity << "\n";
+    for (auto& [kn, i]: s.ion_data) {
+        o << " " << kn << "/current_density        " << csv(i.iX_) << "\n"
+          << " " << kn << "/reversal_potential     " << csv(i.eX_) << "\n"
+          << " " << kn << "/internal_concentration " << csv(i.Xi_) << "\n"
+          << " " << kn << "/external_concentration " << csv(i.Xo_) << "\n"
+          << " " << kn << "/intconc_initial        " << csv(i.init_Xi_) << "\n"
+          << " " << kn << "/extconc_initial        " << csv(i.init_Xo_) << "\n"
+          << " " << kn << "/revpot_initial         " << csv(i.init_eX_) << "\n"
+          << " " << kn << "/node_index             " << csv(i.node_index_) << "\n";
     }
     return o;
 }

--- a/arbor/backends/gpu/shared_state.hpp
+++ b/arbor/backends/gpu/shared_state.hpp
@@ -147,22 +147,23 @@ struct ARB_ARBOR_API shared_state: shared_state_base<shared_state, array, ion_st
     arb_size_type n_detector = 0; // Max number of detectors on all cells.
     arb_size_type n_cv = 0;       // Total number of CVs.
 
-    iarray cv_to_cell;       // Maps CV index to cell index.
-    arb_value_type time;     // integration start time [ms].
-    arb_value_type time_to;  // integration end time [ms]
-    arb_value_type dt;       // dt [ms].
-    array voltage;           // Maps CV index to membrane voltage [mV].
-    array current_density;   // Maps CV index to current density [A/m²].
-    array conductivity;      // Maps CV index to membrane conductivity [kS/m²].
+    iarray cv_to_cell;            // Maps CV index to cell index.
+    arb_value_type time;          // integration start time [ms].
+    arb_value_type time_to;       // integration end time [ms]
+    arb_value_type dt;            // dt [ms].
+    array voltage;                // Maps CV index to membrane voltage [mV].
+    array current_density;        // Maps CV index to current density [A/m²].
+    array conductivity;           // Maps CV index to membrane conductivity [kS/m²].
 
-    array init_voltage;      // Maps CV index to initial membrane voltage [mV].
-    array temperature_degC;  // Maps CV to local temperature (read only) [°C].
-    array diam_um;           // Maps CV to local diameter (read only) [µm].
+    array init_voltage;           // Maps CV index to initial membrane voltage [mV].
+    array temperature_degC;       // Maps CV to local temperature (read only) [°C].
+    array diam_um;                // Maps CV to local diameter (read only) [µm].
+    array area_um2;               // Maps CV to local diameter (read only) [µm²].
 
-    array time_since_spike;   // Stores time since last spike on any detector, organized by cell.
-    iarray src_to_spike;      // Maps spike source index to spike index
+    array time_since_spike;       // Stores time since last spike on any detector, organized by cell.
+    iarray src_to_spike;          // Maps spike source index to spike index
 
-    arb_seed_type cbprng_seed; // random number generator seed
+    arb_seed_type cbprng_seed;    // random number generator seed
 
     sample_event_stream sample_events;
     array sample_time;
@@ -181,11 +182,41 @@ struct ARB_ARBOR_API shared_state: shared_state_base<shared_state, array, ion_st
 
     shared_state(task_system_handle tp,
                  arb_size_type n_cell,
+                 const std::vector<arb_index_type>& cv_to_cell_vec,
+                 const fvm_cv_discretization& D,
+                 const std::vector<arb_index_type>& src_to_spike,
+                 const fvm_detector_info& detector,
+                 const std::unordered_map<std::string, fvm_ion_config>& ions,
+                 const fvm_stimulus_config& stims,
+                 unsigned align,
+                 arb_seed_type cbprng_seed_ = 0u)
+        : shared_state{std::move(tp),
+                       n_cell,
+                       (arb_size_type) D.size(),
+                       cv_to_cell_vec,
+                       D.init_membrane_potential,
+                       D.temperature_K,
+                       D.diam_um,
+                       D.cv_area,
+                       src_to_spike,
+                       detector,
+                       align,
+                       cbprng_seed_}
+    {
+        configure_stimulus(stims);
+        configure_solver(D);
+        add_ions(D, ions);
+    }
+
+
+    shared_state(task_system_handle tp,
+                 arb_size_type n_cell,
                  arb_size_type n_cv,
                  const std::vector<arb_index_type>& cv_to_cell_vec,
                  const std::vector<arb_value_type>& init_membrane_potential,
                  const std::vector<arb_value_type>& temperature_K,
                  const std::vector<arb_value_type>& diam,
+                 const std::vector<arb_value_type>& area,
                  const std::vector<arb_index_type>& src_to_spike,
                  const fvm_detector_info& detector,
                  unsigned, // align parameter ignored

--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -54,11 +54,9 @@ inline unsigned min_alignment(unsigned align) {
 
 using pad = util::padded_allocator<>;
 
-ion_state::ion_state(
-    int charge,
-    const fvm_ion_config& ion_data,
-    unsigned align,
-    solver_ptr ptr):
+ion_state::ion_state(const fvm_ion_config& ion_data,
+                     unsigned align,
+                     solver_ptr ptr):
     alignment(min_alignment(align)),
     write_eX_(ion_data.revpot_written),
     write_Xo_(ion_data.econc_written),
@@ -75,7 +73,7 @@ ion_state::ion_state(
     reset_Xi_(ion_data.reset_iconc.begin(), ion_data.reset_iconc.end(), pad(alignment)),
     reset_Xo_(ion_data.reset_econc.begin(), ion_data.reset_econc.end(), pad(alignment)),
     init_eX_(ion_data.init_revpot.begin(), ion_data.init_revpot.end(), pad(alignment)),
-    charge(1u, charge, pad(alignment)),
+    charge(1u, ion_data.charge, pad(alignment)),
     solver(std::move(ptr)) {
     arb_assert(node_index_.size()==init_Xi_.size());
     arb_assert(node_index_.size()==init_Xo_.size());
@@ -200,6 +198,7 @@ shared_state::shared_state(task_system_handle,    // ignored in mc backend
                            const std::vector<arb_value_type>& init_membrane_potential,
                            const std::vector<arb_value_type>& temperature_K,
                            const std::vector<arb_value_type>& diam,
+                           const std::vector<arb_value_type>& area,
                            const std::vector<arb_index_type>& src_to_spike_,
                            const fvm_detector_info& detector,
                            unsigned align,
@@ -215,6 +214,7 @@ shared_state::shared_state(task_system_handle,    // ignored in mc backend
     init_voltage(init_membrane_potential.begin(), init_membrane_potential.end(), pad(alignment)),
     temperature_degC(n_cv_, pad(alignment)),
     diam_um(diam.begin(), diam.end(), pad(alignment)),
+    area_um2(area.begin(), area.end(), pad(alignment)),
     time_since_spike(n_cell*n_detector, pad(alignment)),
     src_to_spike(src_to_spike_.begin(), src_to_spike_.end(), pad(alignment)),
     cbprng_seed(cbprng_seed_),
@@ -278,27 +278,26 @@ void shared_state::take_samples() {
 ARB_ARBOR_API std::ostream& operator<<(std::ostream& out, const shared_state& s) {
     using io::csv;
 
-    out << "n_cv         " << s.n_cv << "\n";
-    out << "time         " << s.time << "\n";
-    out << "time_to      " << s.time_to << "\n";
-    out << "dt           " << s.dt << "\n";
-    out << "voltage      " << csv(s.voltage) << "\n";
-    out << "init_voltage " << csv(s.init_voltage) << "\n";
-    out << "temperature  " << csv(s.temperature_degC) << "\n";
-    out << "diameter     " << csv(s.diam_um) << "\n";
-    out << "current      " << csv(s.current_density) << "\n";
-    out << "conductivity " << csv(s.conductivity) << "\n";
-    for (const auto& ki: s.ion_data) {
-        auto& kn = ki.first;
-        auto& i = ki.second;
-        out << kn << "/current_density        " << csv(i.iX_) << "\n";
-        out << kn << "/reversal_potential     " << csv(i.eX_) << "\n";
-        out << kn << "/internal_concentration " << csv(i.Xi_) << "\n";
-        out << kn << "/external_concentration " << csv(i.Xo_) << "\n";
-        out << kn << "/intconc_initial        " << csv(i.init_Xi_) << "\n";
-        out << kn << "/extconc_initial        " << csv(i.init_Xo_) << "\n";
-        out << kn << "/revpot_initial         " << csv(i.init_eX_) << "\n";
-        out << kn << "/node_index             " << csv(i.node_index_) << "\n";
+    out << "n_cv         " << s.n_cv << "\n"
+        << "time         " << s.time << "\n"
+        << "time_to      " << s.time_to << "\n"
+        << "dt           " << s.dt << "\n"
+        << "voltage      " << csv(s.voltage) << "\n"
+        << "init_voltage " << csv(s.init_voltage) << "\n"
+        << "temperature  " << csv(s.temperature_degC) << "\n"
+        << "diameter     " << csv(s.diam_um) << "\n"
+        << "area         " << csv(s.area_um2) << "\n"
+        << "current      " << csv(s.current_density) << "\n"
+        << "conductivity " << csv(s.conductivity) << "\n";
+    for (const auto& [kn, i]: s.ion_data) {
+        out << kn << "/current_density        " << csv(i.iX_) << "\n"
+            << kn << "/reversal_potential     " << csv(i.eX_) << "\n"
+            << kn << "/internal_concentration " << csv(i.Xi_) << "\n"
+            << kn << "/external_concentration " << csv(i.Xo_) << "\n"
+            << kn << "/intconc_initial        " << csv(i.init_Xi_) << "\n"
+            << kn << "/extconc_initial        " << csv(i.init_Xo_) << "\n"
+            << kn << "/revpot_initial         " << csv(i.init_eX_) << "\n"
+            << kn << "/node_index             " << csv(i.node_index_) << "\n";
     }
 
     return out;
@@ -406,6 +405,7 @@ void shared_state::instantiate(arb::mechanism& m,
     m.ppack_.vec_g            = conductivity.data();
     m.ppack_.temperature_degC = temperature_degC.data();
     m.ppack_.diam_um          = diam_um.data();
+    m.ppack_.area_um2         = area_um2.data();
     m.ppack_.time_since_spike = time_since_spike.data();
     m.ppack_.n_detectors      = n_detector;
     m.ppack_.events           = {};

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -914,6 +914,14 @@ ARB_ARBOR_API fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_globa
     for (auto cell_idx: count_along(cells)) {
         append(combined, cell_mech[cell_idx]);
     }
+    for (auto& [ion, data]: combined.ions) {
+        if (auto charge = util::value_by_key(gprop.ion_species, ion)) {
+            data.charge = *charge;
+        }
+        else {
+            throw cable_cell_error("unrecognized ion '"+ion+"' in mechanism.");
+        }
+    }
     return combined;
 }
 
@@ -986,12 +994,12 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
     // Voltage mechanisms
     if (!voltage_processes.empty())
     {
-        const auto& configs = make_voltage_mechanism_config(voltage_processes, data);
+        auto configs = make_voltage_mechanism_config(voltage_processes, data);
         M.mechanisms.insert(configs.begin(), configs.end());
     }
     // Density mechanisms
     if (!density_mechanisms.empty()) {
-        const auto& configs = make_density_mechanism_config(density_mechanisms, data, ion_build_data);
+        auto configs = make_density_mechanism_config(density_mechanisms, data, ion_build_data);
         M.mechanisms.insert(configs.begin(), configs.end());
     }
     // Synapses:
@@ -1005,9 +1013,9 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
     }
     // Gap junctions
     if (!junction_processes.empty()) {
-        const auto& configs = make_gj_mechanism_config(junction_processes,
-                                                       gj_conns,
-                                                       data,
+        auto configs = make_gj_mechanism_config(junction_processes,
+                                                gj_conns,
+                                                data,
                                                        ion_build_data);
         M.mechanisms.insert(configs.begin(), configs.end());
     }
@@ -1022,12 +1030,12 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
         auto ion_data = dflt.ion_data;
         ion_data.insert(global_dflt.ion_data.begin(),
                         global_dflt.ion_data.end());
-        const auto& configs = make_ion_config(std::move(ion_build_data),
-                                              ion_data,
-                                              int_concentration,
-                                              ext_concentration,
-                                              rev_potential,
-                                              data);
+        auto configs = make_ion_config(std::move(ion_build_data),
+                                       ion_data,
+                                       int_concentration,
+                                       ext_concentration,
+                                       rev_potential,
+                                       data);
         M.ions.insert(configs.begin(), configs.end());
     }
     // Reversal potentials

--- a/arbor/fvm_layout.hpp
+++ b/arbor/fvm_layout.hpp
@@ -256,6 +256,9 @@ struct fvm_ion_config {
     // diffusivity
     bool is_diffusive = false;
     std::vector<value_type> face_diffusivity;
+
+    // charge
+    int charge;
 };
 
 struct fvm_stimulus_config {

--- a/arbor/include/arbor/mechanism_abi.h
+++ b/arbor/include/arbor/mechanism_abi.h
@@ -20,7 +20,7 @@ extern "C" {
 
 // Version
 #define ARB_MECH_ABI_VERSION_MAJOR 0
-#define ARB_MECH_ABI_VERSION_MINOR 5
+#define ARB_MECH_ABI_VERSION_MINOR 6
 #define ARB_MECH_ABI_VERSION_PATCH 0
 #define ARB_MECH_ABI_VERSION ((ARB_MECH_ABI_VERSION_MAJOR * 10000L * 10000L) + (ARB_MECH_ABI_VERSION_MAJOR * 10000L) + ARB_MECH_ABI_VERSION_PATCH)
 
@@ -99,6 +99,7 @@ typedef struct arb_mechanism_ppack {
     arb_value_type* vec_g;
     arb_value_type* temperature_degC;
     arb_value_type* diam_um;
+    arb_value_type* area_um2;
     arb_value_type* time_since_spike;
     arb_index_type* node_index;
     arb_index_type* peer_index;

--- a/doc/dev/mechanism_abi.rst
+++ b/doc/dev/mechanism_abi.rst
@@ -211,6 +211,10 @@ fully formed to the interface. At this point:
 
     [Array] CV diameter
 
+  .. c:member:: arb_value_type* area_um2
+
+    [Array] CV lateral surface area in :math:`\mu m^2`
+
   .. c:member:: arb_value_type* time_since_spike
 
     Times since last spike; one entry per cell and detector.

--- a/doc/fileformat/nmodl.rst
+++ b/doc/fileformat/nmodl.rst
@@ -41,6 +41,7 @@ quantity                                         identifier                     
 voltage                                          v / v_peer                                           mV
 temperature                                      celsius                                              °C
 diameter (cross-sectional)                       diam                                                 µm
+area (lateral)                                   area                                                 µm²
 
 current_density (density mechanisms)             identifier defined using ``NONSPECIFIC_CURRENT``     mA/cm²
 conductivity (density mechanisms)                identifier inferred from current_density equation    S/cm²
@@ -93,14 +94,18 @@ Special variables
 -----------------
 
 * Arbor exposes some parameters from the simulation to the NMODL mechanisms.
-  These include ``v``, ``diam``, and ``celsius`` in addition to the previously
-  mentioned ion parameters.
+  These include
+
+  - ``v`` membrane voltage on current CV in mV,
+  - ``diam`` CV diameter (cross-section) in µm,
+  - ``area`` CV lateral (ie cylindrical mantle) surface area in µm²,
+  - ``celsius`` CV temperature in Celsius
 * These special variables should not be ``ASSIGNED`` or ``CONSTANT``, they are
   ``PARAMETER``. This is different from NEURON where a built-in variable is
   declared ``ASSIGNED`` to make it accessible.
 * ``diam`` and ``celsius`` are set from the simulation side.
 * ``v`` is a reserved variable name and can be read but not written in NMODL.
-* ``dt``, ``time``, and ``area`` are not exposed to NMODL mechanisms.
+* ``dt`` and ``time`` are not exposed to NMODL mechanisms.
 * ``NONSPECIFIC_CURRENTS`` should not be ``PARAMETER``, ``ASSIGNED`` or ``CONSTANT``.
   They just need to be declared in the NEURON block.
 

--- a/modcc/identifier.hpp
+++ b/modcc/identifier.hpp
@@ -58,6 +58,7 @@ enum class sourceKind {
     ion_valence,
     temperature,
     diameter,
+    area,
     no_source
 };
 
@@ -103,6 +104,8 @@ inline std::string to_string(sourceKind v) {
     case sourceKind::ion_econc:           return "ion_econc";
     case sourceKind::ion_valence:         return "ion_valence";
     case sourceKind::temperature:         return "temperature";
+    case sourceKind::diameter:            return "diameter";
+    case sourceKind::area:                return "area";
     case sourceKind::no_source:           return "no source";
     default:                              return "unknown source";
     }

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -683,7 +683,7 @@ void Module::add_variables_to_symbols() {
             continue;
         }
 
-        // Special cases: 'celsius', 'diam' and 't' are external indexed-variables with special
+        // Special cases: 'celsius', 'diam', and 'area' are external indexed-variables with special
         // data sources. Retrieval of their values is handled especially by printers.
 
         if (id.name() == "celsius") {
@@ -692,9 +692,8 @@ void Module::add_variables_to_symbols() {
         else if (id.name() == "diam") {
             create_indexed_variable("diam", sourceKind::diameter, accessKind::read, "", Location());
         }
-        else if (id.name() == "t") {
-            create_variable(Token{tok::identifier, "t", Location()},
-                accessKind::read, visibilityKind::global, linkageKind::local, rangeKind::scalar);
+        else if (id.name() == "area") {
+            create_indexed_variable("area", sourceKind::area, accessKind::read, "", Location());
         }
         else {
             // Parameters are scalar by default, but may later be changed to range.
@@ -708,22 +707,12 @@ void Module::add_variables_to_symbols() {
         }
     }
 
-    // Remove `celsius`, `diam` and `t` from the parameter block, as they are not true parameters anymore.
+    // Remove `celsius`, `diam` and `area` from the parameter block, as they are not true parameters anymore.
     parameter_block_.parameters.erase(
         std::remove_if(parameter_block_.begin(), parameter_block_.end(),
-            [](const Id& id) { return id.name() == "celsius"; }),
-        parameter_block_.end()
-    );
-
-    parameter_block_.parameters.erase(
-        std::remove_if(parameter_block_.begin(), parameter_block_.end(),
-            [](const Id& id) { return id.name() == "diam"; }),
-        parameter_block_.end()
-    );
-
-    parameter_block_.parameters.erase(
-        std::remove_if(parameter_block_.begin(), parameter_block_.end(),
-            [](const Id& id) { return id.name() == "t"; }),
+            [](const Id& id) { return (id.name() == "celsius")
+                                   || (id.name() == "area")
+                                   || (id.name() == "diam"); }),
         parameter_block_.end()
     );
 

--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -258,6 +258,7 @@ ARB_LIBMODCC_API std::string emit_cpp_source(const Module& module_, const printe
                                    "[[maybe_unused]] arb_value_type * __restrict__ {0}vec_g                        = pp->vec_g;\\\n"
                                    "[[maybe_unused]] arb_value_type * __restrict__ {0}temperature_degC             = pp->temperature_degC;\\\n"
                                    "[[maybe_unused]] arb_value_type * __restrict__ {0}diam_um                      = pp->diam_um;\\\n"
+                                   "[[maybe_unused]] arb_value_type * __restrict__ {0}area_um2                     = pp->area_um2;\\\n"
                                    "[[maybe_unused]] arb_value_type * __restrict__ {0}time_since_spike             = pp->time_since_spike;\\\n"
                                    "[[maybe_unused]] arb_index_type * __restrict__ {0}node_index                   = pp->node_index;\\\n"
                                    "[[maybe_unused]] arb_index_type * __restrict__ {0}peer_index                   = pp->peer_index;\\\n"

--- a/modcc/printer/gpuprinter.cpp
+++ b/modcc/printer/gpuprinter.cpp
@@ -140,6 +140,7 @@ ARB_LIBMODCC_API std::string emit_gpu_cu_source(const Module& module_, const pri
                                    "arb_value_type * __restrict__ {0}vec_g             __attribute__((unused)) = params_.vec_g;\\\n"
                                    "arb_value_type * __restrict__ {0}temperature_degC  __attribute__((unused)) = params_.temperature_degC;\\\n"
                                    "arb_value_type * __restrict__ {0}diam_um           __attribute__((unused)) = params_.diam_um;\\\n"
+                                   "arb_value_type * __restrict__ {0}area_um2          __attribute__((unused)) = params_.area_um2;\\\n"
                                    "arb_value_type * __restrict__ {0}time_since_spike  __attribute__((unused)) = params_.time_since_spike;\\\n"
                                    "arb_index_type * __restrict__ {0}node_index        __attribute__((unused)) = params_.node_index;\\\n"
                                    "arb_index_type * __restrict__ {0}peer_index        __attribute__((unused)) = params_.peer_index;\\\n"

--- a/modcc/printer/printerutil.cpp
+++ b/modcc/printer/printerutil.cpp
@@ -240,6 +240,10 @@ ARB_LIBMODCC_API indexed_variable_info decode_indexed_variable(IndexedVariable* 
         v.data_var = "diam_um";
         v.readonly = true;
         break;
+    case sourceKind::area:
+        v.data_var = "area_um2";
+        v.readonly = true;
+        break;
     default:
         throw compiler_exception(pprintf("unrecognized indexed data source: %", sym), sym->location());
     }

--- a/test/unit/test_abi.cpp
+++ b/test/unit/test_abi.cpp
@@ -50,11 +50,12 @@ TEST(abi, multicore_initialisation) {
     std::vector<arb_index_type> cv_to_cell(ncv, 0);
     std::vector<arb_value_type> temp(ncv, 23);
     std::vector<arb_value_type> diam(ncv, 1.);
+    std::vector<arb_value_type> area(ncv, 10.);
     std::vector<arb_value_type> vinit(ncv, -65);
     std::vector<arb_index_type> src_to_spike = {};
 
     arb::multicore::shared_state shared_state(thread_pool, ncell, ncv, cv_to_cell,
-                                              vinit, temp, diam, src_to_spike,
+                                              vinit, temp, diam, area, src_to_spike,
                                               arb::fvm_detector_info{},
                                               mech.data_alignment());
 
@@ -130,11 +131,12 @@ TEST(abi, multicore_null) {
     std::vector<arb_index_type> cv_to_cell(ncv, 0);
     std::vector<arb_value_type> temp(ncv, 23);
     std::vector<arb_value_type> diam(ncv, 1.);
+    std::vector<arb_value_type> area(ncv, 10.);
     std::vector<arb_value_type> vinit(ncv, -65);
     std::vector<arb_index_type> src_to_spike = {};
 
     arb::multicore::shared_state shared_state(thread_pool, ncell, ncv, cv_to_cell,
-                                              vinit, temp, diam, src_to_spike,
+                                              vinit, temp, diam, area, src_to_spike,
                                               arb::fvm_detector_info{},
                                               mech.data_alignment());
 

--- a/test/unit/test_fvm_lowered.cpp
+++ b/test/unit/test_fvm_lowered.cpp
@@ -569,9 +569,10 @@ TEST(fvm_lowered, ionic_concentrations) {
     arb_size_type ncell = 1;
     arb_size_type ncv = 1;
     std::vector<arb_index_type> cv_to_cell(ncv, 0);
-    std::vector<arb_value_type> temp(ncv, 23);
-    std::vector<arb_value_type> diam(ncv, 1.);
-    std::vector<arb_value_type> vinit(ncv, -65);
+    std::vector<arb_value_type> temp(ncv, 23.0);
+    std::vector<arb_value_type> diam(ncv, 1.0);
+    std::vector<arb_value_type> area(ncv, 10.0);
+    std::vector<arb_value_type> vinit(ncv, -65.0);
     std::vector<arb_index_type> src_to_spike = {};
 
     fvm_ion_config ion_config;
@@ -591,6 +592,7 @@ TEST(fvm_lowered, ionic_concentrations) {
     ion_config.init_iconc.assign(ncv, 0.);
     ion_config.reset_econc.assign(ncv, 0.);
     ion_config.reset_iconc.assign(ncv, 2.3e-4);
+    ion_config.charge = 2;
 
     auto read_cai  = cat.instance(backend::kind, "read_cai_init");
     auto write_cai = cat.instance(backend::kind, "write_cai_breakpoint");
@@ -599,11 +601,11 @@ TEST(fvm_lowered, ionic_concentrations) {
     auto& write_cai_mech = write_cai.mech;
 
     auto shared_state = std::make_unique<typename backend::shared_state>(thread_pool, ncell, ncv, cv_to_cell,
-                                                                         vinit, temp, diam,
+                                                                         vinit, temp, diam, area,
                                                                          src_to_spike,
                                                                          fvm_detector_info{},
                                                                          read_cai_mech->data_alignment());
-    shared_state->add_ion("ca", 2, ion_config);
+    shared_state->add_ion("ca", ion_config);
 
     shared_state->instantiate(*read_cai_mech, 0, overrides, layout, {});
     shared_state->instantiate(*write_cai_mech, 1, overrides, layout, {});

--- a/test/unit/test_kinetic_linear.cpp
+++ b/test/unit/test_kinetic_linear.cpp
@@ -59,12 +59,13 @@ void run_test(std::string mech_name,
 
     std::vector<arb_value_type> temp(ncv, 300.);
     std::vector<arb_value_type> diam(ncv, 1.);
+    std::vector<arb_value_type> area(ncv, 10.);
     std::vector<arb_value_type> vinit(ncv, -65);
     std::vector<arb_index_type> src_to_spike = {};
 
     // Create the fvm shared state for the simple cell.
     auto shared_state = std::make_unique<typename backend::shared_state>(thread_pool, ncell, ncv, cv_to_cell,
-                                                                         vinit, temp, diam,
+                                                                         vinit, temp, diam, area,
                                                                          src_to_spike,
                                                                          fvm_detector_info{},
                                                                          mech->data_alignment());

--- a/test/unit/test_synapses.cpp
+++ b/test/unit/test_synapses.cpp
@@ -92,11 +92,12 @@ TEST(synapses, syn_basic_state) {
     shared_state state(thread_pool,
                        num_cells,
                        num_comp,
-                       std::vector<index_type>(num_comp, 0),
-                       std::vector<value_type>(num_comp, -65),
-                       std::vector<value_type>(num_comp, temp_K),
-                       std::vector<value_type>(num_comp, 1.),
-                       std::vector<index_type>(0),
+                       std::vector<index_type>(num_comp, 0),      // cv -> cell
+                       std::vector<value_type>(num_comp, -65),    // U_m
+                       std::vector<value_type>(num_comp, temp_K), // T
+                       std::vector<value_type>(num_comp, 1.),     // diameter
+                       std::vector<value_type>(num_comp, 10.),    // area
+                       std::vector<index_type>(0),                // src -> spike
                        fvm_detector_info{},
                        align);
 

--- a/test/unit/testing/diam_test.mod
+++ b/test/unit/testing/diam_test.mod
@@ -2,26 +2,24 @@ NEURON {
     SUFFIX diam_test
 }
 
-PARAMETER {
-    diam
-}
+PARAMETER { diam area }
 
 STATE {
     d
-}
-
-ASSIGNED {
+    a
 }
 
 BREAKPOINT {
-    SOLVE states
+    SOLVE state
 }
 
-DERIVATIVE states {
+DERIVATIVE state {
     d = diam
+    a = area
 }
 
 INITIAL {
-    d = 0
+    d = -23.0
+    a = -42.0
 }
 


### PR DESCRIPTION
Add `area` variable in NMODL, this is used by _concentration models_ where flux over the membrane is proportional
to ionic current, the (lateral) CV area, and Faraday's constant and _diffusive models_ which have similar formulae.

Also pushes ion state and solver construction into shared state to isolate fvm_lowered from that duty.
Simplifies the construction of ion state.