### PR TITLE
Python/pip strikes again: execute `pip install` in venvs

### DIFF
--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           python-version: ${{ matrix.config.py }}
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate
+        run: python -m pip install --upgrade pip
       - name: Install Python packages
         run:  pip install numpy sphinx svgwrite sphinx-rtd-theme mpi4py pandas seaborn
       - name: Clone w/ submodules
@@ -209,21 +209,29 @@ jobs:
         with:
           submodules: recursive
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate
+        run: python -m pip install --upgrade pip && python -m venv env
       - name: Debug info Python
         run: |
+          . env/bin/activate
           which python
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
-        run: . env/bin/activate && CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
+        run: |
+          . env/bin/activate
+          CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
       - name: Check that build flags match
         run: |
+          . env/bin/activate
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"
       - name: Run Python tests
-        run: python -m unittest discover -v -s python
+        run: |
+          . env/bin/activate
+          python -m unittest discover -v -s python
       - name: Run Python examples
-        run: scripts/run_python_examples.sh
+        run: |
+          . env/bin/activate
+          scripts/run_python_examples.sh
   testdocs:
     name: "Docs build test"
     runs-on: ${{ matrix.os }}
@@ -241,15 +249,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate
+        run: python -m pip install --upgrade pip && python -m venv env
       - name: Clone w/ submodules
         uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install Python packages
-        run: python3 -m pip install -r doc/requirements.txt -U
+        run: |
+          . env/bin/activate
+          pip install -r doc/requirements.txt -U
       - name: Build Arbor Docs
         run: |
+          . env/bin/activate
           mkdir build
           cd build
           cmake .. -DARB_WITH_PYTHON=ON -DPython3_EXECUTABLE=`which python` -DARB_USE_BUNDLED_LIBS=ON

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -216,7 +216,7 @@ jobs:
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
-        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python -m pip install .
+        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
       - name: Check that build flags match
         run: |
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -216,7 +216,7 @@ jobs:
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
-        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
+        run: . env/bin/activate && CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
       - name: Check that build flags match
         run: |
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -216,7 +216,7 @@ jobs:
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
-        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
+        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install . --user
       - name: Check that build flags match
         run: |
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -216,7 +216,7 @@ jobs:
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
-        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python -m pip install .
+        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python -m pip install . --user
       - name: Check that build flags match
         run: |
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -216,7 +216,7 @@ jobs:
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
-        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python -m pip install . --user
+        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python -m pip install .
       - name: Check that build flags match
         run: |
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -209,7 +209,7 @@ jobs:
         with:
           submodules: recursive
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate && echo PATH=$PATH >> $GITHUB_ENV
+        run: python -m pip install --upgrade pip && python -m venv ~/env && . ~/env/bin/activate && echo PATH=$PATH >> $GITHUB_ENV
       - name: Debug info Python
         run: |
           which python
@@ -241,7 +241,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate && echo PATH=$PATH >> $GITHUB_ENV
+        run: python -m pip install --upgrade pip && python -m venv ~/env && . ~/env/bin/activate && echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Clone w/ submodules
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -193,6 +193,7 @@ jobs:
         run: |
           arbor-build-catalogue -v default mechanisms/default
           ./scripts/test-catalogue.py ./default-catalogue.so
+
   testpip:
     name: "Pip build test + Python examples test"
     runs-on: ${{ matrix.os }}
@@ -209,29 +210,30 @@ jobs:
         with:
           submodules: recursive
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv env
+        run: python -m pip install --upgrade pip && python -m venv ~/env
       - name: Debug info Python
         run: |
-          . env/bin/activate
+          . ~/env/bin/activate
           which python
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
         run: |
-          . env/bin/activate
+          . ~/env/bin/activate
           CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
       - name: Check that build flags match
         run: |
-          . env/bin/activate
+          . ~/env/bin/activate
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"
       - name: Run Python tests
         run: |
-          . env/bin/activate
+          . ~/env/bin/activate
           python -m unittest discover -v -s python
       - name: Run Python examples
         run: |
-          . env/bin/activate
+          . ~/env/bin/activate
           scripts/run_python_examples.sh
+
   testdocs:
     name: "Docs build test"
     runs-on: ${{ matrix.os }}
@@ -249,18 +251,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv env
+        run: python -m pip install --upgrade pip && python -m venv ~/env
       - name: Clone w/ submodules
         uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install Python packages
         run: |
-          . env/bin/activate
+          . ~/env/bin/activate
           pip install -r doc/requirements.txt -U
       - name: Build Arbor Docs
         run: |
-          . env/bin/activate
+          . ~/env/bin/activate
           mkdir build
           cd build
           cmake .. -DARB_WITH_PYTHON=ON -DPython3_EXECUTABLE=`which python` -DARB_USE_BUNDLED_LIBS=ON

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -110,8 +110,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.config.py }}
-      - name: Update pip
-        run: python -m pip install --upgrade pip
+      - name: Update pip and setup venv
+        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate
       - name: Install Python packages
         run:  pip install numpy sphinx svgwrite sphinx-rtd-theme mpi4py pandas seaborn
       - name: Clone w/ submodules
@@ -208,8 +208,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Update pip
-        run: python -m pip install --upgrade pip
+      - name: Update pip and setup venv
+        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate
       - name: Debug info Python
         run: |
           which python
@@ -240,8 +240,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Update pip
-        run: python -m pip install --upgrade pip
+      - name: Update pip and setup venv
+        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate
       - name: Clone w/ submodules
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.config.py }}
-      - name: Update pip and setup venv
+      - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Install Python packages
         run:  pip install numpy sphinx svgwrite sphinx-rtd-theme mpi4py pandas seaborn
@@ -193,7 +193,6 @@ jobs:
         run: |
           arbor-build-catalogue -v default mechanisms/default
           ./scripts/test-catalogue.py ./default-catalogue.so
-
   testpip:
     name: "Pip build test + Python examples test"
     runs-on: ${{ matrix.os }}
@@ -210,30 +209,21 @@ jobs:
         with:
           submodules: recursive
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv ~/env
+        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate && echo PATH=$PATH >> $GITHUB_ENV
       - name: Debug info Python
         run: |
-          . ~/env/bin/activate
           which python
           python --version
           pip --version
       - name: Build and install Arbor using pip + build flags
-        run: |
-          . ~/env/bin/activate
-          CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" pip install .
+        run: CMAKE_ARGS="-DARB_VECTORIZE=ON -DARB_ARCH=native" python -m pip install .
       - name: Check that build flags match
         run: |
-          . ~/env/bin/activate
           python -c "import arbor; print(arbor.config())" | grep -q "'arch': 'native'"
       - name: Run Python tests
-        run: |
-          . ~/env/bin/activate
-          python -m unittest discover -v -s python
+        run: python -m unittest discover -v -s python
       - name: Run Python examples
-        run: |
-          . ~/env/bin/activate
-          scripts/run_python_examples.sh
-
+        run: scripts/run_python_examples.sh
   testdocs:
     name: "Docs build test"
     runs-on: ${{ matrix.os }}
@@ -251,18 +241,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip and setup venv
-        run: python -m pip install --upgrade pip && python -m venv ~/env
+        run: python -m pip install --upgrade pip && python -m venv env && . env/bin/activate && echo PATH=$PATH >> $GITHUB_ENV
       - name: Clone w/ submodules
         uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install Python packages
-        run: |
-          . ~/env/bin/activate
-          pip install -r doc/requirements.txt -U
+        run: python -m pip install -r doc/requirements.txt -U
       - name: Build Arbor Docs
         run: |
-          . ~/env/bin/activate
           mkdir build
           cd build
           cmake .. -DARB_WITH_PYTHON=ON -DPython3_EXECUTABLE=`which python` -DARB_USE_BUNDLED_LIBS=ON


### PR DESCRIPTION
A recent release of `pip` merged a PR addressing PEP 668. Distros  of Python may now mark `site-packages` directories as 'managed', which means `pip` is not allowed to write to them. This means Arbors CMake is now, due to assumptions about prefixes, is not able to correctly install the Python package anymore: `pip` is a hard requirement for that. We already document that `pip` is the preferred way, so that's OK, but what's new is that `pip` doesn't seem to default to a user install anymore, if the system dir is not writable (or 'managed'), ergo: install does not work. Moreover, on at least Debian 12, there's even no longer such a thing as user installs, so even the `--user` flag does not help.

`venv`s seem therefore the only place to install Python packages these days, so let's.