### PR TITLE
🔍  Add clang-tidy.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+Checks: "-*,modernize-*,-modernize-use-trailing-return-type,-modernize-concat-nested-namespaces,-modernize-avoid-c-arrays,-modernize-use-nodiscard,bugprone-*,-bugprone-exception-escape,-bugprone-macro-parentheses,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions,misc-*,-misc-throw-by-value-catch-by-reference,-misc-no-recursion,-misc-non-private-member-variables-in-classes,-misc-const-correctness,-misc-confusable-identifiers,clang-analyzer-core-*,performance-*"
+# WarningsAsErrors: "*"
+
+# IMPORTANT: Set HeaderFilterRegex as shown below.
+# Do not set it to '.*', for example.
+HeaderFilterRegex: ""

--- a/arbor/affinity.hpp
+++ b/arbor/affinity.hpp
@@ -44,7 +44,7 @@ void set_affinity(int index, int count, affinity_kind kind) {
     hwloc(hwloc_topology_load(topology), "Topo load");
     // Fetch our current restrictions and apply them to our topology
     hwloc_cpuset_t cpus = hwloc_bitmap_alloc();
-    hwloc(cpus == NULL, "Bitmap allocation");
+    hwloc(cpus == nullptr, "Bitmap allocation");
     auto bitmap_guard = util::on_scope_exit([&] { hwloc_bitmap_free(cpus); });
     hwloc(hwloc_get_cpubind(topology, cpus, HWLOC_CPUBIND_PROCESS), "Get cpuset.");
     hwloc(hwloc_topology_restrict(topology, cpus, 0), "Topo restrict.");

--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -163,8 +163,8 @@ bad_catalogue_error::bad_catalogue_error(const std::string& msg)
     : arbor_exception(pprintf("Error while opening catalogue '{}'", msg))
 {}
 
-bad_catalogue_error::bad_catalogue_error(const std::string& msg, const std::any& pe)
-    : arbor_exception(pprintf("Error while opening catalogue '{}'", msg)), platform_error(pe)
+bad_catalogue_error::bad_catalogue_error(const std::string& msg, std::any pe)
+    : arbor_exception(pprintf("Error while opening catalogue '{}'", msg)), platform_error(std::move(pe))
 {}
 
 unsupported_abi_error::unsupported_abi_error(size_t v):

--- a/arbor/arbexcept.cpp
+++ b/arbor/arbexcept.cpp
@@ -73,7 +73,7 @@ bad_probeset_id::bad_probeset_id(cell_member_type probeset_id):
     probeset_id(probeset_id)
 {}
 
-gj_unsupported_lid_selection_policy::gj_unsupported_lid_selection_policy(cell_gid_type gid, cell_tag_type label):
+gj_unsupported_lid_selection_policy::gj_unsupported_lid_selection_policy(cell_gid_type gid, const cell_tag_type& label):
     arbor_exception(pprintf("Model building error on cell {}: gap junction site label \"{}\" must be univalent.", gid, label)),
     gid(gid),
     label(label)

--- a/arbor/backends/event.hpp
+++ b/arbor/backends/event.hpp
@@ -13,8 +13,8 @@ namespace arb {
 // Post-synaptic spike events
 
 struct target_handle {
-    cell_local_size_type mech_id;    // mechanism type identifier (per cell group).
-    cell_local_size_type mech_index; // instance of the mechanism
+    cell_local_size_type mech_id = 0;    // mechanism type identifier (per cell group).
+    cell_local_size_type mech_index = 0; // instance of the mechanism
 
     target_handle() = default;
     target_handle(cell_local_size_type mech_id, cell_local_size_type mech_index):
@@ -54,8 +54,8 @@ inline arb_deliverable_event_stream make_event_stream_state(arb_deliverable_even
 using probe_handle = const arb_value_type*;
 
 struct raw_probe_info {
-    probe_handle handle;      // where the to-be-probed value sits
-    sample_size_type offset;  // offset into array to store raw probed value
+    probe_handle handle = nullptr; // where the to-be-probed value sits
+    sample_size_type offset = 0;   // offset into array to store raw probed value
 };
 
 struct sample_event {

--- a/arbor/backends/event_stream_base.hpp
+++ b/arbor/backends/event_stream_base.hpp
@@ -42,7 +42,7 @@ public:
         index_ += (index_ <= ev_spans_.size() ? 1 : 0);
     }
 
-    auto marked_events() {
+    auto marked_events() const {
         using std::begin;
         using std::end;
         if (empty()) {

--- a/arbor/backends/event_stream_state.hpp
+++ b/arbor/backends/event_stream_state.hpp
@@ -11,8 +11,8 @@ template <typename EvData>
 struct event_stream_state {
     using value_type = EvData;
 
-    const value_type* begin_marked;   // offset to beginning of marked events
-    const value_type* end_marked;     // offset to one-past-end of marked events
+    const value_type* begin_marked = nullptr;   // offset to beginning of marked events
+    const value_type* end_marked = nullptr;     // offset to one-past-end of marked events
 
     std::size_t size() const noexcept {
         return end_marked - begin_marked;

--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -262,13 +262,14 @@ std::pair<arb_value_type, arb_value_type> shared_state::voltage_bounds() const {
 
 void shared_state::take_samples() {
     sample_events.mark();
-    if (!sample_events.empty()) {
-        const auto [begin, end] = sample_events.marked_events();
-        // Null handles are explicitly permitted, and always give a sample of zero.
-        for (auto p = begin; p<end; ++p) {
-            sample_time[p->offset] = time;
-            sample_value[p->offset] = p->handle? *p->handle: 0;
-        }
+    const auto& [begin, end] = sample_events.marked_events();
+    if (begin == end) return;
+    if (begin == nullptr || end == nullptr) throw arbor_internal_error{"Invalid sample stream state."};
+    // Null handles are explicitly permitted, and always give a sample of zero.
+    for (auto p = begin; p < end; ++p) {
+        auto off = p->offset;
+        sample_time[off] = time;
+        sample_value[off] = p->handle ? *p->handle : 0;
     }
 }
 

--- a/arbor/backends/multicore/shared_state.cpp
+++ b/arbor/backends/multicore/shared_state.cpp
@@ -31,7 +31,6 @@
 namespace arb {
 namespace multicore {
 
-using util::make_range;
 using util::make_span;
 using util::ptr_by_key;
 using util::value_by_key;
@@ -182,7 +181,7 @@ void istim_state::add_current(const arb_value_type time, array& current_density)
             J = math::lerp(J, J1, u);
         }
 
-        if (frequency_[i]) {
+        if (0 != frequency_[i]) {
             J *= std::sin(two_pi*frequency_[i]*time + phase_[i]);
         }
 
@@ -215,7 +214,7 @@ shared_state::shared_state(task_system_handle,    // ignored in mc backend
     init_voltage(init_membrane_potential.begin(), init_membrane_potential.end(), pad(alignment)),
     temperature_degC(n_cv_, pad(alignment)),
     diam_um(diam.begin(), diam.end(), pad(alignment)),
-    time_since_spike(n_cell*n_detector, pad(alignment)),
+    time_since_spike(n_cell*static_cast<std::size_t>(n_detector), pad(alignment)),
     src_to_spike(src_to_spike_.begin(), src_to_spike_.end(), pad(alignment)),
     cbprng_seed(cbprng_seed_),
     watcher{n_cv_,
@@ -406,7 +405,7 @@ void shared_state::instantiate(arb::mechanism& m,
     m.ppack_.temperature_degC = temperature_degC.data();
     m.ppack_.diam_um          = diam_um.data();
     m.ppack_.time_since_spike = time_since_spike.data();
-    m.ppack_.n_detectors      = n_detector;
+    m.ppack_.n_detectors      = static_cast<arb_index_type>(n_detector);
     m.ppack_.events           = {};
 
     bool mult_in_place = !pos_data.multiplicity.empty();
@@ -429,7 +428,7 @@ void shared_state::instantiate(arb::mechanism& m,
         if (!oion) throw arbor_internal_error(util::pprintf("multicore/mechanism: mechanism holds ion '{}' with no corresponding shared state", ion));
 
         auto& ion_state = m.ppack_.ion_states[idx];
-        ion_state = {0};
+        ion_state = {nullptr};
         ion_state.current_density         = oion->iX_.data();
         ion_state.reversal_potential      = oion->eX_.data();
         ion_state.internal_concentration  = oion->Xi_.data();

--- a/arbor/backends/multicore/shared_state.hpp
+++ b/arbor/backends/multicore/shared_state.hpp
@@ -153,13 +153,13 @@ struct ARB_ARBOR_API shared_state: shared_state_base<shared_state, array, ion_st
     arb_size_type n_detector = 0; // Max number of detectors on all cells.
     arb_size_type n_cv = 0;   // Total number of CVs.
 
-    iarray cv_to_cell;        // Maps CV index to the first spike
-    arb_value_type time;      // integration start time [ms].
-    arb_value_type time_to;   // integration end time [ms]
-    arb_value_type dt;        // dt [ms].
-    array voltage;            // Maps CV index to membrane voltage [mV].
-    array current_density;    // Maps CV index to membrane current density contributions [A/m²].
-    array conductivity;       // Maps CV index to membrane conductivity [kS/m²].
+    iarray cv_to_cell;          // Maps CV index to the first spike
+    arb_value_type time = 0;    // integration start time [ms].
+    arb_value_type time_to = 0; // integration end time [ms]
+    arb_value_type dt = 0;      // dt [ms].
+    array voltage;              // Maps CV index to membrane voltage [mV].
+    array current_density;      // Maps CV index to membrane current density contributions [A/m²].
+    array conductivity;         // Maps CV index to membrane conductivity [kS/m²].
 
     array init_voltage;       // Maps CV index to initial membrane voltage [mV].
     array temperature_degC;   // Maps CV to local temperature (read only) [°C].

--- a/arbor/backends/multicore/threshold_watcher.hpp
+++ b/arbor/backends/multicore/threshold_watcher.hpp
@@ -14,13 +14,13 @@ namespace multicore {
 class threshold_watcher {
 public:
     threshold_watcher() = default;
-    threshold_watcher(const execution_context& ctx) {}
+    threshold_watcher(const execution_context&) {}
 
     threshold_watcher(const arb_size_type num_cv,
                       const arb_index_type* src_to_spike,
                       const std::vector<arb_index_type>& cv_index,
                       const std::vector<arb_value_type>& thresholds,
-                      const execution_context& context):
+                      const execution_context&):
         src_to_spike_(src_to_spike),
         n_detectors_(cv_index.size()),
         cv_index_(cv_index),

--- a/arbor/backends/shared_state_base.hpp
+++ b/arbor/backends/shared_state_base.hpp
@@ -3,6 +3,8 @@
 #include <arbor/mechanism_abi.h>
 #include <arbor/common_types.hpp>
 
+#include "timestep_range.hpp"
+
 #include "backends/event.hpp"
 #include "backends/common_types.hpp"
 #include "fvm_layout.hpp"
@@ -28,7 +30,7 @@ struct shared_state_base {
 
     void begin_epoch(const std::vector<std::vector<std::vector<deliverable_event>>>& staged_events_per_mech_id,
                      const std::vector<std::vector<sample_event>>& samples,
-                     const timestep_range& dts) {
+                     const timestep_range&) {
         auto d = static_cast<D*>(this);
         // events
         auto& storage = d->storage;

--- a/arbor/benchmark_cell_group.cpp
+++ b/arbor/benchmark_cell_group.cpp
@@ -47,7 +47,7 @@ void benchmark_cell_group::reset() {
         c.time_sequence.reset();
     }
 
-    clear_spikes();
+    benchmark_cell_group::clear_spikes();
 }
 
 cell_kind benchmark_cell_group::get_cell_kind() const {

--- a/arbor/benchmark_cell_group.cpp
+++ b/arbor/benchmark_cell_group.cpp
@@ -55,8 +55,8 @@ cell_kind benchmark_cell_group::get_cell_kind() const {
 }
 
 void benchmark_cell_group::advance(epoch ep,
-                                   time_type dt,
-                                   const event_lane_subrange& event_lanes)
+                                   time_type /*dt*/,
+                                   const event_lane_subrange& /*event_lanes*/)
 {
     using std::chrono::high_resolution_clock;
     using duration_type = std::chrono::duration<double, std::micro>;

--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -213,7 +213,7 @@ struct cable_cell_impl {
 
 using impl_ptr = std::unique_ptr<cable_cell_impl, void (*)(cable_cell_impl*)>;
 impl_ptr make_impl(cable_cell_impl* c) {
-    return impl_ptr(c, [](cable_cell_impl* p){delete p;});
+    return {c, [](cable_cell_impl* p){ delete p; }};
 }
 
 void cable_cell_impl::init(const decor& d) {

--- a/arbor/cable_cell_param.cpp
+++ b/arbor/cable_cell_param.cpp
@@ -76,39 +76,39 @@ cable_cell_parameter_set neuron_parameter_defaults = {
 std::vector<defaultable> cable_cell_parameter_set::serialize() const {
     std::vector<defaultable> D;
     if (init_membrane_potential) {
-        D.push_back(arb::init_membrane_potential{*this->init_membrane_potential});
+        D.emplace_back(arb::init_membrane_potential{*this->init_membrane_potential});
     }
     if (temperature_K) {
-        D.push_back(arb::temperature_K{*this->temperature_K});
+        D.emplace_back(arb::temperature_K{*this->temperature_K});
     }
     if (axial_resistivity) {
-        D.push_back(arb::axial_resistivity{*this->axial_resistivity});
+        D.emplace_back(arb::axial_resistivity{*this->axial_resistivity});
     }
     if (membrane_capacitance) {
-        D.push_back(arb::membrane_capacitance{*this->membrane_capacitance});
+        D.emplace_back(arb::membrane_capacitance{*this->membrane_capacitance});
     }
 
     for (const auto& [name, data]: ion_data) {
         if (data.init_int_concentration) {
-            D.push_back(init_int_concentration{name, *data.init_int_concentration});
+            D.emplace_back(init_int_concentration{name, *data.init_int_concentration});
         }
         if (data.init_ext_concentration) {
-            D.push_back(init_ext_concentration{name, *data.init_ext_concentration});
+            D.emplace_back(init_ext_concentration{name, *data.init_ext_concentration});
         }
         if (data.init_reversal_potential) {
-            D.push_back(init_reversal_potential{name, *data.init_reversal_potential});
+            D.emplace_back(init_reversal_potential{name, *data.init_reversal_potential});
         }
         if (data.diffusivity) {
-            D.push_back(ion_diffusivity{name, *data.diffusivity});
+            D.emplace_back(ion_diffusivity{name, *data.diffusivity});
         }
     }
 
     for (const auto& [name, mech]: reversal_potential_method) {
-        D.push_back(ion_reversal_potential_method{name, mech});
+        D.emplace_back(ion_reversal_potential_method{name, mech});
     }
 
     if (discretization) {
-        D.push_back(*discretization);
+        D.emplace_back(*discretization);
     }
 
     return D;

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -209,7 +209,8 @@ communicator::exchange(std::vector<spike> local_spikes) {
     if (remote_spike_filter_) {
         local_spikes.erase(std::remove_if(local_spikes.begin(),
                                           local_spikes.end(),
-                                          [this] (const auto& s) { return !remote_spike_filter_(s); }));
+                                          [this] (const auto& s) { return !remote_spike_filter_(s); }),
+                           local_spikes.end());
     }
     auto remote_spikes = distributed_->remote_gather_spikes(local_spikes);
     PL();

--- a/arbor/communication/dry_run_context.cpp
+++ b/arbor/communication/dry_run_context.cpp
@@ -16,14 +16,14 @@ struct dry_run_context_impl {
     explicit dry_run_context_impl(unsigned num_ranks, unsigned num_cells_per_tile):
         num_ranks_(num_ranks), num_cells_per_tile_(num_cells_per_tile) {};
     std::vector<spike>
-    remote_gather_spikes(const std::vector<spike>& local_spikes) const {
+    remote_gather_spikes(const std::vector<spike>& /*local_spikes*/) const {
         return {};
     }
     gathered_vector<spike>
     gather_spikes(const std::vector<spike>& local_spikes) const {
         using count_type = typename gathered_vector<spike>::count_type;
 
-        count_type local_size = local_spikes.size();
+        auto local_size = local_spikes.size();
 
         std::vector<spike> gathered_spikes;
         gathered_spikes.reserve(local_size*num_ranks_);
@@ -51,7 +51,7 @@ struct dry_run_context_impl {
     gather_gids(const std::vector<cell_gid_type>& local_gids) const {
         using count_type = typename gathered_vector<cell_gid_type>::count_type;
 
-        count_type local_size = local_gids.size();
+        auto local_size = local_gids.size();
 
         std::vector<cell_gid_type> gathered_gids;
         gathered_gids.reserve(local_size*num_ranks_);

--- a/arbor/communication/dry_run_context.cpp
+++ b/arbor/communication/dry_run_context.cpp
@@ -43,7 +43,7 @@ struct dry_run_context_impl {
             partition.push_back(static_cast<count_type>(i*local_size));
         }
 
-        return gathered_vector<spike>(std::move(gathered_spikes), std::move(partition));
+        return {std::move(gathered_spikes), std::move(partition)};
     }
     void remote_ctrl_send_continue(const epoch&) const {}
     void remote_ctrl_send_done() const {}
@@ -71,7 +71,7 @@ struct dry_run_context_impl {
             partition.push_back(static_cast<count_type>(i*local_size));
         }
 
-        return gathered_vector<cell_gid_type>(std::move(gathered_gids), std::move(partition));
+        return {std::move(gathered_gids), std::move(partition)};
     }
 
     std::vector<std::vector<cell_gid_type>>
@@ -105,7 +105,7 @@ struct dry_run_context_impl {
     cell_labels_and_gids gather_cell_labels_and_gids(const cell_labels_and_gids& local_labels_and_gids) const {
         auto global_ranges = gather_cell_label_range(local_labels_and_gids.label_range);
         auto gids = gather_gids(local_labels_and_gids.gids);
-        return cell_labels_and_gids(global_ranges, gids.values());
+        return {global_ranges, gids.values()};
     }
 
     template <typename T>

--- a/arbor/cv_policy.cpp
+++ b/arbor/cv_policy.cpp
@@ -23,8 +23,8 @@ static auto unique_sum = [](auto&&... lss) {
 // cv_policy_bar_ represents the result of operator|.
 
 struct cv_policy_plus_: cv_policy_base {
-    cv_policy_plus_(const cv_policy& lhs, const cv_policy& rhs):
-        lhs_(lhs), rhs_(rhs) {}
+    cv_policy_plus_(cv_policy lhs, cv_policy rhs):
+        lhs_(std::move(lhs)), rhs_(std::move(rhs)) {}
 
     cv_policy_base_ptr clone() const override {
         return cv_policy_base_ptr(new cv_policy_plus_(*this));
@@ -49,8 +49,8 @@ ARB_ARBOR_API cv_policy operator+(const cv_policy& lhs, const cv_policy& rhs) {
 }
 
 struct cv_policy_bar_: cv_policy_base {
-    cv_policy_bar_(const cv_policy& lhs, const cv_policy& rhs):
-        lhs_(lhs), rhs_(rhs) {}
+    cv_policy_bar_(cv_policy lhs, cv_policy rhs):
+        lhs_(std::move(lhs)), rhs_(std::move(rhs)) {}
 
     cv_policy_base_ptr clone() const override {
         return cv_policy_base_ptr(new cv_policy_bar_(*this));

--- a/arbor/cv_policy.cpp
+++ b/arbor/cv_policy.cpp
@@ -14,9 +14,11 @@
 
 namespace arb {
 
-static auto unique_sum = [](auto&&... lss) {
+namespace {
+auto unique_sum = [](auto&&... lss) {
     return ls::support(sum(std::forward<decltype(lss)>(lss)...));
 };
+}
 
 // Combinators:
 // cv_policy_plus_ represents the result of operator+,

--- a/arbor/distributed_context.hpp
+++ b/arbor/distributed_context.hpp
@@ -84,7 +84,7 @@ public:
         return impl_->gather_cell_labels_and_gids(local_labels_and_gids);
     }
 
-    std::vector<std::string> gather(std::string value, int root) const {
+    std::vector<std::string> gather(const std::string& value, int root) const {
         return impl_->gather(value, root);
     }
 

--- a/arbor/distributed_context.hpp
+++ b/arbor/distributed_context.hpp
@@ -134,7 +134,7 @@ private:
 
         ARB_PP_FOREACH(ARB_INTERFACE_COLLECTIVES_, ARB_COLLECTIVE_TYPES_)
 
-        virtual ~interface() {}
+        virtual ~interface() = default;
     };
 
     template <typename Impl>

--- a/arbor/distributed_context.hpp
+++ b/arbor/distributed_context.hpp
@@ -52,7 +52,7 @@ public:
     // default constructor uses a local context: see below.
     distributed_context();
 
-    template <typename Impl>
+    template <typename Impl, typename = std::enable_if<!std::is_same_v<Impl, distributed_context>>>
     distributed_context(Impl&& impl):
         impl_(new wrap<Impl>(std::forward<Impl>(impl)))
     {}
@@ -204,7 +204,7 @@ struct local_context {
         );
     }
     std::vector<spike>
-    remote_gather_spikes(const std::vector<spike>& local_spikes) const {
+    remote_gather_spikes(const std::vector<spike>& /*local_spikes*/) const {
         return {};
     }
     gathered_vector<cell_gid_type>

--- a/arbor/domain_decomposition.cpp
+++ b/arbor/domain_decomposition.cpp
@@ -19,7 +19,7 @@ domain_decomposition::domain_decomposition(
     const std::vector<group_description>& groups)
 {
     struct partition_gid_domain {
-        partition_gid_domain(const gathered_vector<cell_gid_type>& divs, unsigned domains) {
+        partition_gid_domain(const gathered_vector<cell_gid_type>& divs) {
             auto rank_part = util::partition_view(divs.partition());
             for (auto rank: count_along(rank_part)) {
                 for (auto gid: util::subrange_view(divs.values(), rank_part[rank])) {
@@ -81,7 +81,7 @@ domain_decomposition::domain_decomposition(
     num_local_cells_ = num_local_cells;
     num_global_cells_ = num_global_cells;
     groups_ = groups;
-    gid_domain_ = partition_gid_domain(global_gids, num_domains);
+    gid_domain_ = partition_gid_domain(global_gids);
 }
 
 int domain_decomposition::gid_domain(cell_gid_type gid) const {

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -631,13 +631,13 @@ ARB_ARBOR_API fvm_voltage_interpolant fvm_interpolate_voltage(const cable_cell& 
         msize_t bid = site.branch;
 
         arb_assert(vrefs.proximal.loc.pos<vrefs.distal.loc.pos);
-        mcable rr_span  = mcable{bid, vrefs.proximal.loc.pos , vrefs.distal.loc.pos};
+        auto rr_span = mcable{bid, vrefs.proximal.loc.pos , vrefs.distal.loc.pos};
         double rr_resistance = embedding.integrate_ixa(rr_span, D.axial_resistivity[0].at(bid));
 
         // Note: site is not necessarily distal to the most proximal reference point.
         bool flip_rs = vrefs.proximal.loc.pos>site.pos;
-        mcable rs_span = flip_rs? mcable{bid, site.pos, vrefs.proximal.loc.pos}
-                                : mcable{bid, vrefs.proximal.loc.pos, site.pos};
+        auto rs_span = flip_rs ? mcable{bid, site.pos, vrefs.proximal.loc.pos}
+                               : mcable{bid, vrefs.proximal.loc.pos, site.pos};
 
         double rs_resistance = embedding.integrate_ixa(rs_span, D.axial_resistivity[0].at(bid));
         if (flip_rs) {

--- a/arbor/fvm_lowered_cell.hpp
+++ b/arbor/fvm_lowered_cell.hpp
@@ -224,7 +224,7 @@ struct fvm_lowered_cell {
 
     virtual arb_value_type time() const = 0;
 
-    virtual ~fvm_lowered_cell() {}
+    virtual ~fvm_lowered_cell() = default;
 };
 
 using fvm_lowered_cell_ptr = std::unique_ptr<fvm_lowered_cell>;

--- a/arbor/fvm_lowered_cell.hpp
+++ b/arbor/fvm_lowered_cell.hpp
@@ -133,8 +133,8 @@ struct missing_probe_info {
 
 struct fvm_probe_data {
     fvm_probe_data() = default;
-    fvm_probe_data(fvm_probe_scalar p): info(std::move(p)) {}
-    fvm_probe_data(fvm_probe_interpolated p): info(std::move(p)) {}
+    fvm_probe_data(fvm_probe_scalar p): info(p) {}
+    fvm_probe_data(fvm_probe_interpolated p): info(p) {}
     fvm_probe_data(fvm_probe_multi p): info(std::move(p)) {}
     fvm_probe_data(fvm_probe_weighted_multi p): info(std::move(p)) {}
     fvm_probe_data(fvm_probe_interpolated_multi p): info(std::move(p)) {}

--- a/arbor/fvm_lowered_cell_impl.hpp
+++ b/arbor/fvm_lowered_cell_impl.hpp
@@ -47,7 +47,7 @@ public:
     using size_type = arb_size_type;
 
     fvm_lowered_cell_impl(execution_context ctx, arb_seed_type seed = 0):
-        context_(ctx),
+        context_(std::move(ctx)),
         seed_{seed}
     {};
 
@@ -713,7 +713,7 @@ void resolve_probe(const cable_probe_membrane_voltage& p, probe_resolution_data<
 }
 
 template <typename B>
-void resolve_probe(const cable_probe_membrane_voltage_cell& p, probe_resolution_data<B>& R) {
+void resolve_probe(const cable_probe_membrane_voltage_cell&  /*p*/, probe_resolution_data<B>& R) {
     fvm_probe_multi r;
     mcable_list cables;
 
@@ -762,7 +762,7 @@ void resolve_probe(const cable_probe_total_ion_current_density& p, probe_resolut
 }
 
 template <typename B>
-void resolve_probe(const cable_probe_total_ion_current_cell& p, probe_resolution_data<B>& R) {
+void resolve_probe(const cable_probe_total_ion_current_cell& /*p*/, probe_resolution_data<B>& R) {
     fvm_probe_interpolated_multi r;
     std::vector<const double*> stim_handles;
 
@@ -789,7 +789,7 @@ void resolve_probe(const cable_probe_total_ion_current_cell& p, probe_resolution
 }
 
 template <typename B>
-void resolve_probe(const cable_probe_total_current_cell& p, probe_resolution_data<B>& R) {
+void resolve_probe(const cable_probe_total_current_cell& /*p*/, probe_resolution_data<B>& R) {
     fvm_probe_membrane_currents r;
 
     auto cell_cv_ival = R.D.geometry.cell_cv_interval(R.cell_idx);
@@ -829,7 +829,7 @@ void resolve_probe(const cable_probe_total_current_cell& p, probe_resolution_dat
 }
 
 template <typename B>
-void resolve_probe(const cable_probe_stimulus_current_cell& p, probe_resolution_data<B>& R) {
+void resolve_probe(const cable_probe_stimulus_current_cell& /*p*/, probe_resolution_data<B>& R) {
     fvm_probe_weighted_multi r;
 
     const auto& stim_cvs = R.M.stimuli.cv_unique;

--- a/arbor/hardware/power.cpp
+++ b/arbor/hardware/power.cpp
@@ -14,7 +14,7 @@ bool has_energy_measurement() {
 }
 
 energy_size_type energy() {
-    energy_size_type result = energy_size_type(-1);
+    auto result = energy_size_type(-1);
 
     std::ifstream fid(CRAY_PM_COUNTER_ENERGY);
     if (fid) {

--- a/arbor/iexpr.cpp
+++ b/arbor/iexpr.cpp
@@ -218,7 +218,7 @@ struct interpolation: public iexpr_interface {
         if (!d2) return 0.0;
 
         const auto sum = d1.value() + d2.value();
-        if (!sum) return (prox_v + dist_v) * 0.5;
+        if (0 == sum) return (prox_v + dist_v) * 0.5;
 
         return prox_v * (d2.value() / sum) + dist_v * (d1.value() / sum);
     }
@@ -336,13 +336,13 @@ struct log: public iexpr_interface {
 
 iexpr::iexpr(double value) { *this = iexpr::scalar(value); }
 
-iexpr iexpr::scalar(double value) { return iexpr(iexpr_type::scalar, std::make_tuple(value)); }
+iexpr iexpr::scalar(double value) { return {iexpr_type::scalar, std::make_tuple(value)}; }
 
 iexpr iexpr::pi() { return iexpr::scalar(math::pi<double>); }
 
 iexpr iexpr::distance(double scale, locset loc) {
-    return iexpr(
-        iexpr_type::distance, std::make_tuple(scale, std::variant<locset, region>(std::move(loc))));
+    return {
+        iexpr_type::distance, std::make_tuple(scale, std::variant<locset, region>(std::move(loc)))};
 }
 
 iexpr iexpr::distance(locset loc) {
@@ -350,8 +350,8 @@ iexpr iexpr::distance(locset loc) {
 }
 
 iexpr iexpr::distance(double scale, region reg) {
-    return iexpr(
-        iexpr_type::distance, std::make_tuple(scale, std::variant<locset, region>(std::move(reg))));
+    return {
+        iexpr_type::distance, std::make_tuple(scale, std::variant<locset, region>(std::move(reg)))};
 }
 
 iexpr iexpr::distance(region reg) {
@@ -359,8 +359,8 @@ iexpr iexpr::distance(region reg) {
 }
 
 iexpr iexpr::proximal_distance(double scale, locset loc) {
-    return iexpr(iexpr_type::proximal_distance,
-        std::make_tuple(scale, std::variant<locset, region>(std::move(loc))));
+    return {iexpr_type::proximal_distance,
+        std::make_tuple(scale, std::variant<locset, region>(std::move(loc)))};
 }
 
 iexpr iexpr::proximal_distance(locset loc) {
@@ -368,8 +368,8 @@ iexpr iexpr::proximal_distance(locset loc) {
 }
 
 iexpr iexpr::proximal_distance(double scale, region reg) {
-    return iexpr(iexpr_type::proximal_distance,
-        std::make_tuple(scale, std::variant<locset, region>(std::move(reg))));
+    return {iexpr_type::proximal_distance,
+        std::make_tuple(scale, std::variant<locset, region>(std::move(reg)))};
 }
 
 iexpr iexpr::proximal_distance(region reg) {
@@ -377,8 +377,8 @@ iexpr iexpr::proximal_distance(region reg) {
 }
 
 iexpr iexpr::distal_distance(double scale, locset loc) {
-    return iexpr(iexpr_type::distal_distance,
-        std::make_tuple(scale, std::variant<locset, region>(std::move(loc))));
+    return {iexpr_type::distal_distance,
+        std::make_tuple(scale, std::variant<locset, region>(std::move(loc)))};
 }
 
 iexpr iexpr::distal_distance(locset loc) {
@@ -386,8 +386,7 @@ iexpr iexpr::distal_distance(locset loc) {
 }
 
 iexpr iexpr::distal_distance(double scale, region reg) {
-    return iexpr(iexpr_type::distal_distance,
-        std::make_tuple(scale, std::variant<locset, region>(std::move(reg))));
+    return {iexpr_type::distal_distance, std::make_tuple(scale, std::variant<locset, region>(std::move(reg)))};
 }
 
 iexpr iexpr::distal_distance(region reg) {
@@ -398,61 +397,59 @@ iexpr iexpr::interpolation(double prox_value,
     locset prox_list,
     double dist_value,
     locset dist_list) {
-    return iexpr(iexpr_type::interpolation,
+    return {iexpr_type::interpolation,
         std::make_tuple(prox_value,
             std::variant<locset, region>(std::move(prox_list)),
             dist_value,
-            std::variant<locset, region>(std::move(dist_list))));
+            std::variant<locset, region>(std::move(dist_list)))};
 }
 
 iexpr iexpr::interpolation(double prox_value,
     region prox_list,
     double dist_value,
     region dist_list) {
-    return iexpr(iexpr_type::interpolation,
+    return {iexpr_type::interpolation,
         std::make_tuple(prox_value,
             std::variant<locset, region>(std::move(prox_list)),
             dist_value,
-            std::variant<locset, region>(std::move(dist_list))));
+            std::variant<locset, region>(std::move(dist_list)))};
 }
 
-iexpr iexpr::radius(double scale) { return iexpr(iexpr_type::radius, std::make_tuple(scale)); }
+iexpr iexpr::radius(double scale) { return {iexpr_type::radius, std::make_tuple(scale)}; }
 
 iexpr iexpr::radius() { return iexpr::radius(1.0); }
 
-iexpr iexpr::diameter(double scale) { return iexpr(iexpr_type::diameter, std::make_tuple(scale)); }
+iexpr iexpr::diameter(double scale) { return {iexpr_type::diameter, std::make_tuple(scale)}; }
 
 iexpr iexpr::diameter() { return iexpr::diameter(1.0); }
 
 iexpr iexpr::add(iexpr left, iexpr right) {
-    return iexpr(iexpr_type::add, std::make_tuple(std::move(left), std::move(right)));
+    return {iexpr_type::add, std::make_tuple(std::move(left), std::move(right))};
 }
 
 iexpr iexpr::sub(iexpr left, iexpr right) {
-    return iexpr(iexpr_type::sub, std::make_tuple(std::move(left), std::move(right)));
+    return {iexpr_type::sub, std::make_tuple(std::move(left), std::move(right))};
 }
 
 iexpr iexpr::mul(iexpr left, iexpr right) {
-    return iexpr(iexpr_type::mul, std::make_tuple(std::move(left), std::move(right)));
+    return {iexpr_type::mul, std::make_tuple(std::move(left), std::move(right))};
 }
 
 iexpr iexpr::div(iexpr left, iexpr right) {
-    return iexpr(iexpr_type::div, std::make_tuple(std::move(left), std::move(right)));
+    return {iexpr_type::div, std::make_tuple(std::move(left), std::move(right))};
 }
 
-iexpr iexpr::exp(iexpr value) { return iexpr(iexpr_type::exp, std::make_tuple(std::move(value))); }
+iexpr iexpr::exp(iexpr value) { return {iexpr_type::exp, std::make_tuple(std::move(value))}; }
 
-iexpr iexpr::step_right(iexpr value) { return iexpr(iexpr_type::step_right, std::make_tuple(std::move(value))); }
+iexpr iexpr::step_right(iexpr value) { return {iexpr_type::step_right, std::make_tuple(std::move(value))}; }
 
-iexpr iexpr::step_left(iexpr value) { return iexpr(iexpr_type::step_left, std::make_tuple(std::move(value))); }
+iexpr iexpr::step_left(iexpr value) { return {iexpr_type::step_left, std::make_tuple(std::move(value))}; }
 
-iexpr iexpr::step(iexpr value) { return iexpr(iexpr_type::step, std::make_tuple(std::move(value))); }
+iexpr iexpr::step(iexpr value) { return {iexpr_type::step, std::make_tuple(std::move(value))}; }
 
-iexpr iexpr::log(iexpr value) { return iexpr(iexpr_type::log, std::make_tuple(std::move(value))); }
+iexpr iexpr::log(iexpr value) { return {iexpr_type::log, std::make_tuple(std::move(value))}; }
 
-iexpr iexpr::named(std::string name) {
-    return iexpr(iexpr_type::named, std::make_tuple(std::move(name)));
-}
+iexpr iexpr::named(std::string name) { return {iexpr_type::named, std::make_tuple(std::move(name))}; }
 
 iexpr_ptr thingify(const iexpr& expr, const mprovider& m) {
     switch (expr.type()) {

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -87,7 +87,7 @@ struct ARB_SYMBOL_VISIBLE gj_kind_mismatch: arbor_exception {
 };
 
 struct ARB_SYMBOL_VISIBLE gj_unsupported_lid_selection_policy: arbor_exception {
-    gj_unsupported_lid_selection_policy(cell_gid_type gid, cell_tag_type label);
+    gj_unsupported_lid_selection_policy(cell_gid_type gid, const cell_tag_type& label);
     cell_gid_type gid;
     cell_tag_type label;
 };

--- a/arbor/include/arbor/arbexcept.hpp
+++ b/arbor/include/arbor/arbexcept.hpp
@@ -179,7 +179,7 @@ struct ARB_SYMBOL_VISIBLE file_not_found_error: arbor_exception {
 //
 struct ARB_SYMBOL_VISIBLE bad_catalogue_error: arbor_exception {
     bad_catalogue_error(const std::string&);
-    bad_catalogue_error(const std::string&, const std::any&);
+    bad_catalogue_error(const std::string&, std::any);
     std::any platform_error;
 };
 

--- a/arbor/include/arbor/benchmark_cell.hpp
+++ b/arbor/include/arbor/benchmark_cell.hpp
@@ -2,6 +2,7 @@
 
 #include <arbor/export.hpp>
 #include <arbor/schedule.hpp>
+#include <utility>
 
 namespace arb {
 
@@ -21,7 +22,7 @@ struct ARB_SYMBOL_VISIBLE benchmark_cell {
 
     benchmark_cell() = delete;
     benchmark_cell(cell_tag_type source, cell_tag_type target, schedule seq, double ratio):
-        source(source), target(target), time_sequence(seq), realtime_ratio(ratio) {};
+        source(std::move(source)), target(std::move(target)), time_sequence(std::move(seq)), realtime_ratio(ratio) {};
 };
 
 } // namespace arb

--- a/arbor/include/arbor/cable_cell_param.hpp
+++ b/arbor/include/arbor/cable_cell_param.hpp
@@ -249,8 +249,8 @@ struct ARB_SYMBOL_VISIBLE scaled_mechanism {
 
     explicit scaled_mechanism(TaggedMech m) : t_mech(std::move(m)) {}
 
-    scaled_mechanism& scale(std::string name, iexpr expr) {
-        scale_expr.insert_or_assign(name, expr);
+    scaled_mechanism& scale(const std::string& name, iexpr expr) {
+        scale_expr.insert_or_assign(name, std::move(expr));
         return *this;
     }
 };

--- a/arbor/include/arbor/common_types.hpp
+++ b/arbor/include/arbor/common_types.hpp
@@ -82,7 +82,7 @@ struct cell_local_label_type {
     cell_tag_type tag;
     lid_selection_policy policy;
 
-    cell_local_label_type(cell_tag_type tag, lid_selection_policy policy=lid_selection_policy::assert_univalent):
+    cell_local_label_type(cell_tag_type tag, lid_selection_policy policy=lid_selection_policy::assert_univalent) noexcept:
         tag(std::move(tag)), policy(policy) {}
 };
 

--- a/arbor/include/arbor/cv_policy.hpp
+++ b/arbor/include/arbor/cv_policy.hpp
@@ -65,7 +65,7 @@ struct cv_policy_base {
     virtual locset cv_boundary_points(const cable_cell& cell) const = 0;
     virtual region domain() const = 0;
     virtual std::unique_ptr<cv_policy_base> clone() const = 0;
-    virtual ~cv_policy_base() {}
+    virtual ~cv_policy_base() = default;
     virtual std::ostream& print(std::ostream&) = 0;
 };
 
@@ -135,7 +135,7 @@ private:
 
 struct ARB_ARBOR_API cv_policy_single: cv_policy_base {
     explicit cv_policy_single(region domain = reg::all()):
-        domain_(domain) {}
+        domain_(std::move(domain)) {}
 
     cv_policy_base_ptr clone() const override;
     locset cv_boundary_points(const cable_cell&) const override;

--- a/arbor/include/arbor/event_generator.hpp
+++ b/arbor/include/arbor/event_generator.hpp
@@ -99,36 +99,30 @@ private:
 
 // Simplest generator: just do nothing
 inline
-event_generator empty_generator(
-    cell_local_label_type target,
-    float weight)
-{
-    return event_generator(std::move(target), weight, schedule());
+event_generator empty_generator(cell_local_label_type target,
+                                float weight) {
+    return {std::move(target), weight, schedule()};
 }
 
 
 // Generate events at integer multiples of dt that lie between tstart and tstop.
 
-inline event_generator regular_generator(
-    cell_local_label_type target,
-    float weight,
-    time_type tstart,
-    time_type dt,
-    time_type tstop=terminal_time)
-{
-    return event_generator(std::move(target), weight, regular_schedule(tstart, dt, tstop));
+inline event_generator regular_generator(cell_local_label_type target,
+                                         float weight,
+                                         time_type tstart,
+                                         time_type dt,
+                                         time_type tstop=terminal_time) {
+    return {std::move(target), weight, regular_schedule(tstart, dt, tstop)};
 }
 
 template <typename RNG>
-inline event_generator poisson_generator(
-    cell_local_label_type target,
-    float weight,
-    time_type tstart,
-    time_type rate_kHz,
-    const RNG& rng,
-    time_type tstop=terminal_time)
-{
-    return event_generator(std::move(target), weight, poisson_schedule(tstart, rate_kHz, rng, tstop));
+inline event_generator poisson_generator(cell_local_label_type target,
+                                         float weight,
+                                         time_type tstart,
+                                         time_type rate_kHz,
+                                         const RNG& rng,
+                                         time_type tstop=terminal_time) {
+    return {std::move(target), weight, poisson_schedule(tstart, rate_kHz, rng, tstop)};
 }
 
 
@@ -137,9 +131,8 @@ inline event_generator poisson_generator(
 template<typename S> inline
 event_generator explicit_generator(cell_local_label_type target,
                                    float weight,
-                                   const S& s)
-{
-    return event_generator(std::move(target), weight, explicit_schedule(s));
+                                   const S& s) {
+    return {std::move(target), weight, explicit_schedule(s)};
 }
 
 } // namespace arb

--- a/arbor/include/arbor/mechcat.hpp
+++ b/arbor/include/arbor/mechcat.hpp
@@ -45,8 +45,8 @@ public:
     using value_type = double;
 
     mechanism_catalogue();
-    mechanism_catalogue(mechanism_catalogue&& other);
-    mechanism_catalogue& operator=(mechanism_catalogue&& other);
+    mechanism_catalogue(mechanism_catalogue&& other) noexcept;
+    mechanism_catalogue& operator=(mechanism_catalogue&& other) noexcept;
 
     mechanism_catalogue(const mechanism_catalogue& other);
     mechanism_catalogue& operator=(const mechanism_catalogue& other);

--- a/arbor/include/arbor/morph/isometry.hpp
+++ b/arbor/include/arbor/morph/isometry.hpp
@@ -15,7 +15,7 @@ struct ARB_ARBOR_API isometry {
     // as applied to absolute coordinates (composed by addition).
 
     friend isometry operator*(const isometry& a, const isometry& b) {
-        return isometry(b.q_*a.q_, a.tx_+b.tx_, a.ty_+b.ty_, a.tz_+b.tz_);
+        return {b.q_*a.q_, a.tx_+b.tx_, a.ty_+b.ty_, a.tz_+b.tz_};
     }
 
     template <typename PointLike>
@@ -37,7 +37,7 @@ private:
 
 public:
     static isometry translate(double x, double y, double z) {
-        return isometry(quaternion{1, 0, 0, 0}, x, y, z);
+        return {quaternion{1, 0, 0, 0}, x, y, z};
     }
 
     template <typename PointLike>
@@ -50,7 +50,7 @@ public:
         double norm = std::sqrt(ax*ax+ay*ay+az*az);
         double vscale = std::sin(theta/2)/norm;
 
-        return isometry(quaternion{std::cos(theta/2), ax*vscale, ay*vscale, az*vscale}, 0, 0, 0);
+        return {quaternion{std::cos(theta/2), ax*vscale, ay*vscale, az*vscale}, 0, 0, 0};
     }
 
     template <typename PointLike>

--- a/arbor/include/arbor/morph/isometry.hpp
+++ b/arbor/include/arbor/morph/isometry.hpp
@@ -33,7 +33,7 @@ private:
     double tx_ = 0, ty_ = 0, tz_ = 0;
 
     isometry(quaternion q, double tx, double ty, double tz):
-        q_(std::move(q)), tx_(tx), ty_(ty), tz_(tz) {}
+        q_(q), tx_(tx), ty_(ty), tz_(tz) {}
 
 public:
     static isometry translate(double x, double y, double z) {

--- a/arbor/include/arbor/morph/locset.hpp
+++ b/arbor/include/arbor/morph/locset.hpp
@@ -83,7 +83,7 @@ public:
 
 private:
     struct interface {
-        virtual ~interface() {}
+        virtual ~interface() = default;
         virtual std::unique_ptr<interface> clone() = 0;
         virtual std::ostream& print(std::ostream&) = 0;
         virtual mlocation_list thingify(const mprovider&) = 0;
@@ -96,15 +96,15 @@ private:
         explicit wrap(const Impl& impl): wrapped(impl) {}
         explicit wrap(Impl&& impl): wrapped(std::move(impl)) {}
 
-        virtual std::unique_ptr<interface> clone() override {
+         std::unique_ptr<interface> clone() override {
             return std::unique_ptr<interface>(new wrap<Impl>(wrapped));
         }
 
-        virtual mlocation_list thingify(const mprovider& m) override {
+         mlocation_list thingify(const mprovider& m) override {
             return thingify_(wrapped, m);
         }
 
-        virtual std::ostream& print(std::ostream& o) override {
+         std::ostream& print(std::ostream& o) override {
             return o << wrapped;
         }
 

--- a/arbor/include/arbor/morph/morphology.hpp
+++ b/arbor/include/arbor/morph/morphology.hpp
@@ -18,7 +18,7 @@ class ARB_ARBOR_API morphology {
     std::shared_ptr<const morphology_impl> impl_;
 
 public:
-    morphology(segment_tree m);
+    morphology(const segment_tree& m);
     morphology();
 
     // Empty/default-constructed morphology?

--- a/arbor/include/arbor/morph/mprovider.hpp
+++ b/arbor/include/arbor/morph/mprovider.hpp
@@ -30,7 +30,7 @@ struct ARB_ARBOR_API mprovider {
 
 private:
     mprovider(arb::morphology m, const label_dict* ldptr):
-        morphology_(m), embedding_(m), label_dict_ptr(ldptr) { init(); }
+        morphology_(std::move(m)), embedding_(morphology_), label_dict_ptr(ldptr) { init(); }
 
     arb::morphology morphology_;
     concrete_embedding embedding_;

--- a/arbor/include/arbor/morph/mprovider.hpp
+++ b/arbor/include/arbor/morph/mprovider.hpp
@@ -16,8 +16,8 @@ namespace arb {
 using concrete_embedding = embed_pwlin;
 
 struct ARB_ARBOR_API mprovider {
-    mprovider(arb::morphology m, const label_dict& dict): mprovider(m, &dict) {}
-    explicit mprovider(arb::morphology m): mprovider(m, nullptr) {}
+    mprovider(arb::morphology m, const label_dict& dict): mprovider(std::move(m), &dict) {}
+    explicit mprovider(arb::morphology m): mprovider(std::move(m), nullptr) {}
 
     // Throw exception on missing or recursive definition.
     const mextent& region(const std::string& name) const;

--- a/arbor/include/arbor/morph/primitives.hpp
+++ b/arbor/include/arbor/morph/primitives.hpp
@@ -87,12 +87,12 @@ ARB_ARBOR_API mlocation_list support(mlocation_list);
 
 struct ARB_SYMBOL_VISIBLE mcable {
     // The id of the branch on which the cable lies.
-    msize_t branch;
+    msize_t branch = 0;
 
     // Relative location of the end points on the branch.
     // 0 ≤ prox_pos ≤ dist_pos ≤ 1
-    double prox_pos; // ∈ [0,1]
-    double dist_pos; // ∈ [0,1]
+    double prox_pos = 0; // ∈ [0,1]
+    double dist_pos = 0; // ∈ [0,1]
 
     friend mlocation prox_loc(const mcable& c) {
         return {c.branch, c.prox_pos};

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -29,7 +29,8 @@ public:
     explicit region(const Impl& impl):
         impl_(new wrap<Impl>(impl)) {}
 
-    region(region&& other) = default;
+    region(region&& other) noexcept = default;
+    region& operator=(region&& other) noexcept = default;
 
     // The default constructor creates an empty "nil" region.
     region();
@@ -81,8 +82,8 @@ public:
     friend region intersect(region, region);
 
     template <typename ...Args>
-    friend region intersect(region l, region r, Args... args) {
-        return intersect(intersect(std::move(l), std::move(r)), std::move(args)...);
+    friend region intersect(const region& l, const region& r, Args... args) {
+        return intersect(intersect(l, r), std::move(args)...);
     }
 
 private:

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -87,7 +87,7 @@ public:
 
 private:
     struct interface {
-        virtual ~interface() {}
+        virtual ~interface() = default;
         virtual std::unique_ptr<interface> clone() = 0;
         virtual std::ostream& print(std::ostream&) = 0;
         virtual mextent thingify(const mprovider&) = 0;
@@ -100,15 +100,15 @@ private:
         explicit wrap(const Impl& impl): wrapped(impl) {}
         explicit wrap(Impl&& impl): wrapped(std::move(impl)) {}
 
-        virtual std::unique_ptr<interface> clone() override {
+         std::unique_ptr<interface> clone() override {
             return std::make_unique<wrap<Impl>>(wrapped);
         }
 
-        virtual mextent thingify(const mprovider& m) override {
+         mextent thingify(const mprovider& m) override {
             return thingify_(wrapped, m);
         }
 
-        virtual std::ostream& print(std::ostream& o) override {
+         std::ostream& print(std::ostream& o) override {
             return o << wrapped;
         }
 

--- a/arbor/include/arbor/morph/stitch.hpp
+++ b/arbor/include/arbor/morph/stitch.hpp
@@ -32,11 +32,11 @@ struct mstitch {
     int tag;
 
     mstitch(std::string id, mpoint prox, mpoint dist, int tag = 0):
-        id(std::move(id)), prox(std::move(prox)), dist(std::move(dist)), tag(tag)
+        id(std::move(id)), prox(prox), dist(dist), tag(tag)
     {}
 
     mstitch(std::string id, mpoint dist, int tag = 0):
-        id(std::move(id)), dist(std::move(dist)), tag(tag)
+        id(std::move(id)), dist(dist), tag(tag)
     {}
 };
 
@@ -47,10 +47,10 @@ struct ARB_ARBOR_API stitch_builder {
     stitch_builder();
 
     stitch_builder(const stitch_builder&) = delete;
-    stitch_builder(stitch_builder&&);
+    stitch_builder(stitch_builder&&) noexcept;
 
     stitch_builder& operator=(const stitch_builder&) = delete;
-    stitch_builder& operator=(stitch_builder&&);
+    stitch_builder& operator=(stitch_builder&&) noexcept;
 
     // Make a new stitch in the morphology, return reference to self.
     //
@@ -78,7 +78,7 @@ struct ARB_ARBOR_API stitched_morphology {
     stitched_morphology(stitch_builder&&); // implicit
 
     stitched_morphology(const stitched_morphology&) = delete;
-    stitched_morphology(stitched_morphology&&);
+    stitched_morphology(stitched_morphology&&) noexcept;
 
     arb::morphology morphology() const;
     region stitch(const std::string& id) const;

--- a/arbor/include/arbor/profile/clock.hpp
+++ b/arbor/include/arbor/profile/clock.hpp
@@ -2,7 +2,7 @@
 
 #include <arbor/export.hpp>
 
-typedef unsigned long long tick_type;
+using tick_type = unsigned long long;
 
 // Assuming POSIX monotonic clock is available; add
 // feature test if we need to fall back to generic or

--- a/arbor/include/arbor/recipe.hpp
+++ b/arbor/include/arbor/recipe.hpp
@@ -22,7 +22,8 @@ struct probe_info {
     probe_info(probe_info&&) = default;
 
     // Implicit ctor uses tag of zero.
-    template <typename X>
+    template <typename X,
+              typename = std::enable_if<!std::is_same_v<X, probe_tag>>> // otherwise, we'd hide ctors above
     probe_info(X&& x, probe_tag tag = 0):
         tag(tag), address(std::forward<X>(x)) {}
 };
@@ -68,14 +69,14 @@ struct ARB_ARBOR_API has_gap_junctions {
     virtual std::vector<gap_junction_connection> gap_junctions_on(cell_gid_type) const {
         return {};
     }
-    virtual ~has_gap_junctions() {}
+    virtual ~has_gap_junctions() = default;
 };
 
 struct ARB_ARBOR_API has_synapses {
     virtual std::vector<cell_connection> connections_on(cell_gid_type) const {
         return {};
     }
-    virtual ~has_synapses() {}
+    virtual ~has_synapses() = default;
 };
 
 struct ARB_ARBOR_API has_external_synapses {
@@ -88,14 +89,14 @@ struct ARB_ARBOR_API has_probes {
     virtual std::vector<probe_info> get_probes(cell_gid_type gid) const {
         return {};
     }
-    virtual ~has_probes() {}
+    virtual ~has_probes() = default;
 };
 
 struct ARB_ARBOR_API has_generators {
     virtual std::vector<event_generator> event_generators(cell_gid_type) const {
         return {};
     }
-    virtual ~has_generators() {}
+    virtual ~has_generators() = default;
 };
 
 // Toppings allow updating a simulation
@@ -103,7 +104,7 @@ struct ARB_ARBOR_API connectivity:
         public has_synapses,
                has_external_synapses,
                has_generators {
-    virtual ~connectivity() {}
+    ~connectivity() override = default;
 };
 
 // Recipes allow building a simulation by lazy queries
@@ -117,7 +118,7 @@ struct ARB_ARBOR_API recipe: public has_gap_junctions, has_probes, connectivity 
     // Global property type will be specific to given cell kind.
     virtual std::any get_global_properties(cell_kind) const { return std::any{}; };
 
-    virtual ~recipe() {}
+    ~recipe() override = default;
 };
 
 } // namespace arb

--- a/arbor/include/arbor/recipe.hpp
+++ b/arbor/include/arbor/recipe.hpp
@@ -86,7 +86,7 @@ struct ARB_ARBOR_API has_external_synapses {
 };
 
 struct ARB_ARBOR_API has_probes {
-    virtual std::vector<probe_info> get_probes(cell_gid_type gid) const {
+    virtual std::vector<probe_info> get_probes(cell_gid_type) const {
         return {};
     }
     virtual ~has_probes() = default;

--- a/arbor/include/arbor/s_expr.hpp
+++ b/arbor/include/arbor/s_expr.hpp
@@ -55,7 +55,7 @@ struct symbol {
     operator std::string() const { return str; }
 };
 
-inline symbol operator"" _symbol(const char* chars, size_t size) {
+inline symbol operator"" _symbol(const char* chars, size_t /*size*/) {
     return {chars};
 }
 
@@ -131,7 +131,7 @@ struct ARB_ARBOR_API s_expr {
             if (finished()) inner_ = nullptr;
         }
 
-        s_expr_iterator_impl(const sentinel& e):
+        s_expr_iterator_impl(const sentinel& /*e*/):
             inner_(nullptr)
         {}
 
@@ -167,7 +167,7 @@ struct ARB_ARBOR_API s_expr {
         bool operator!=(const s_expr_iterator_impl& other) const {
             return !(*this==other);
         }
-        bool operator==(const sentinel& other) const {
+        bool operator==(const sentinel& /*other*/) const {
             return !inner_;
         }
         bool operator!=(const sentinel& other) const {

--- a/arbor/include/arbor/s_expr.hpp
+++ b/arbor/include/arbor/s_expr.hpp
@@ -69,7 +69,7 @@ struct ARB_ARBOR_API s_expr {
 
     // This value_wrapper is used to wrap the shared pointer
     template <typename T>
-    struct value_wrapper{
+    struct value_wrapper {
         using state_t = std::unique_ptr<T>;
         state_t state;
 
@@ -89,7 +89,7 @@ struct ARB_ARBOR_API s_expr {
             return *this;
         }
 
-        value_wrapper(value_wrapper&& other) = default;
+        value_wrapper(value_wrapper&& other) noexcept = default;
 
         friend std::ostream& operator<<(std::ostream& o, const value_wrapper& w) {
             return o << *w.state;
@@ -210,21 +210,21 @@ struct ARB_ARBOR_API s_expr {
 
     s_expr(const s_expr& s) = default;
     s_expr() = default;
-    s_expr(token t): state(std::move(t)) {}
+    s_expr(const token& t): state(t) {}
     s_expr(s_expr l, s_expr r):
         state(pair_type(std::move(l), std::move(r)))
     {}
     s_expr& operator=(const s_expr& s) = default;
 
-    explicit s_expr(std::string s):
-        s_expr(token{{0,0}, tok::string, std::move(s)}) {}
+    explicit s_expr(const std::string& s):
+        s_expr(token{{0,0}, tok::string, s}) {}
     explicit s_expr(const char* s):
         s_expr(token{{0,0}, tok::string, s}) {}
     s_expr(double x):
         s_expr(token{{0,0}, tok::real, std::to_string(x)}) {}
     s_expr(int x):
         s_expr(token{{0,0}, tok::integer, std::to_string(x)}) {}
-    s_expr(symbol s):
+    s_expr(const symbol& s):
         s_expr(token{{0,0}, tok::symbol, s}) {}
 
     bool is_atom() const;

--- a/arbor/include/arbor/s_expr.hpp
+++ b/arbor/include/arbor/s_expr.hpp
@@ -208,13 +208,13 @@ struct ARB_ARBOR_API s_expr {
     using pair_type = s_pair<value_wrapper<s_expr>>;
     std::variant<token, pair_type> state = token{{0,0}, tok::nil, "()"};
 
-    s_expr(const s_expr& s): state(s.state) {}
+    s_expr(const s_expr& s) = default;
     s_expr() = default;
     s_expr(token t): state(std::move(t)) {}
     s_expr(s_expr l, s_expr r):
         state(pair_type(std::move(l), std::move(r)))
     {}
-    s_expr& operator=(const s_expr& s) { state = s.state; return *this; }
+    s_expr& operator=(const s_expr& s) = default;
 
     explicit s_expr(std::string s):
         s_expr(token{{0,0}, tok::string, std::move(s)}) {}

--- a/arbor/include/arbor/sampling.hpp
+++ b/arbor/include/arbor/sampling.hpp
@@ -10,7 +10,7 @@ namespace arb {
 
 using cell_member_predicate = std::function<bool (cell_member_type)>;
 
-static cell_member_predicate all_probes = [](cell_member_type pid) { return true; };
+static cell_member_predicate all_probes = [](cell_member_type) { return true; };
 
 inline cell_member_predicate one_probe(cell_member_type pid) {
     return [pid](cell_member_type x) { return pid==x; };

--- a/arbor/include/arbor/simd/neon.hpp
+++ b/arbor/include/arbor/simd/neon.hpp
@@ -555,7 +555,7 @@ struct neon_double2 : implbase<neon_double2> {
     // coefficients
     // a0, ..., an by a0+x·(a1+x·(a2+...+x·an)...).
 
-    static inline float64x2_t horner(float64x2_t x, double a0) {
+    static inline float64x2_t horner(float64x2_t, double a0) {
         return broadcast(a0);
     }
 

--- a/arbor/include/arbor/simd/simd.hpp
+++ b/arbor/include/arbor/simd/simd.hpp
@@ -151,17 +151,17 @@ namespace detail {
     };
 
     template <typename Impl, typename V>
-    static void indirect_copy_to(const simd_mask_impl<Impl>& s, V* p, unsigned width) {
+    static void indirect_copy_to(const simd_mask_impl<Impl>& s, V* p, unsigned) {
         Impl::mask_copy_to(s.value_, p);
     }
 
     template <typename Impl, typename V>
-    static void indirect_copy_to(const simd_impl<Impl>& s, V* p, unsigned width) {
+    static void indirect_copy_to(const simd_impl<Impl>& s, V* p, unsigned) {
         Impl::copy_to(s.value_, p);
     }
 
     template <typename Impl, typename ImplMask, typename V>
-    static void indirect_copy_to(const simd_impl<Impl>& data, const simd_mask_impl<ImplMask>& mask, V* p, unsigned width) {
+    static void indirect_copy_to(const simd_impl<Impl>& data, const simd_mask_impl<ImplMask>& mask, V* p, unsigned) {
         Impl::copy_to_masked(data.value_, p, mask.value_);
     }
 
@@ -230,12 +230,12 @@ namespace detail {
     };
 
     template <typename Impl, typename ImplIndex, typename V>
-    static void indirect_indexed_copy_to(const simd_impl<Impl>& s, V* p, const simd_impl<ImplIndex>& index, unsigned width) {
+    static void indirect_indexed_copy_to(const simd_impl<Impl>& s, V* p, const simd_impl<ImplIndex>& index, unsigned) {
         Impl::scatter(tag<ImplIndex>{}, s.value_, p, index.value_);
     }
 
     template <typename Impl, typename ImplIndex, typename ImplMask, typename V>
-    static void indirect_indexed_copy_to(const simd_impl<Impl>& data, const simd_mask_impl<ImplMask>& mask, V* p, const simd_impl<ImplIndex>& index, unsigned width) {
+    static void indirect_indexed_copy_to(const simd_impl<Impl>& data, const simd_mask_impl<ImplMask>& mask, V* p, const simd_impl<ImplIndex>& index, unsigned) {
         Impl::scatter(tag<ImplIndex>{}, data.value_, p, index.value_, mask.value_);
     }
 
@@ -334,12 +334,12 @@ namespace detail {
     }
 
     template <typename Impl, typename ImplMask, typename V>
-    static void where_copy_to(const simd_mask_impl<ImplMask>& mask, simd_impl<Impl>& f, const V* t, unsigned width) {
+    static void where_copy_to(const simd_mask_impl<ImplMask>& mask, simd_impl<Impl>& f, const V* t, unsigned) {
         f.value_ = Impl::ifelse(mask.value_, Impl::copy_from_masked(t, mask.value_), f.value_);
     }
 
     template <typename Impl, typename ImplIndex, typename ImplMask, typename V>
-    static void where_copy_to(const simd_mask_impl<ImplMask>& mask, simd_impl<Impl>& f,  const V* p, const simd_impl<ImplIndex>& index, unsigned width) {
+    static void where_copy_to(const simd_mask_impl<ImplMask>& mask, simd_impl<Impl>& f,  const V* p, const simd_impl<ImplIndex>& index, unsigned) {
         simd_impl<Impl> temp = Impl::broadcast(0);
         temp.value_ = Impl::gather(tag<ImplIndex>{}, temp.value_, p, index.value_, mask.value_);
         f.value_ = Impl::ifelse(mask.value_, temp.value_, f.value_);
@@ -984,12 +984,12 @@ To simd_cast(const From& s) {
 }
 
 template <typename S, std::enable_if_t<is_simd<S>::value, int> = 0>
-inline constexpr int width(const S a = S{}) {
+inline constexpr int width(const S = S{}) {
     return S::width;
 };
 
 template <typename S, std::enable_if_t<is_simd<S>::value, int> = 0>
-inline constexpr unsigned min_align(const S a = S{}) {
+inline constexpr unsigned min_align(const S = S{}) {
     return S::min_align;
 };
 

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -153,7 +153,7 @@ private:
     }
 
     simulation build(context ctx, domain_decomposition const& decomp) const {
-        return simulation(rec_, ctx, decomp, seed_);
+        return {rec_, ctx, decomp, seed_};
     }
 
 private:

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -35,13 +35,13 @@ public:
 
     simulation(const recipe& rec,
                context ctx = make_context(),
-               std::function<domain_decomposition(const recipe&, context)> balancer = 
+               const std::function<domain_decomposition(const recipe&, context)>& balancer =
                    [](auto& r, auto c) { return partition_load_balance(r, c); },
                arb_seed_type seed = 0):
         simulation(rec, ctx, balancer(rec, ctx), seed) {}
 
     simulation(simulation const&) = delete;
-    simulation(simulation&&);
+    simulation(simulation&&) noexcept;
 
     static simulation_builder create(recipe const &);
 
@@ -117,8 +117,8 @@ public:
         return *this;
     }
 
-    simulation_builder& set_decomposition(domain_decomposition decomp) noexcept {
-        balancer_ = [decomp = std::move(decomp)](const recipe&, context) {return decomp; };
+    simulation_builder& set_decomposition(const domain_decomposition& decomp) noexcept {
+        balancer_ = [decomp = decomp](const recipe&, context) {return decomp; };
         return *this;
     }
 

--- a/arbor/include/arbor/simulation.hpp
+++ b/arbor/include/arbor/simulation.hpp
@@ -38,7 +38,7 @@ public:
                std::function<domain_decomposition(const recipe&, context)> balancer = 
                    [](auto& r, auto c) { return partition_load_balance(r, c); },
                arb_seed_type seed = 0):
-        simulation(rec, ctx, balancer(rec, ctx)) {}
+        simulation(rec, ctx, balancer(rec, ctx), seed) {}
 
     simulation(simulation const&) = delete;
     simulation(simulation&&);

--- a/arbor/include/arbor/util/any_ptr.hpp
+++ b/arbor/include/arbor/util/any_ptr.hpp
@@ -72,8 +72,10 @@ struct ARB_SYMBOL_VISIBLE any_ptr {
     }
 
     any_ptr& operator=(const any_ptr& other) noexcept {
-        type_ptr_ = other.type_ptr_;
-        ptr_ = other.ptr_;
+        if (&other != this) {
+          type_ptr_ = other.type_ptr_;
+          ptr_ = other.ptr_;
+        }
         return *this;
     }
 

--- a/arbor/include/arbor/util/compat.hpp
+++ b/arbor/include/arbor/util/compat.hpp
@@ -9,7 +9,7 @@
 
 namespace compat {
 
-constexpr bool using_intel_compiler(int major=0, int minor=0, int patchlevel=0) {
+constexpr bool using_intel_compiler(int=0, int=0, int=0) {
 #if defined(__INTEL_COMPILER)
     return __INTEL_COMPILER >= major*100 + minor &&
            __INTEL_COMPILER_UPDATE >= patchlevel;

--- a/arbor/include/arbor/util/expected.hpp
+++ b/arbor/include/arbor/util/expected.hpp
@@ -72,7 +72,7 @@ struct unexpected {
 
     unexpected() = default;
     unexpected(const unexpected&) = default;
-    unexpected(unexpected&&) = default;
+    unexpected(unexpected&&) noexcept  = default;
 
     // Emplace-style ctors.
 
@@ -109,7 +109,7 @@ struct unexpected {
 
     unexpected& operator=(const unexpected& u) { value_ = u.value_; return *this; }
 
-    unexpected& operator=(unexpected&& u) { value_ = std::move(u.value_); return *this; }
+    unexpected& operator=(unexpected&& u) noexcept { value_ = std::move(u.value_); return *this; }
 
     template <typename F>
     unexpected& operator=(const unexpected<F>& u) { value_ = u.value_; return *this; }
@@ -157,7 +157,7 @@ struct expected {
 
     expected() = default;
     expected(const expected&) = default;
-    expected(expected&&) = default;
+    expected(expected&&) noexcept  = default;
 
     // Emplace-style ctors.
 
@@ -424,7 +424,7 @@ struct expected<void, E> {
 
     expected() = default;
     expected(const expected&) = default;
-    expected(expected&&) = default;
+    expected(expected&&) noexcept = default;
 
     // Emplace-style ctors.
 

--- a/arbor/include/arbor/util/expected.hpp
+++ b/arbor/include/arbor/util/expected.hpp
@@ -45,7 +45,7 @@ struct bad_expected_access;
 template <>
 struct bad_expected_access<void>: std::exception {
     bad_expected_access() = default;
-    virtual const char* what() const noexcept override { return "bad expected access"; }
+     const char* what() const noexcept override { return "bad expected access"; }
 };
 
 template <typename E>

--- a/arbor/include/arbor/util/expected.hpp
+++ b/arbor/include/arbor/util/expected.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <variant>
 
+#include <arbor/arbexcept.hpp>
 #include <arbor/util/extra_traits.hpp>
 
 namespace arb {
@@ -50,7 +51,7 @@ struct bad_expected_access<void>: std::exception {
 
 template <typename E>
 struct bad_expected_access: public bad_expected_access<void> {
-    explicit bad_expected_access(E error): error_(error) {}
+    explicit bad_expected_access(E error): error_(std::move(error)) {}
 
     E& error() & { return error_; }
     const E& error() const& { return error_; }
@@ -106,15 +107,15 @@ struct unexpected {
 
     // Assignment operators.
 
-    unexpected& operator=(const unexpected& u) { return value_ = u.value_, *this; }
+    unexpected& operator=(const unexpected& u) { value_ = u.value_; return *this; }
 
-    unexpected& operator=(unexpected&& u) { return value_ = std::move(u.value_), *this; }
-
-    template <typename F>
-    unexpected& operator=(const unexpected<F>& u) { return value_ = u.value_, *this; }
+    unexpected& operator=(unexpected&& u) { value_ = std::move(u.value_); return *this; }
 
     template <typename F>
-    unexpected& operator=(unexpected<F>&& u) { return value_ = std::move(u.value_), *this; }
+    unexpected& operator=(const unexpected<F>& u) { value_ = u.value_; return *this; }
+
+    template <typename F>
+    unexpected& operator=(unexpected<F>&& u) { value_ = std::move(u.value_); return *this; }
 
     // Access.
 
@@ -498,11 +499,24 @@ struct expected<void, E> {
         if (!has_value()) throw bad_expected_access<E>(error());
     }
 
-    const E& error() const& { return data_->value(); }
-    E& error() & { return data_->value(); }
+    const E& error() const& {
+        if (!data_.has_value()) throw arbor_internal_error("Invalid state of expected: neither error nor value");
+        return data_->value();
+    }
+    E& error() & {
+        if (!data_.has_value()) throw arbor_internal_error("Invalid state of expected: neither error nor value");
+        return data_->value();
+    }
 
-    const E&& error() const&& { return std::move(data_->value()); }
-    E&& error() && { return std::move(data_->value()); }
+    const E&& error() const&& {
+        if (!data_.has_value()) throw arbor_internal_error("Invalid state of expected: neither error nor value");
+        return std::move(data_->value());
+    }
+
+    E&& error() && {
+        if (!data_.has_value()) throw arbor_internal_error("Invalid state of expected: neither error nor value");
+        return std::move(data_->value());
+    }
 
 private:
     data_type data_;

--- a/arbor/include/arbor/util/extra_traits.hpp
+++ b/arbor/include/arbor/util/extra_traits.hpp
@@ -7,7 +7,7 @@ namespace util {
 
 template <typename T>
 struct remove_cvref {
-    typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+    using type = std::remove_cv_t<std::remove_reference_t<T>>;
 };
 
 template <typename T>

--- a/arbor/include/arbor/util/unique_any.hpp
+++ b/arbor/include/arbor/util/unique_any.hpp
@@ -106,7 +106,7 @@ private:
 
     template <typename T>
     struct model: public interface {
-        ~model() = default;
+        ~model() override = default;
         model(const T& other): value(other) {}
         model(T&& other): value(std::move(other)) {}
 

--- a/arbor/io/locked_ostream.cpp
+++ b/arbor/io/locked_ostream.cpp
@@ -59,11 +59,11 @@ locked_ostream::locked_ostream(std::streambuf *b):
 {}
 
 
-locked_ostream::locked_ostream(locked_ostream&& other):
-    std::ostream(std::move(other)), // This moves other
+locked_ostream::locked_ostream(locked_ostream&& other) noexcept:
+    std::ostream(std::move(other)),
     mex(std::move(other.mex))
 {
-    set_rdbuf(other.rdbuf());       // ... and here we use it ... oh-oh
+    set_rdbuf(rdbuf());
     other.set_rdbuf(nullptr);
 }
 

--- a/arbor/io/locked_ostream.cpp
+++ b/arbor/io/locked_ostream.cpp
@@ -58,7 +58,6 @@ locked_ostream::locked_ostream(std::streambuf *b):
     mex(register_sbuf(b))
 {}
 
-
 locked_ostream::locked_ostream(locked_ostream&& other) noexcept:
     std::ostream(std::move(other)),
     mex(std::move(other.mex))

--- a/arbor/io/locked_ostream.hpp
+++ b/arbor/io/locked_ostream.hpp
@@ -11,7 +11,7 @@ namespace io {
 
 struct locked_ostream: std::ostream {
     locked_ostream(std::streambuf *b);
-    locked_ostream(locked_ostream&& other);
+    locked_ostream(locked_ostream&& other) noexcept;
 
     ~locked_ostream() override;
 

--- a/arbor/io/locked_ostream.hpp
+++ b/arbor/io/locked_ostream.hpp
@@ -13,7 +13,7 @@ struct locked_ostream: std::ostream {
     locked_ostream(std::streambuf *b);
     locked_ostream(locked_ostream&& other);
 
-    ~locked_ostream();
+    ~locked_ostream() override;
 
     std::unique_lock<std::mutex> guard();
 

--- a/arbor/io/trace.hpp
+++ b/arbor/io/trace.hpp
@@ -56,7 +56,7 @@ namespace impl {
             lock_(this->guard())
         {}
 
-        ~emit_nl_locked() {
+        ~emit_nl_locked() override {
             if (rdbuf()) {
                 (*this) << std::endl;
             }

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -30,7 +30,7 @@ void cell_label_range::add_label(cell_tag_type label, lid_range range) {
     if (sizes_.empty()) throw arbor_internal_error("adding label to cell_label_range without cell");
     ++sizes_.back();
     labels_.push_back(std::move(label));
-    ranges_.push_back(std::move(range));
+    ranges_.push_back(range);
 }
 
 void cell_label_range::append(cell_label_range other) {

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -157,8 +157,8 @@ resolver::state_variant resolver::construct_state(lid_selection_policy pol) {
 	case lid_selection_policy::round_robin_halt:
         return round_robin_halt_state();
     case lid_selection_policy::assert_univalent:
-       return assert_univalent_state();
-    default: return assert_univalent_state();
+    default:
+        return assert_univalent_state();
     }
 }
 
@@ -169,8 +169,8 @@ resolver::state_variant resolver::construct_state(lid_selection_policy pol, cell
 	case lid_selection_policy::round_robin_halt:
         return round_robin_halt_state(state);
     case lid_selection_policy::assert_univalent:
-       return assert_univalent_state();
-    default: return assert_univalent_state();
+    default:
+        return assert_univalent_state();
     }
 }
 

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -88,7 +88,7 @@ private:
 
 struct ARB_ARBOR_API round_robin_state {
     cell_lid_type state = 0;
-    round_robin_state() : state(0) {};
+    round_robin_state() = default;
     round_robin_state(cell_lid_type state) : state(state) {};
     cell_lid_type get();
     lid_hopefully update(const label_resolution_map::range_set& range);
@@ -96,7 +96,7 @@ struct ARB_ARBOR_API round_robin_state {
 
 struct ARB_ARBOR_API round_robin_halt_state {
     cell_lid_type state = 0;
-    round_robin_halt_state() : state(0) {};
+    round_robin_halt_state() = default;
     round_robin_halt_state(cell_lid_type state) : state(state) {};
     cell_lid_type get();
     lid_hopefully update(const label_resolution_map::range_set& range);

--- a/arbor/lif_cell_group.cpp
+++ b/arbor/lif_cell_group.cpp
@@ -94,15 +94,17 @@ void lif_cell_group::reset() {
 }
 
 // produce voltage V_m at t1, given cell state at t0 and no spikes in [t0, t1)
-static double
+namespace {
+double
 lif_decay(const lif_cell& cell, double t0, double t1) {
     return (cell.V_m - cell.E_L)*exp((t0 - t1)/cell.tau_m) + cell.E_L;
+}
 }
 
 // Advances a single cell (lid) with the exact solution (jumps can be arbitrary).
 // Parameter dt is ignored, since we make jumps between two consecutive spikes.
 void lif_cell_group::advance_cell(time_type tfinal,
-                                  time_type dt,
+                                  time_type /*dt*/,
                                   cell_gid_type lid,
                                   const event_lane_subrange& event_lanes) {
     const auto gid = gids_[lid];

--- a/arbor/lif_cell_group.hpp
+++ b/arbor/lif_cell_group.hpp
@@ -16,7 +16,7 @@
 
 namespace arb {
 
-class ARB_ARBOR_API lif_cell_group: public cell_group {
+class ARB_ARBOR_API lif_cell_group final: public cell_group {
 public:
     using value_type = double;
 
@@ -25,20 +25,20 @@ public:
     // Constructor containing gid of first cell in a group and a container of all cells.
     lif_cell_group(const std::vector<cell_gid_type>& gids, const recipe& rec, cell_label_range& cg_sources, cell_label_range& cg_targets);
 
-    virtual cell_kind get_cell_kind() const override;
-    virtual void reset() override;
-    virtual void advance(epoch epoch, time_type dt, const event_lane_subrange& events) override;
+    cell_kind get_cell_kind() const override;
+    void reset() override;
+    void advance(epoch epoch, time_type dt, const event_lane_subrange& events) override;
 
-    virtual const std::vector<spike>& spikes() const override;
-    virtual void clear_spikes() override;
+    const std::vector<spike>& spikes() const override;
+    void clear_spikes() override;
 
     // Sampler association methods below should be thread-safe, as they might be invoked
     // from a sampler call back called from a different cell group running on a different thread.
-    virtual void add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function) override;
-    virtual void remove_sampler(sampler_association_handle) override;
-    virtual void remove_all_samplers() override;
+    void add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function) override;
+    void remove_sampler(sampler_association_handle) override;
+    void remove_all_samplers() override;
 
-    virtual std::vector<probe_metadata> get_probe_metadata(cell_member_type) const override;
+    std::vector<probe_metadata> get_probe_metadata(cell_member_type) const override;
 
 private:
     enum class lif_probe_kind { voltage };

--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -178,8 +178,7 @@ void run_samples(
     const arb_value_type* raw_times,
     const arb_value_type* raw_samples,
     std::vector<sample_record>& sample_records,
-    fvm_probe_scratch& scratch)
-{
+    fvm_probe_scratch& scratch) {
     auto n_raw_per_sample = p.raw_handles.size();
     auto n_sample = (sc.end_offset-sc.begin_offset)/n_raw_per_sample;
     arb_assert((sc.end_offset-sc.begin_offset)==n_sample*n_raw_per_sample);

--- a/arbor/mc_cell_group.cpp
+++ b/arbor/mc_cell_group.cpp
@@ -151,20 +151,20 @@ void run_samples(
     fvm_probe_scratch& scratch)
 {
     constexpr sample_size_type n_raw_per_sample = 2;
-    sample_size_type n_sample = (sc.end_offset-sc.begin_offset)/n_raw_per_sample;
+    auto n_sample = (sc.end_offset-sc.begin_offset)/n_raw_per_sample;
     arb_assert((sc.end_offset-sc.begin_offset)==n_sample*n_raw_per_sample);
 
     auto& tmp = std::get<std::vector<double>>(scratch);
     tmp.clear();
     sample_records.clear();
 
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         tmp.push_back(p.coef[0]*raw_samples[offset] + p.coef[1]*raw_samples[offset+1]);
     }
 
     const auto& ctmp = tmp;
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &ctmp[j]});
     }
@@ -188,13 +188,13 @@ void run_samples(
     sample_ranges.clear();
     sample_records.clear();
 
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         sample_ranges.emplace_back(raw_samples+offset, raw_samples+offset+n_raw_per_sample);
     }
 
     const auto& csample_ranges = sample_ranges;
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }
@@ -223,21 +223,21 @@ void run_samples(
     tmp.clear();
     tmp.reserve(n_raw_per_sample*n_sample);
 
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
-        for (sample_size_type i = 0; i<n_raw_per_sample; ++i) {
+        for (auto i = 0ul; i<n_raw_per_sample; ++i) {
             tmp.push_back(raw_samples[offset+i]*p.weight[i]);
         }
     }
 
     const double* tmp_ptr = tmp.data();
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         sample_ranges.emplace_back(tmp_ptr, tmp_ptr+n_raw_per_sample);
         tmp_ptr += n_raw_per_sample;
     }
 
     const auto& csample_ranges = sample_ranges;
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }
@@ -268,23 +268,23 @@ void run_samples(
     tmp.clear();
     tmp.reserve(n_interp_per_sample*n_sample);
 
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         const auto* raw_a = raw_samples + offset;
         const auto* raw_b = raw_a + n_interp_per_sample;
-        for (sample_size_type i = 0; i<n_interp_per_sample; ++i) {
+        for (auto i = 0ul; i<n_interp_per_sample; ++i) {
             tmp.push_back(raw_a[i]*p.coef[0][i]+raw_b[i]*p.coef[1][i]);
         }
     }
 
     const double* tmp_ptr = tmp.data();
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         sample_ranges.emplace_back(tmp_ptr, tmp_ptr+n_interp_per_sample);
         tmp_ptr += n_interp_per_sample;
     }
 
     const auto& csample_ranges = sample_ranges;
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_interp_per_sample+sc.begin_offset;
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }
@@ -318,7 +318,7 @@ void run_samples(
 
     sample_records.clear();
 
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         auto tmp_base = tmp.data()+j*n_cable;
 
@@ -358,7 +358,7 @@ void run_samples(
     }
 
     const auto& csample_ranges = sample_ranges;
-    for (sample_size_type j = 0; j<n_sample; ++j) {
+    for (auto j = 0ul; j<n_sample; ++j) {
         auto offset = j*n_raw_per_sample+sc.begin_offset;
         sample_records.push_back(sample_record{time_type(raw_times[offset]), &csample_ranges[j]});
     }

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -527,8 +527,8 @@ std::vector<std::string> mechanism_catalogue::mechanism_names() const {
     return state_->mechanism_names();
 }
 
-mechanism_catalogue::mechanism_catalogue(mechanism_catalogue&& other) = default;
-mechanism_catalogue& mechanism_catalogue::operator=(mechanism_catalogue&& other) = default;
+mechanism_catalogue::mechanism_catalogue(mechanism_catalogue&& other) noexcept = default;
+mechanism_catalogue& mechanism_catalogue::operator=(mechanism_catalogue&& other) noexcept = default;
 
 mechanism_catalogue::mechanism_catalogue(const mechanism_catalogue& other):
     state_(new catalogue_state(*other.state_))

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -284,7 +284,7 @@ struct catalogue_state {
 
         mechanism_info_ptr new_info;
         if (auto parent_info = info(parent)) {
-            new_info.reset(new mechanism_info(parent_info.value()));
+            new_info = std::make_unique<mechanism_info>(parent_info.value());
         }
         else {
             return unexpected(parent_info.error());
@@ -396,15 +396,15 @@ struct catalogue_state {
             }
 
             if (is_ion(k)) {
-                ion_remap.push_back({k, v});
+                ion_remap.emplace_back(k, v);
             }
             else {
-                char* end = 0;
-                double v_value = std::strtod(v.c_str(), &end);
+                char* end = nullptr;
+                auto v_value = std::strtod(v.c_str(), &end);
                 if (!end || *end) {
                     return unexpected_exception_ptr(invalid_parameter_value(name, k, v));
                 }
-                global_params.push_back({k, v_value});
+                global_params.emplace_back(k, v_value);
             }
         }
 
@@ -535,7 +535,7 @@ mechanism_catalogue::mechanism_catalogue(const mechanism_catalogue& other):
 
 mechanism_catalogue& mechanism_catalogue::operator=(const mechanism_catalogue& other) {
     if (this != &other) {
-        state_.reset(new catalogue_state(*other.state_));
+        state_ = std::make_unique<catalogue_state>(*other.state_);
     }
     return *this;
 }

--- a/arbor/mechcat.cpp
+++ b/arbor/mechcat.cpp
@@ -247,7 +247,8 @@ struct catalogue_state {
         const std::string* base = &name;
 
         if (!defined(name)) {
-            if ((implicit_deriv = derive(name))) {
+            implicit_deriv = derive(name);
+            if (implicit_deriv) {
                 base = &implicit_deriv->parent;
             }
             else {

--- a/arbor/memory/allocator.hpp
+++ b/arbor/memory/allocator.hpp
@@ -191,7 +191,7 @@ public:
         return nullptr;
     }
 
-    void deallocate(pointer p, size_type cnt) {
+    void deallocate(pointer p, size_type) {
         if (p) {
             free_policy(p);
         }
@@ -240,7 +240,7 @@ namespace util {
     template <>
     struct type_printer<impl::gpu::device_policy>{
         static std::string print() {
-            return std::string("device_policy");
+            return "device_policy";
         }
     };
 

--- a/arbor/memory/array.hpp
+++ b/arbor/memory/array.hpp
@@ -145,7 +145,7 @@ public:
     array(const array& other) :
         base(coordinator_type().allocate(other.size()))
     {
-        static_assert(impl::is_array_t<array>::value, "");
+        static_assert(impl::is_array_t<array>::value);
 #ifdef VERBOSE
         std::cerr << util::green("array(array&)")
                   << " " << util::type_printer<array>::print()

--- a/arbor/memory/array.hpp
+++ b/arbor/memory/array.hpp
@@ -156,7 +156,7 @@ public:
     }
 
     // move constructor
-    array(array&& other) {
+    array(array&& other) noexcept {
 #ifdef VERBOSE
         std::cerr << util::green("array(array&&)")
                   << " " << util::type_printer<array>::print()
@@ -195,7 +195,7 @@ public:
         return *this;
     }
 
-    array& operator = (array&& other) {
+    array& operator=(array&& other) noexcept {
 #ifdef VERBOSE
         std::cerr << util::green("array operator=(array&&)")
                   << "\n  this  "  << util::pretty_printer<array>::print(*this)

--- a/arbor/memory/array_view.hpp
+++ b/arbor/memory/array_view.hpp
@@ -204,7 +204,7 @@ public:
         typename Other,
         typename = std::enable_if_t< impl::is_array<Other>::value >
     >
-    array_view operator=(Other&& other) {
+    array_view& operator=(Other&& other) {
         #if VERBOSE
         std::cerr << util::pretty_printer<array_view>::print(*this)
                   << "::" << util::blue("operator=") << "("
@@ -278,6 +278,9 @@ public:
         return coordinator_type::alignment();
     }
 
+    // disallow constructors that imply allocation of memory
+    array_view(std::size_t n) = delete;
+
 protected :
     template < typename U, typename C>
     friend void impl::reset(array_view<U, C>&, U*, std::size_t);
@@ -301,9 +304,6 @@ protected :
         pointer_ = ptr;
         size_ = n;
     }
-
-    // disallow constructors that imply allocation of memory
-    array_view(std::size_t n) = delete;
 
     coordinator_type coordinator_;
     pointer          pointer_;
@@ -387,7 +387,7 @@ public:
         typename Other,
         typename = std::enable_if_t< impl::is_array<Other>::value >
     >
-    const_array_view operator=(Other&& other) {
+    const_array_view& operator=(Other&& other) {
 #if VERBOSE
         std::cerr << util::pretty_printer<const_array_view>::print(*this)
                   << "::" << util::blue("operator=") << "("

--- a/arbor/memory/definitions.hpp
+++ b/arbor/memory/definitions.hpp
@@ -8,8 +8,8 @@ namespace arb {
 namespace memory {
 
 namespace types {
-    typedef std::ptrdiff_t  difference_type;
-    typedef std::size_t     size_type;
+    using difference_type = std::ptrdiff_t;
+    using size_type = std::size_t;
 } // namespace types
 
 namespace util {
@@ -19,8 +19,8 @@ namespace util {
 
     template <typename T>
     struct pretty_printer{
-        static std::string print(const T& val) {
-            return std::string("T()");
+        static std::string print(const T& /*val*/) {
+            return "T()";
         }
     };
 
@@ -53,7 +53,7 @@ namespace util {
 
     template <typename First, typename Second>
     struct pretty_printer<std::pair<First, Second>>{
-        typedef std::pair<First, Second> T;
+        using T = std::pair<First, Second>;
         static std::string print(const T& val) {
             std::stringstream str;
             str << type_printer<T>::print()
@@ -74,28 +74,28 @@ namespace util {
     template <>
     struct type_printer<float>{
         static std::string print() {
-            return std::string("float");
+            return "float";
         }
     };
 
     template <>
     struct type_printer<double>{
         static std::string print() {
-            return std::string("double");
+            return "double";
         }
     };
 
     template <>
     struct type_printer<size_t>{
         static std::string print() {
-            return std::string("size_t");
+            return "size_t";
         }
     };
 
     template <>
     struct type_printer<int>{
         static std::string print() {
-            return std::string("int");
+            return "int";
         }
     };
 

--- a/arbor/memory/device_coordinator.hpp
+++ b/arbor/memory/device_coordinator.hpp
@@ -39,7 +39,7 @@ namespace util {
 
     template <typename T, typename Allocator>
     struct pretty_printer<device_coordinator<T,Allocator>>{
-        static std::string print(const device_coordinator<T,Allocator>& val) {
+        static std::string print(const device_coordinator<T,Allocator>&) {
             return type_printer<device_coordinator<T,Allocator>>::print();
         }
     };
@@ -60,10 +60,11 @@ public:
         return tmp;
     }
 
-protected:
     template <typename Other>
-    void operator =(Other&&) {}
+    const_device_reference& operator=(Other&&) = delete;
 
+
+protected:
     const_pointer pointer_;
 };
 
@@ -228,7 +229,7 @@ public:
     // generates compile time error if there is an attempt to copy from memory
     // that is managed by a coordinator for which there is no specialization
     template <class CoordOther>
-    void copy(const array_view<value_type, CoordOther>& from, view_type& to) {
+    void copy(const array_view<value_type, CoordOther>&, view_type&) {
         static_assert(true, "device_coordinator: unable to copy from other Coordinator");
     }
 

--- a/arbor/memory/gpu_wrappers.cpp
+++ b/arbor/memory/gpu_wrappers.cpp
@@ -87,39 +87,27 @@ LOG_ERROR("memory:: "+std::string(__func__)+"(): no GPU support")
 namespace arb {
 namespace memory {
 
-void gpu_memcpy_d2d(void* dest, const void* src, std::size_t n) {
-    NOGPU;
-}
+void gpu_memcpy_d2d(void* /*dest*/, const void* /*src*/, std::size_t /*n*/) { NOGPU; }
 
-void gpu_memcpy_d2h(void* dest, const void* src, std::size_t n) {
-    NOGPU;
-}
+void gpu_memcpy_d2h(void* /*dest*/, const void* /*src*/, std::size_t /*n*/) { NOGPU; }
 
-void gpu_memcpy_h2d(void* dest, const void* src, std::size_t n) {
-    NOGPU;
-}
+void gpu_memcpy_h2d(void* /*dest*/, const void* /*src*/, std::size_t /*n*/) { NOGPU; }
 
-void gpu_memcpy_h2d_async(void* dest, const void* src, std::size_t n) {
-    NOGPU;
-}
+void gpu_memcpy_h2d_async(void* /*dest*/, const void* /*src*/, std::size_t /*n*/) { NOGPU; }
 
-void* gpu_host_register(void* ptr, std::size_t size) {
+void* gpu_host_register(void*, std::size_t) {
     NOGPU;
     return nullptr;
 }
 
-void gpu_host_unregister(void* ptr) {
-    NOGPU;
-}
+void gpu_host_unregister(void*) { NOGPU; }
 
-void* gpu_malloc(std::size_t n) {
+void* gpu_malloc(std::size_t) {
     NOGPU;
     return nullptr;
 }
 
-void gpu_free(void* ptr) {
-    NOGPU;
-}
+void gpu_free(void*) { NOGPU; }
 
 } // namespace memory
 } // namespace arb

--- a/arbor/memory/gpu_wrappers.cpp
+++ b/arbor/memory/gpu_wrappers.cpp
@@ -105,7 +105,7 @@ void gpu_memcpy_h2d_async(void* dest, const void* src, std::size_t n) {
 
 void* gpu_host_register(void* ptr, std::size_t size) {
     NOGPU;
-    return 0;
+    return nullptr;
 }
 
 void gpu_host_unregister(void* ptr) {
@@ -114,7 +114,7 @@ void gpu_host_unregister(void* ptr) {
 
 void* gpu_malloc(std::size_t n) {
     NOGPU;
-    return 0;
+    return nullptr;
 }
 
 void gpu_free(void* ptr) {

--- a/arbor/memory/host_coordinator.hpp
+++ b/arbor/memory/host_coordinator.hpp
@@ -24,7 +24,7 @@ class device_coordinator;
 
 namespace util {
     template <typename T, typename Allocator>
-    struct type_printer<host_coordinator<T,Allocator>>{
+    struct type_printer<host_coordinator<T, Allocator>>{
         static std::string print() {
             #if VERBOSE>1
             return util::white("host_coordinator") + "<" + type_printer<T>::print()
@@ -36,9 +36,9 @@ namespace util {
     };
 
     template <typename T, typename Allocator>
-    struct pretty_printer<host_coordinator<T,Allocator>>{
-        static std::string print(const host_coordinator<T,Allocator>& val) {
-            return type_printer<host_coordinator<T,Allocator>>::print();;
+    struct pretty_printer<host_coordinator<T, Allocator>>{
+        static std::string print(const host_coordinator<T, Allocator>& /*val*/) {
+            return type_printer<host_coordinator<T, Allocator>>::print();;
         }
     };
 } // namespace util

--- a/arbor/morph/cv_data.cpp
+++ b/arbor/morph/cv_data.cpp
@@ -146,7 +146,7 @@ ARB_ARBOR_API std::optional<cell_cv_data> cv_data(const cable_cell& cell) {
 
 using impl_ptr = std::unique_ptr<cell_cv_data_impl, void (*)(cell_cv_data_impl*)>;
 impl_ptr make_impl(cell_cv_data_impl* c) {
-    return impl_ptr(c, [](cell_cv_data_impl* p){delete p;});
+    return {c, [](cell_cv_data_impl* p){delete p;}};
 }
 
 cell_cv_data::cell_cv_data(const cable_cell& cell, const locset& lset):

--- a/arbor/morph/cv_data.cpp
+++ b/arbor/morph/cv_data.cpp
@@ -88,7 +88,7 @@ cell_cv_data_impl::cell_cv_data_impl(const cable_cell& cell, const locset& lset)
         }
 
         util::sort(cables);
-        util::append(cv_cables, std::move(cables));
+        util::append(cv_cables, cables);
         cv_cables_divs.push_back(cv_cables.size());
         ++cv_index;
     }

--- a/arbor/morph/embed_pwlin.cpp
+++ b/arbor/morph/embed_pwlin.cpp
@@ -227,7 +227,7 @@ mcable_list data_cmp(const std::vector<pw_ratpoly<1, 0>>& f_on_branch, msize_t b
             continue;
         }
         if (op(left_val, val) && op(right_val, val)) {
-            L.push_back({bid, left, right});
+            L.emplace_back(mcable{bid, left, right});
             continue;
         }
 
@@ -235,11 +235,11 @@ mcable_list data_cmp(const std::vector<pw_ratpoly<1, 0>>& f_on_branch, msize_t b
         auto edge = math::lerp(left, right, cable_loc);
 
         if (op(left_val, val)) {
-            L.push_back({bid, left, edge});
+            L.emplace_back(mcable{bid, left, edge});
             continue;
         }
         if (!op(left_val, val)) {
-            L.push_back({bid, edge, right});
+            L.emplace_back(mcable{bid, edge, right});
             continue;
         }
     }

--- a/arbor/morph/embed_pwlin.cpp
+++ b/arbor/morph/embed_pwlin.cpp
@@ -189,9 +189,10 @@ double embed_pwlin::integrate_ixa(const mcable& c) const {
 }
 
 // Integrate piecewise function over a cable:
-
-static pw_constant_fn restrict(const pw_constant_fn& g, double left, double right) {
+namespace {
+pw_constant_fn restrict(const pw_constant_fn& g, double left, double right) {
     return pw_zip_with(g, pw_elements<void>{{left, right}});
+}
 }
 
 double embed_pwlin::integrate_length(const mcable& c, const pw_constant_fn& g) const {

--- a/arbor/morph/label_dict.cpp
+++ b/arbor/morph/label_dict.cpp
@@ -8,6 +8,7 @@
 #include <arbor/morph/region.hpp>
 
 namespace arb {
+using arb::locset;
 
 label_dict& label_dict::add_swc_tags() {
     set("soma", reg::tagged(1));
@@ -21,7 +22,7 @@ size_t label_dict::size() const {
     return locsets_.size() + regions_.size();
 }
 
-label_dict& label_dict::set(const std::string& name, arb::locset ls) {
+label_dict &label_dict::set(const std::string &name, arb::locset ls) {
     if (regions_.count(name) || iexpressions_.count(name)) {
         throw label_type_mismatch(name);
     }

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -10,6 +10,7 @@
 #include <arbor/morph/mprovider.hpp>
 #include <arbor/morph/primitives.hpp>
 #include <arbor/morph/region.hpp>
+#include <utility>
 
 #include "util/cbrng.hpp"
 #include "util/partition.hpp"
@@ -663,7 +664,7 @@ std::ostream& operator<<(std::ostream& o, const lsup_& x) {
 // are also in the region.
 
 struct lrestrict_: locset_tag {
-    explicit lrestrict_(const locset& l, const region& r): ls{l}, reg{r} {}
+    explicit lrestrict_(locset l, region r): ls{std::move(l)}, reg{std::move(r)} {}
     locset ls;
     region reg;
 };

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -548,7 +548,6 @@ ARB_ARBOR_API locset uniform(arb::region reg, unsigned left, unsigned right, uin
 
 mlocation_list thingify_(const uniform_& u, const mprovider& p) {
     mlocation_list L;
-    auto morpho = p.morphology();
     auto embed = p.embedding();
 
     // Thingify the region and store relevant data

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -38,11 +38,11 @@ ARB_ARBOR_API locset nil() {
     return locset{nil_{}};
 }
 
-mlocation_list thingify_(const nil_& x, const mprovider&) {
+mlocation_list thingify_(const nil_&, const mprovider&) {
     return {};
 }
 
-std::ostream& operator<<(std::ostream& o, const nil_& x) {
+std::ostream& operator<<(std::ostream& o, const nil_&) {
     return o << "(locset-nil)";
 }
 
@@ -114,7 +114,7 @@ mlocation_list thingify_(const terminal_&, const mprovider& p) {
     return locs;
 }
 
-std::ostream& operator<<(std::ostream& o, const terminal_& x) {
+std::ostream& operator<<(std::ostream& o, const terminal_&) {
     return o << "(terminal)";
 }
 
@@ -258,11 +258,11 @@ ARB_ARBOR_API locset root() {
     return locset{root_{}};
 }
 
-mlocation_list thingify_(const root_&, const mprovider& p) {
+mlocation_list thingify_(const root_&, const mprovider&) {
     return {mlocation{0, 0.}};
 }
 
-std::ostream& operator<<(std::ostream& o, const root_& x) {
+std::ostream& operator<<(std::ostream& o, const root_&) {
     return o << "(root)";
 }
 
@@ -278,7 +278,7 @@ mlocation_list thingify_(const segments_&, const mprovider& p) {
     return p.embedding().segment_ends();
 }
 
-std::ostream& operator<<(std::ostream& o, const segments_& x) {
+std::ostream& operator<<(std::ostream& o, const segments_&) {
     return o << "(segment-boundaries)";
 }
 

--- a/arbor/morph/morphexcept.cpp
+++ b/arbor/morph/morphexcept.cpp
@@ -10,8 +10,10 @@ namespace arb {
 
 using arb::util::pprintf;
 
-static std::string msize_string(msize_t x) {
+namespace {
+std::string msize_string(msize_t x) {
     return x==mnpos? "mnpos": pprintf("{}", x);
+}
 }
 
 invalid_mlocation::invalid_mlocation(mlocation loc):

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -139,8 +139,8 @@ std::ostream& operator<<(std::ostream& o, const morphology_impl& m) {
 // morphology implementation
 //
 
-morphology::morphology(segment_tree m):
-    impl_(std::make_shared<const morphology_impl>(std::move(m)))
+morphology::morphology(const segment_tree& m):
+    impl_(std::make_shared<const morphology_impl>(m))
 {}
 
 morphology::morphology():
@@ -436,6 +436,7 @@ ARB_ARBOR_API std::vector<mextent> components(const morphology& m, const mextent
     }
 
     std::vector<mextent> components;
+    components.reserve(component_cables.size());
     for (auto& cl: component_cables) {
         components.emplace_back(std::move(cl));
     }

--- a/arbor/morph/morphology.cpp
+++ b/arbor/morph/morphology.cpp
@@ -428,7 +428,7 @@ ARB_ARBOR_API std::vector<mextent> components(const morphology& m, const mextent
         }
         else {
             index = component_cables.size();
-            component_cables.push_back({});
+            component_cables.emplace_back();
         }
 
         component_cables[index].push_back(c);

--- a/arbor/morph/mprovider.cpp
+++ b/arbor/morph/mprovider.cpp
@@ -39,9 +39,9 @@ void mprovider::init() {
 // provided label_dict, and the maps updated accordingly. Post-initialization,
 // label_dict_ptr will be null, and concrete regions/locsets will only be retrieved
 // from the maps established during initialization.
-
+namespace {
 template <typename RegOrLocMap, typename LabelDictMap>
-static const auto& try_lookup(const mprovider& provider, const std::string& name, RegOrLocMap& map, const LabelDictMap* dict_ptr) {
+const auto& try_lookup(const mprovider& provider, const std::string& name, RegOrLocMap& map, const LabelDictMap* dict_ptr) {
     auto it = map.find(name);
     if (it==map.end()) {
         if (dict_ptr) {
@@ -64,6 +64,7 @@ static const auto& try_lookup(const mprovider& provider, const std::string& name
     else {
         return it->second.value();
     }
+}
 }
 
 const mextent& mprovider::region(const std::string& name) const {

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -49,7 +49,7 @@ std::ostream& operator<<(std::ostream& o, const nil_&) {
 // Explicit cable section.
 
 struct cable_: region_tag {
-    explicit cable_(mcable c): cable(std::move(c)) {}
+    explicit cable_(mcable c): cable(c) {}
     mcable cable;
 };
 
@@ -346,7 +346,7 @@ std::ostream& operator<<(std::ostream& o, const proximal_interval_& d) {
         o << "(proximal-interval " << d.end << " " << d.distance << ")";
 }
 
-mextent radius_cmp(const mprovider& p, region r, double val, comp_op op) {
+mextent radius_cmp(const mprovider& p, const region& r, double val, comp_op op) {
     const auto& e = p.embedding();
     auto reg_extent = thingify(r, p);
     msize_t bid = mnpos;

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -2,6 +2,7 @@
 #include <stack>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <arbor/morph/locset.hpp>
@@ -97,7 +98,7 @@ mextent thingify_(const cable_list_& reg, const mprovider& p) {
     if (last_branch>=p.morphology().num_branches()) {
         throw no_such_branch(last_branch);
     }
-    return mextent(reg.cables);
+    return {reg.cables};
 }
 
 std::ostream& operator<<(std::ostream& o, const cable_list_& x) {
@@ -157,7 +158,7 @@ mextent thingify_(const tagged_& reg, const mprovider& p) {
     }
     // NOTE: this should always be true since we traverse things in order.
     arb_assert(util::is_sorted(cables));
-    return mextent(cables);
+    return {cables};
 }
 
 std::ostream& operator<<(std::ostream& o, const tagged_& t) {
@@ -184,7 +185,7 @@ mextent thingify_(const segment_& reg, const mprovider& p) {
     }
 
     mcable_list cables = {e.segment(id)};
-    return mextent(cables);
+    return {cables};
 }
 
 std::ostream& operator<<(std::ostream& o, const segment_& reg) {
@@ -204,9 +205,9 @@ mextent thingify_(const all_&, const mprovider& p) {
     mcable_list branches;
     branches.reserve(nb);
     for (auto i: util::make_span(nb)) {
-        branches.push_back({i,0,1});
+        branches.emplace_back(mcable{i, 0, 1});
     }
-    return mextent(branches);
+    return {branches};
 }
 
 std::ostream& operator<<(std::ostream& o, const all_& t) {
@@ -279,7 +280,7 @@ mextent thingify_(const distal_interval_& reg, const mprovider& p) {
     }
 
     util::sort(L);
-    return mextent(L);
+    return {L};
 }
 
 std::ostream& operator<<(std::ostream& o, const distal_interval_& d) {
@@ -336,7 +337,7 @@ mextent thingify_(const proximal_interval_& reg, const mprovider& p) {
     }
 
     util::sort(L);
-    return mextent(L);
+    return {L};
 }
 
 std::ostream& operator<<(std::ostream& o, const proximal_interval_& d) {
@@ -444,7 +445,7 @@ mextent projection_cmp(const mprovider& p, double v, comp_op op) {
     for (auto i: util::make_span(m.num_branches())) {
         util::append(L, e.projection_cmp(i, val, op));
     }
-    return mextent(L);
+    return {L};
 }
 
 // Region with all segments with projection less than val
@@ -567,7 +568,7 @@ std::ostream& operator<<(std::ostream& o, const named_& x) {
 // Adds all cover points to a region.
 // Ensures that all valid representations of all fork points in the region are included.
 struct super_: region_tag {
-    explicit super_(const region& rg): reg{rg} {}
+    explicit super_(region rg): reg{std::move(rg)} {}
     region reg;
 };
 
@@ -701,7 +702,7 @@ mextent thingify_(const reg_not& P, const mprovider& p) {
         }
     }
 
-    return mextent(result);
+    return {result};
 }
 
 std::ostream& operator<<(std::ostream& o, const reg_not& x) {

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -37,11 +37,11 @@ ARB_ARBOR_API region nil() {
     return region{nil_{}};
 }
 
-mextent thingify_(const nil_& x, const mprovider&) {
+mextent thingify_(const nil_&, const mprovider&) {
     return mextent{};
 }
 
-std::ostream& operator<<(std::ostream& o, const nil_& x) {
+std::ostream& operator<<(std::ostream& o, const nil_&) {
     return o << "(region-nil)";
 }
 
@@ -210,7 +210,7 @@ mextent thingify_(const all_&, const mprovider& p) {
     return {branches};
 }
 
-std::ostream& operator<<(std::ostream& o, const all_& t) {
+std::ostream& operator<<(std::ostream& o, const all_&) {
     return o << "(all)";
 }
 

--- a/arbor/morph/stitch.cpp
+++ b/arbor/morph/stitch.cpp
@@ -169,7 +169,7 @@ stitched_morphology::stitched_morphology(const stitch_builder& builder):
 stitched_morphology::stitched_morphology(stitched_morphology&& other) = default;
 
 arb::morphology stitched_morphology::morphology() const {
-    return arb::morphology(impl_->stree);
+    return {impl_->stree};
 }
 
 label_dict stitched_morphology::labels(const std::string& prefix) const {
@@ -206,7 +206,7 @@ std::vector<msize_t> stitched_morphology::segments(const std::string& id) const 
     auto seg_ids = util::transform_view(util::make_range(impl_->id_to_segs.equal_range(id)), util::second);
     if (seg_ids.empty()) throw no_such_stitch(id);
 
-    return std::vector<msize_t>(begin(seg_ids), end(seg_ids));
+    return {begin(seg_ids), end(seg_ids)};
 }
 
 stitched_morphology::~stitched_morphology() = default;

--- a/arbor/morph/stitch.cpp
+++ b/arbor/morph/stitch.cpp
@@ -115,8 +115,8 @@ struct stitch_builder_impl {
 
 stitch_builder::stitch_builder(): impl_(new stitch_builder_impl) {}
 
-stitch_builder::stitch_builder(stitch_builder&&) = default;
-stitch_builder& stitch_builder::operator=(stitch_builder&&) = default;
+stitch_builder::stitch_builder(stitch_builder&&) noexcept = default;
+stitch_builder& stitch_builder::operator=(stitch_builder&&) noexcept = default;
 
 stitch_builder& stitch_builder::add(mstitch f, const std::string& parent_id, double along) {
     impl_->add(std::move(f), parent_id, along);
@@ -166,7 +166,7 @@ stitched_morphology::stitched_morphology(const stitch_builder& builder):
     impl_(new stitched_morphology_impl(*builder.impl_))
 {}
 
-stitched_morphology::stitched_morphology(stitched_morphology&& other) = default;
+stitched_morphology::stitched_morphology(stitched_morphology&& other) noexcept = default;
 
 arb::morphology stitched_morphology::morphology() const {
     return {impl_->stree};

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -7,7 +7,6 @@
 #include <arbor/domain_decomposition.hpp>
 #include <arbor/load_balance.hpp>
 #include <arbor/recipe.hpp>
-#include <arbor/symmetric_recipe.hpp>
 #include <arbor/context.hpp>
 
 #include "cell_group_factory.hpp"

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -226,7 +226,7 @@ ARB_ARBOR_API domain_decomposition partition_load_balance(
     // global all-to-all to gather a local copy of the global gid list on each node.
     auto global_gids = dist->gather_gids(local_gids);
 
-    return domain_decomposition(rec, ctx, groups);
+    return {rec, ctx, groups};
 }
 
 } // namespace arb

--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -172,6 +172,7 @@ ARB_ARBOR_API domain_decomposition partition_load_balance(
     };
 
     std::vector<cell_kind> kinds;
+    kinds.reserve(kind_lists.size());
     for (auto l: kind_lists) {
         kinds.push_back(cell_kind(l.first));
     }

--- a/arbor/profile/clock.cpp
+++ b/arbor/profile/clock.cpp
@@ -1,5 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
-#include <time.h>
+#include <ctime>
 
 // Keep implementation out of header in order to avoid
 // global namespace pollution from <time.h>.

--- a/arbor/profile/meter_manager.cpp
+++ b/arbor/profile/meter_manager.cpp
@@ -109,12 +109,11 @@ ARB_ARBOR_API meter_report make_meter_report(const meter_manager& manager, conte
     meter_report report;
 
     // Add the times to the meter outputs
-    report.meters.push_back(measurement("time", "s", manager.times(), ctx));
+    report.meters.emplace_back("time", "s", manager.times(), ctx);
 
     // Gather the meter outputs.
     for (auto& m: manager.meters()) {
-        report.meters.push_back(
-            measurement(m->name(), m->units(), m->measurements(), ctx));
+        report.meters.emplace_back(m->name(), m->units(), m->measurements(), ctx);
     }
 
     // Gather a vector with the names of the node that each rank is running on.

--- a/arbor/profile/profiler.cpp
+++ b/arbor/profile/profiler.cpp
@@ -275,10 +275,10 @@ profile_node make_profile_tree(const profile& p) {
 
     // Build a tree description of the regions and sub-regions in the profile.
     profile_node tree("root");
-    for (auto idx: make_span(0, p.names.size())) {
+    for (auto idx: util::make_span(0, p.names.size())) {
         profile_node* node = &tree;
         const auto depth  = names[idx].size();
-        for (auto i: make_span(0, depth-1)) {
+        for (auto i: util::make_span(0, depth-1)) {
             auto& node_name = names[idx][i];
             auto& kids = node->children;
 

--- a/arbor/profile/profiler.cpp
+++ b/arbor/profile/profiler.cpp
@@ -14,7 +14,6 @@ namespace arb {
 namespace profile {
 
 using timer_type = timer<>;
-using util::make_span;
 
 #ifdef ARB_HAVE_PROFILING
 namespace {
@@ -421,10 +420,10 @@ ARB_ARBOR_API std::ostream& print_profiler_summary(std::ostream& os, double limi
 ARB_ARBOR_API void profiler_leave() {}
 ARB_ARBOR_API void profiler_enter(region_id_type) {}
 ARB_ARBOR_API profile profiler_summary();
-ARB_ARBOR_API profile profiler_summary() {return profile();}
+ARB_ARBOR_API profile profiler_summary() {return {};}
 ARB_ARBOR_API region_id_type profiler_region_id(const std::string&) {return 0;}
 ARB_ARBOR_API std::ostream& operator<<(std::ostream& o, const profile&) {return o;}
-ARB_ARBOR_API std::ostream& profiler_print_summary(std::ostream& os, double limit) { return os; }
+ARB_ARBOR_API std::ostream& profiler_print_summary(std::ostream& os, double) { return os; }
 
 
 #endif // ARB_HAVE_PROFILING

--- a/arbor/profile/profiler.cpp
+++ b/arbor/profile/profiler.cpp
@@ -239,7 +239,7 @@ profile profiler::results() const {
     p.counts = std::vector<region_id_type>(nregions);
     for (auto& r: recorders_) {
         auto& accumulators = r.accumulators();
-        for (auto i: make_span(0, accumulators.size())) {
+        for (auto i: util::make_span(0, accumulators.size())) {
             p.times[i]  += accumulators[i].time;
             p.counts[i] += accumulators[i].count;
         }

--- a/arbor/s_expr.cpp
+++ b/arbor/s_expr.cpp
@@ -483,7 +483,7 @@ s_expr parse(lexer& L) {
             else if (t.kind == tok::lparen) {
                 auto e = parse(L);
                 if (e.is_atom() && e.atom().kind==tok::error) return e;
-                *n = {std::move(e), {}};
+                *n = {e, {}};
                 t = L.current();
             }
             else {

--- a/arbor/s_expr.cpp
+++ b/arbor/s_expr.cpp
@@ -88,15 +88,15 @@ static std::unordered_map<std::string, tok> keyword_to_tok = {
 };
 
 class lexer {
-    const char* line_start_;
-    const char* stream_;
-    unsigned line_;
+    const char* line_start_ = nullptr;
+    const char* stream_ = nullptr;
+    unsigned line_{0};
     token token_;
 
 public:
 
     lexer(const char* begin):
-        line_start_(begin), stream_(begin), line_(0)
+        line_start_(begin), stream_(begin)
     {
         // Prime the first token.
         parse();
@@ -115,7 +115,7 @@ public:
 private:
 
     src_location loc() const {
-        return src_location(line_+1, stream_-line_start_+1);
+        return {line_+1, static_cast<unsigned>(stream_-line_start_+1)};
     }
 
     bool empty() const {
@@ -268,7 +268,7 @@ private:
 
         symbol += c;
         ++stream_;
-        while(1) {
+        for(;;) {
             c = *stream_;
 
             if(is_valid_symbol_char(c)) {
@@ -321,7 +321,7 @@ private:
 
         str += c;
         ++stream_;
-        while(1) {
+        for(;;) {
             c = *stream_;
             if (std::isdigit(c)) {
                 str += c;

--- a/arbor/s_expr.cpp
+++ b/arbor/s_expr.cpp
@@ -79,13 +79,10 @@ struct s_expr_lexer_error: public arb::arbor_internal_error {
     {}
 };
 
-static std::unordered_map<tok, const char*> tok_to_keyword = {
-    {tok::nil,    "nil"},
-};
-
-static std::unordered_map<std::string, tok> keyword_to_tok = {
-    {"nil",    tok::nil},
-};
+namespace {
+std::unordered_map<tok, const char*> tok_to_keyword = {{tok::nil,    "nil"}};
+std::unordered_map<std::string, tok> keyword_to_tok = {{"nil",    tok::nil}};
+}
 
 class lexer {
     const char* line_start_ = nullptr;

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -91,7 +91,7 @@ ARB_ARBOR_API void merge_cell_events(
 
 class simulation_state {
 public:
-    simulation_state(const recipe& rec, const domain_decomposition& decomp, context ctx, arb_seed_type seed);
+    simulation_state(const recipe& rec, const domain_decomposition& decomp, const context& ctx, arb_seed_type seed);
 
     void update(const connectivity& rec);
 
@@ -193,7 +193,7 @@ private:
 simulation_state::simulation_state(
         const recipe& rec,
         const domain_decomposition& decomp,
-        context ctx,
+        const context& ctx,
         arb_seed_type seed
     ):
     ctx_{ctx},
@@ -233,8 +233,8 @@ simulation_state::simulation_state(
     PL();
 
     PE(init:simulation:resolvers);
-    source_resolution_map_ = label_resolution_map(std::move(global_sources));
-    target_resolution_map_ = label_resolution_map(std::move(local_targets));
+    source_resolution_map_ = label_resolution_map(global_sources);
+    target_resolution_map_ = label_resolution_map(local_targets);
     PL();
 
     PE(init:simulation:comm);
@@ -591,7 +591,7 @@ void simulation::inject_events(const cse_vector& events) {
     impl_->inject_events(events);
 }
 
-simulation::simulation(simulation&&) = default;
+simulation::simulation(simulation&&) noexcept = default;
 
 simulation::~simulation() = default;
 

--- a/arbor/spike_source_cell_group.cpp
+++ b/arbor/spike_source_cell_group.cpp
@@ -45,7 +45,7 @@ cell_kind spike_source_cell_group::get_cell_kind() const {
     return cell_kind::spike_source;
 }
 
-void spike_source_cell_group::advance(epoch ep, time_type dt, const event_lane_subrange& event_lanes) {
+void spike_source_cell_group::advance(epoch ep, time_type, const event_lane_subrange&) {
     PE(advance:sscell);
 
     for (auto i: util::count_along(gids_)) {

--- a/arbor/symmetric_recipe.cpp
+++ b/arbor/symmetric_recipe.cpp
@@ -29,8 +29,8 @@ std::vector<cell_connection> symmetric_recipe::connections_on(cell_gid_type i) c
 
     std::vector<cell_connection> conns = tiled_recipe_->connections_on(i % n_local);
 
-    for (unsigned j = 0; j < conns.size(); j++) {
-        conns[j].source.gid = (conns[j].source.gid + offset) % n_global;
+    for (auto& conn: conns) {
+        conn.source.gid = (conn.source.gid + offset) % n_global;
     }
     return conns;
 }

--- a/arbor/thread_private_spike_store.cpp
+++ b/arbor/thread_private_spike_store.cpp
@@ -16,7 +16,7 @@ struct local_spike_store_type {
     local_spike_store_type(const task_system_handle& ts): buffers_(ts) {};
 };
 
-thread_private_spike_store::thread_private_spike_store(thread_private_spike_store&& t):
+thread_private_spike_store::thread_private_spike_store(thread_private_spike_store&& t) noexcept:
     impl_(std::move(t.impl_))
 {}
 

--- a/arbor/thread_private_spike_store.hpp
+++ b/arbor/thread_private_spike_store.hpp
@@ -24,7 +24,7 @@ public :
     thread_private_spike_store() = default;
     ~thread_private_spike_store();
 
-    thread_private_spike_store(thread_private_spike_store&& t);
+    thread_private_spike_store(thread_private_spike_store&& t) noexcept;
     thread_private_spike_store(const task_system_handle& ts);
 
     /// Collate all of the individual buffers into a single vector of spikes.

--- a/arbor/threading/threading.hpp
+++ b/arbor/threading/threading.hpp
@@ -25,13 +25,13 @@ using std::condition_variable;
 using task = std::function<void()>;
 
 // Tasks with priority higher than max_async_task_priority will be run synchronously.
-constexpr int max_async_task_priority = 1;
+constexpr unsigned max_async_task_priority = 1;
 
 // Wrap task and priority; provide move/release/reset operations and reset on run()
 // to help ensure no wrapped task is run twice.
 struct priority_task {
     task t;
-    int priority = -1;
+    unsigned priority = 0;
 
     priority_task() = default;
     priority_task(task&& t, int priority): t(std::move(t)), priority(priority) {}
@@ -72,7 +72,7 @@ namespace impl {
 
 class ARB_ARBOR_API notification_queue {
     // Number of priority levels in notification queues.
-    static constexpr int n_priority = max_async_task_priority+1;
+    static constexpr unsigned n_priority = max_async_task_priority+1;
 
 public:
     // Tries to acquire the lock to get a task of a requested priority.
@@ -125,7 +125,7 @@ private:
 class ARB_ARBOR_API task_system {
 private:
     // Number of notification queues.
-    unsigned count_;
+    unsigned count_ = 1;
     // Attempt to bind threads?
     bool bind_ = false;
     // Worker threads.
@@ -143,7 +143,7 @@ private:
     static thread_local unsigned current_task_queue_;
 
     // Number of priority levels in notification queues.
-    static constexpr int n_priority = max_async_task_priority+1;
+    static constexpr unsigned n_priority = max_async_task_priority+1;
 
     // Notification queues containing n_priority deques representing
     // different priority levels.

--- a/arbor/threading/threading.hpp
+++ b/arbor/threading/threading.hpp
@@ -246,14 +246,14 @@ private:
         void set(std::exception_ptr ex) {
             error_.store(true, std::memory_order_relaxed);
             lock ex_lock{mutex_};
-            exception_ = std::move(ex);
+            exception_ = ex;
         }
 
         // Clear exception state but return old state.
         // For consistency, this must only be called when there
         // are no tasks in flight that reference this exception state.
         std::exception_ptr reset() {
-            auto ex = std::move(exception_);
+            auto ex = exception_;
             error_.store(false, std::memory_order_relaxed);
             exception_ = nullptr;
             return ex;
@@ -294,7 +294,7 @@ public:
                 exception_status_(ex)
         {}
 
-        wrap(wrap&& other):
+        wrap(wrap&& other) noexcept:
                 f_(std::move(other.f_)),
                 counter_(other.counter_),
                 exception_status_(other.exception_status_)

--- a/arbor/timestep_range.hpp
+++ b/arbor/timestep_range.hpp
@@ -95,7 +95,7 @@ public: // ctors, assignment, reset
         dt = dt < 0 ? (t1-t0) : dt;
         dt_ = std::max(std::numeric_limits<time_type>::min(), dt);
         const time_type delta = (t1<=t0)? 0: t1-t0;
-        const size_type m = static_cast<size_type>(delta/dt_);
+        const auto m = static_cast<size_type>(delta/dt_);
         // Allow slightly larger time steps at the end of the epoch in order to avoid tiny time
         // steps, if the the last time step m*dt_ is at most m floating point representations
         // smaller than t1_. The tolerable floating point range is approximated by the scaled

--- a/arbor/tree.cpp
+++ b/arbor/tree.cpp
@@ -13,7 +13,7 @@
 
 namespace arb {
 
-tree::tree(std::vector<tree::int_type> parent_index) {
+tree::tree(const std::vector<tree::int_type>& parent_index) {
     // validate the input
     if(!is_minimal_degree(parent_index)) {
         throw std::domain_error(

--- a/arbor/tree.hpp
+++ b/arbor/tree.hpp
@@ -27,7 +27,7 @@ public:
 
     /// Create the tree from a parent index that lists the parent segment
     /// of each segment in a cell tree.
-    tree(std::vector<int_type> parent_index);
+    tree(const std::vector<int_type>& parent_index);
 
     size_type num_children() const;
 

--- a/arbor/util/cbrng.hpp
+++ b/arbor/util/cbrng.hpp
@@ -7,6 +7,7 @@
 namespace arb {
 namespace util {
 
+inline
 std::vector<double> uniform(uint64_t seed, unsigned left, unsigned right) {
     typedef r123::Threefry2x64 cbrng;
     std::vector<double> r;
@@ -36,6 +37,5 @@ std::vector<double> uniform(uint64_t seed, unsigned left, unsigned right) {
     }
     return r;
 }
-
 }
 }

--- a/arbor/util/counter.hpp
+++ b/arbor/util/counter.hpp
@@ -21,7 +21,7 @@ struct counter {
     counter(V v): v_{v} {}
 
     counter(const counter&) = default;
-    counter(counter&&) = default;
+    counter(counter&&) noexcept = default;
 
     counter& operator++() {
         ++v_;
@@ -85,7 +85,7 @@ struct counter {
     bool operator>(counter x) const { return v_>x.v_; }
 
     counter& operator=(const counter&) = default;
-    counter& operator=(counter&&) = default;
+    counter& operator=(counter&&) noexcept = default;
 
 private:
     V v_;

--- a/arbor/util/filter.hpp
+++ b/arbor/util/filter.hpp
@@ -98,7 +98,7 @@ public:
         f_.construct(other.f_.cref());
     }
 
-    filter_iterator(filter_iterator&& other):
+    filter_iterator(filter_iterator&& other) noexcept:
         inner_(std::move(other.inner_)),
         end_(std::move(other.end_)),
         ok_{other.ok_}
@@ -106,7 +106,7 @@ public:
         f_.construct(std::move(other.f_.ref()));
     }
 
-    filter_iterator& operator=(filter_iterator&& other) {
+    filter_iterator& operator=(filter_iterator&& other) noexcept {
         if (this!=&other) {
             inner_ = std::move(other.inner_);
             end_ = std::move(other.end_);

--- a/arbor/util/ordered_forest.hpp
+++ b/arbor/util/ordered_forest.hpp
@@ -452,7 +452,7 @@ public:
         return *this;
     }
 
-    ordered_forest& operator=(ordered_forest&& other) {
+    ordered_forest& operator=(ordered_forest&& other) noexcept {
         if (this==&other) return *this;
         delete_node(first_);
 

--- a/arbor/util/padded_alloc.hpp
+++ b/arbor/util/padded_alloc.hpp
@@ -68,7 +68,7 @@ struct padded_allocator {
         return static_cast<pointer>(mem);
     }
 
-    void deallocate(pointer p, std::size_t n) {
+    void deallocate(pointer p, std::size_t) {
         std::free(p);
     }
 

--- a/arbor/util/partition.hpp
+++ b/arbor/util/partition.hpp
@@ -120,7 +120,7 @@ partition_range<SeqIter> partition_view(const Seq& r) {
  */
 
 struct partition_in_place_t {
-    constexpr partition_in_place_t() {}
+    constexpr partition_in_place_t() = default;
 };
 
 constexpr partition_in_place_t partition_in_place;

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -121,7 +121,7 @@ struct pw_element {
     {}
 
     pw_element(const pw_element&) = default;
-    pw_element(pw_element&&) = default;
+    pw_element(pw_element&&) noexcept = default;
 
     operator X() const { return value; }
     pw_element& operator=(X x) { value = std::move(x); return *this; };
@@ -268,7 +268,7 @@ struct pw_elements {
         assign(vs, es);
     }
 
-    pw_elements(pw_elements&&) = default;
+    pw_elements(pw_elements&&) noexcept = default;
     pw_elements(const pw_elements&) = default;
 
     template <typename Y>
@@ -276,7 +276,7 @@ struct pw_elements {
         vertex_(from.vertex_), value_(from.value_.begin(), from.value_.end())
     {}
 
-    pw_elements& operator=(pw_elements&&) = default;
+    pw_elements& operator=(pw_elements&&) noexcept = default;
     pw_elements& operator=(const pw_elements&) = default;
 
     // Access:

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -172,6 +172,7 @@ struct pw_element_proxy {
 // Compute indices into vertex set corresponding to elements that cover a point x:
 
 namespace {
+inline
 std::pair<std::ptrdiff_t, std::ptrdiff_t> equal_range_indices(const std::vector<double>& vertices, double x) {
     if (vertices.empty()) return {0, 0};
 

--- a/arbor/util/range.hpp
+++ b/arbor/util/range.hpp
@@ -52,7 +52,7 @@ struct range {
 
     range() = default;
     range(const range&) = default;
-    range(range&&) = default;
+    range(range&&) noexcept = default;
 
     template <typename U1, typename U2>
     range(U1&& l, U2&& r):
@@ -76,7 +76,7 @@ struct range {
     {}
 
     range& operator=(const range&) = default;
-    range& operator=(range&&) = default;
+    range& operator=(range&&) noexcept = default;
 
     template <typename U1, typename U2>
     range& operator=(const range<U1, U2>& other) {

--- a/arbor/util/sentinel.hpp
+++ b/arbor/util/sentinel.hpp
@@ -178,12 +178,12 @@ using sentinel_iterator_t =
     std::conditional_t<std::is_same<I, S>::value, I, sentinel_iterator<I, S>>;
 
 template <typename I, typename S>
-sentinel_iterator_t<I, S> make_sentinel_iterator(const I& i, const S& s) {
+sentinel_iterator_t<I, S> make_sentinel_iterator(const I& i, const S&) {
     return sentinel_iterator_t<I, S>(i);
 }
 
 template <typename I, typename S>
-sentinel_iterator_t<I, S> make_sentinel_end(const I& i, const S& s) {
+sentinel_iterator_t<I, S> make_sentinel_end(const I&, const S& s) {
     return sentinel_iterator_t<I, S>(s);
 }
 

--- a/arbor/util/sentinel.hpp
+++ b/arbor/util/sentinel.hpp
@@ -64,10 +64,10 @@ public:
 
     sentinel_iterator() = default;
     sentinel_iterator(const sentinel_iterator&) = default;
-    sentinel_iterator(sentinel_iterator&&) = default;
+    sentinel_iterator(sentinel_iterator&&) noexcept = default;
 
     sentinel_iterator& operator=(const sentinel_iterator&) = default;
-    sentinel_iterator& operator=(sentinel_iterator&&) = default;
+    sentinel_iterator& operator=(sentinel_iterator&&) noexcept = default;
 
     // forward and input iterator requirements
 

--- a/arbor/util/strprintf.hpp
+++ b/arbor/util/strprintf.hpp
@@ -67,12 +67,12 @@ std::string strprintf(const char* fmt, Args&&... args) {
     thread_local static std::vector<char> buffer(1024);
 
     for (;;) {
-        int n = std::snprintf(buffer.data(), buffer.size(), fmt, impl::sprintf_arg_translate(std::forward<Args>(args))...);
+        auto n = std::snprintf(buffer.data(), buffer.size(), fmt, impl::sprintf_arg_translate(std::forward<Args>(args))...);
         if (n<0) {
             throw std::system_error(errno, std::generic_category());
         }
         else if ((unsigned)n<buffer.size()) {
-            return std::string(buffer.data(), n);
+            return {buffer.data(), static_cast<std::size_t>(n)};
         }
         buffer.resize(2*n);
     }

--- a/arbor/util/transform.hpp
+++ b/arbor/util/transform.hpp
@@ -59,11 +59,11 @@ public:
         f_.construct(other.f_.cref());
     }
 
-    transform_iterator(transform_iterator&& other): inner_(std::move(other.inner_)) {
+    transform_iterator(transform_iterator&& other) noexcept: inner_(std::move(other.inner_)) {
         f_.construct(std::move(other.f_.ref()));
     }
 
-    transform_iterator& operator=(transform_iterator&& other) {
+    transform_iterator& operator=(transform_iterator&& other) noexcept {
         if (this!=&other) {
             inner_ = std::move(other.inner_);
             f_.construct(std::move(other.f_.ref()));

--- a/arbor/util/unwind.cpp
+++ b/arbor/util/unwind.cpp
@@ -15,26 +15,35 @@
 namespace arb {
 namespace util {
 
-backtrace::backtrace() {
 #ifdef WITH_BACKTRACE
+backtrace::backtrace() {
     auto bt = boost::stacktrace::basic_stacktrace{};
     for (const auto& f: bt) {
         frames_.push_back(source_location{f.name(), f.source_file(), f.source_line()});
     }
-#endif
+
 }
 
 std::ostream& operator<<(std::ostream& out, const backtrace& trace) {
-#ifdef WITH_BACKTRACE
     out << "Backtrace:\n";
     int ix = 0;
     for (const auto& f: trace.frames_) {
         out << std::setw(8) << ix << " " << f.func << " (" << f.file << ":" << f.line << ")\n";
         ix++;
     }
-#endif
     return out;
 }
+
+#else
+
+backtrace::backtrace() = default;
+
+std::ostream& operator<<(std::ostream& out, const backtrace&) {
+    out << "Backtrace disabled\n";
+    return out;
+}
+
+#endif
 
 backtrace& backtrace::pop(std::size_t n) {
     frames_.erase(frames_.begin(),

--- a/arborenv/arbenvexcept.cpp
+++ b/arborenv/arbenvexcept.cpp
@@ -6,6 +6,7 @@
 using namespace std::literals;
 
 namespace arbenv {
+using std::string;
 
 invalid_env_value::invalid_env_value(const std::string& variable, const std::string& value):
     arborenv_exception("environment variable \""s + variable + R"(" has invalid value ")" + value + "\""s),
@@ -20,8 +21,7 @@ no_such_gpu::no_such_gpu(int gpu_id):
     gpu_id(gpu_id)
 {}
 
-gpu_uuid_error::gpu_uuid_error(std::string what):
-    arborenv_exception("error determining GPU uuids: "s+what)
-{}
+gpu_uuid_error::gpu_uuid_error(const string& what)
+    : arborenv_exception("error determining GPU uuids: "s + what) {}
 
 } // namespace arbenv

--- a/arborenv/arbenvexcept.cpp
+++ b/arborenv/arbenvexcept.cpp
@@ -8,7 +8,7 @@ using namespace std::literals;
 namespace arbenv {
 
 invalid_env_value::invalid_env_value(const std::string& variable, const std::string& value):
-    arborenv_exception("environment variable \""s+variable+"\" has invalid value \""s+value+"\""s),
+    arborenv_exception("environment variable \""s + variable + R"(" has invalid value ")" + value + "\""s),
     env_variable(variable),
     env_value(value)
 {}

--- a/arborenv/include/arborenv/arbenvexcept.hpp
+++ b/arborenv/include/arborenv/arbenvexcept.hpp
@@ -33,7 +33,7 @@ struct ARB_SYMBOL_VISIBLE no_such_gpu: arborenv_exception {
 };
 
 struct ARB_SYMBOL_VISIBLE gpu_uuid_error: arborenv_exception {
-    gpu_uuid_error(std::string what);
+    gpu_uuid_error(const std::string& what);
 };
 
 } // namespace arbenv

--- a/arborenv/read_envvar.cpp
+++ b/arborenv/read_envvar.cpp
@@ -11,11 +11,12 @@ using namespace std::literals;
 
 namespace arbenv {
 
-static std::optional<long long> read_env_integer_(const char* env_var, bool throw_on_err) {
+namespace {
+std::optional<long long> read_env_integer_(const char* env_var, bool throw_on_err) {
     const char* str = std::getenv(env_var);
     if (!str || !*str) return std::nullopt;
 
-    char* end = 0;
+    char* end = nullptr;
     errno = 0;
     long long v = std::strtoll(str, &end, 10);
     bool out_of_range = errno==ERANGE;
@@ -36,6 +37,7 @@ static std::optional<long long> read_env_integer_(const char* env_var, bool thro
     }
 
     return v;
+}
 }
 
 std::optional<long long> read_env_integer(const char* env_var) {

--- a/arborio/asc_lexer.cpp
+++ b/arborio/asc_lexer.cpp
@@ -82,13 +82,13 @@ inline bool is_valid_symbol_char(char c) {
 class lexer_impl {
     const char* line_start_;
     const char* stream_;
-    unsigned line_;
+    unsigned line_ = 0;
     token token_;
 
 public:
 
     lexer_impl(const char* begin):
-        line_start_(begin), stream_(begin), line_(0)
+        line_start_(begin), stream_(begin)
     {
         // Prime the first token.
         parse();
@@ -125,9 +125,7 @@ public:
 
 private:
 
-    src_location loc() const {
-        return src_location(line_+1, stream_-line_start_+1);
-    }
+    src_location loc() const { return {line_ + 1, static_cast<unsigned>(stream_ - line_start_ + 1)}; }
 
     bool empty() const {
         return *stream_ == '\0';
@@ -294,7 +292,7 @@ private:
 
         symbol += c;
         ++stream_;
-        while(1) {
+        for (;;) {
             c = *stream_;
 
             if(is_valid_symbol_char(c)) {
@@ -341,7 +339,7 @@ private:
 
         str += c;
         ++stream_;
-        while(1) {
+        for (;;) {
             c = *stream_;
             if (std::isdigit(c)) {
                 str += c;

--- a/arborio/cableio.cpp
+++ b/arborio/cableio.cpp
@@ -339,7 +339,7 @@ morphology make_morphology(const std::vector<std::variant<branch_tuple>>& args) 
     for (const auto& [seg, s_pid]: segs) {
         tree.append(s_pid, seg.prox, seg.dist, seg.tag);
     }
-    return morphology(tree);
+    return {tree};
 }
 
 // Define cable-cell maker
@@ -355,7 +355,7 @@ cable_cell make_cable_cell(const std::vector<std::variant<morphology, label_dict
             [&](const decor & p){ dec = p; });
         std::visit(cable_cell_visitor, a);
     }
-    return cable_cell(morpho, dec, dict);
+    return {morpho, dec, dict};
 }
 version_tuple make_version(const std::string& v) {
     return version_tuple{v};

--- a/arborio/cableio.cpp
+++ b/arborio/cableio.cpp
@@ -538,6 +538,10 @@ template <typename... Args>
 struct make_unordered_call {
     evaluator state;
 
+    make_unordered_call() = delete;
+    make_unordered_call(const make_unordered_call&) = delete;
+    make_unordered_call(make_unordered_call&&) = delete;
+
     template <typename F>
     make_unordered_call(F&& f, const char* msg="call"):
         state(arg_vec_eval<Args...>(std::forward<F>(f)), unordered_match<Args...>(), msg)

--- a/arborio/cableio.cpp
+++ b/arborio/cableio.cpp
@@ -148,15 +148,15 @@ s_expr mksexp(const label_dict& dict) {
     };
     auto defs = slist();
     for (auto& r: dict.locsets()) {
-        defs = s_expr(slist("locset-def"_symbol, s_expr(r.first), round_trip(r.second)), std::move(defs));
+        defs = s_expr(slist("locset-def"_symbol, s_expr(r.first), round_trip(r.second)), defs);
     }
     for (auto& r: dict.regions()) {
-        defs = s_expr(slist("region-def"_symbol, s_expr(r.first), round_trip(r.second)), std::move(defs));
+        defs = s_expr(slist("region-def"_symbol, s_expr(r.first), round_trip(r.second)), defs);
     }
     for (auto& r: dict.iexpressions()) {
-        defs = s_expr(slist("iexpr-def"_symbol, s_expr(r.first), round_trip(r.second)), std::move(defs));
+        defs = s_expr(slist("iexpr-def"_symbol, s_expr(r.first), round_trip(r.second)), defs);
     }
-    return {"label-dict"_symbol, std::move(defs)};
+    return {"label-dict"_symbol, defs};
 }
 s_expr mksexp(const morphology& morph) {
     // s-expression representation of branch i in the morphology

--- a/arborio/cv_policy_parse.cpp
+++ b/arborio/cv_policy_parse.cpp
@@ -68,10 +68,10 @@ eval_map {{"default",
            make_call<locset, region>([] (const locset& l, const region& r) { return arb::cv_policy{arb::cv_policy_explicit(l, r) }; },
                                      "'explicit' with two arguments (explicit (ls:locset) (reg:region))")},
           {"join",
-           make_fold<cv_policy>([](cv_policy l, cv_policy r) { return l + r; },
+           make_fold<cv_policy>([](const cv_policy& l, const cv_policy& r) { return l + r; },
                                 "'join' with at least 2 arguments: (join cv_policy cv_policy ...)")},
           {"replace",
-           make_fold<cv_policy>([](cv_policy l, cv_policy r) { return l | r; },
+           make_fold<cv_policy>([](const cv_policy& l, const cv_policy& r) { return l | r; },
                                 "'replace' with at least 2 arguments: (replace cv_policy cv_policy ...)")},
 };
 

--- a/arborio/include/arborio/label_parse.hpp
+++ b/arborio/include/arborio/label_parse.hpp
@@ -11,6 +11,7 @@
 
 #include <arbor/s_expr.hpp>
 #include <arborio/export.hpp>
+#include <utility>
 
 namespace arborio {
 
@@ -32,7 +33,7 @@ ARB_ARBORIO_API parse_label_hopefully<arb::iexpr> parse_iexpr_expression(const s
 namespace literals {
 
 struct morph_from_string {
-    morph_from_string(const std::string& s): str{s} {}
+    morph_from_string(std::string s): str{std::move(s)} {}
     morph_from_string(const char* s): str{s} {}
 
     std::string str;
@@ -49,7 +50,7 @@ struct morph_from_string {
 };
 
 struct morph_from_label {
-    morph_from_label(const std::string& s): str{s} {}
+    morph_from_label(std::string s): str{std::move(s)} {}
     morph_from_label(const char* s): str{s} {}
 
     std::string str;

--- a/arborio/include/arborio/neurolucida.hpp
+++ b/arborio/include/arborio/neurolucida.hpp
@@ -48,7 +48,7 @@ ARB_ARBORIO_API asc_morphology parse_asc_string(const char* input);
 ARB_ARBORIO_API arb::segment_tree parse_asc_string_raw(const char* input);
 
 // Load asc morphology from file with name filename.
-ARB_ARBORIO_API asc_morphology load_asc(std::string filename);
-ARB_ARBORIO_API arb::segment_tree load_asc_raw(std::string filename);
+ARB_ARBORIO_API asc_morphology load_asc(const std::string& filename);
+ARB_ARBORIO_API arb::segment_tree load_asc_raw(const std::string& filename);
 
 } // namespace arborio

--- a/arborio/include/arborio/neuroml.hpp
+++ b/arborio/include/arborio/neuroml.hpp
@@ -112,10 +112,10 @@ struct ARB_ARBORIO_API neuroml {
     neuroml();
     explicit neuroml(std::string nml_document);
 
-    neuroml(neuroml&&);
+    neuroml(neuroml&&) noexcept;
     neuroml(const neuroml&) = delete;
 
-    neuroml& operator=(neuroml&&);
+    neuroml& operator=(neuroml&&) noexcept;
     neuroml& operator=(const neuroml&) = delete;
 
     // Query top-level cells and (standalone) morphologies.

--- a/arborio/neurolucida.cpp
+++ b/arborio/neurolucida.cpp
@@ -285,7 +285,7 @@ parse_hopefully<zsmear> parse_zsmear(asc::lexer& L) {
     return s;
 }
 
-#define PARSE_ZSMEAR(L, X) if (auto rval__ = parse_zsmear(L)) X=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());
+#define PARSE_ZSMEAR(L, X) 
 
 parse_hopefully<arb::mpoint> parse_point(asc::lexer& L) {
     // check and consume opening paren
@@ -562,7 +562,12 @@ parse_hopefully<sub_tree> parse_sub_tree(asc::lexer& L) {
             }
             // Ignore zSmear.
             else if (symbol_matches("zSmear", t)) {
-                PARSE_ZSMEAR(L, __attribute__((unused)) auto _);
+                if (auto rval = parse_zsmear(L)) {
+                    __attribute__((unused)) auto _ =*rval;
+                }
+                else {
+                    return FORWARD_PARSE_ERROR(rval.error());
+                }
             }
             else if (t.kind==tok::integer || t.kind==tok::real) {
                 // Assume that this is the first sample.

--- a/arborio/neurolucida.cpp
+++ b/arborio/neurolucida.cpp
@@ -95,7 +95,7 @@ parse_hopefully<double> parse_double(asc::lexer& L) {
     return std::stod(t.spelling);
 }
 
-#define PARSE_DOUBLE(L, X) {if (auto rval__ = parse_double(L)) X=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
+#define PARSE_DOUBLE(L, X) {if (auto rval__ = parse_double(L)) (X)=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
 
 // Attempt to parse an integer in the range [0, 256).
 parse_hopefully<std::uint8_t> parse_uint8(asc::lexer& L) {
@@ -113,7 +113,7 @@ parse_hopefully<std::uint8_t> parse_uint8(asc::lexer& L) {
     return static_cast<std::uint8_t>(value);
 }
 
-#define PARSE_UINT8(L, X) {if (auto rval__ = parse_uint8(L)) X=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
+#define PARSE_UINT8(L, X) {if (auto rval__ = parse_uint8(L)) (X)=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
 
 // Find the matching closing parenthesis, and consume it.
 // Assumes that opening paren has been consumed.
@@ -238,7 +238,7 @@ parse_hopefully<asc_color> parse_color(asc::lexer& L) {
     return unexpected(PARSE_ERROR("unexpected symbol in Color description \'"+t.spelling+"\'", t.loc));
 }
 
-#define PARSE_COLOR(L, X) {if (auto rval__ = parse_color(L)) X=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
+#define PARSE_COLOR(L, X) {if (auto rval__ = parse_color(L)) (X)=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
 
 // Parse zSmear statement, which has the form:
 //  (zSmear alpha beta)
@@ -305,7 +305,7 @@ parse_hopefully<arb::mpoint> parse_point(asc::lexer& L) {
     return p;
 }
 
-#define PARSE_POINT(L, X) if (auto rval__ = parse_point(L)) X=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());
+#define PARSE_POINT(L, X) if (auto rval__ = parse_point(L)) (X)=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());
 
 parse_hopefully<arb::mpoint> parse_spine(asc::lexer& L) {
     EXPECT_TOKEN(L, tok::lt);
@@ -319,7 +319,7 @@ parse_hopefully<arb::mpoint> parse_spine(asc::lexer& L) {
     return arb::mpoint{};
 }
 
-#define PARSE_SPINE(L, X) if (auto rval__ = parse_spine(L)) X=std::move(*rval__); else return FORWARD_PARSE_ERROR(rval__.error());
+#define PARSE_SPINE(L, X) if (auto rval__ = parse_spine(L)) (X)=std::move(*rval__); else return FORWARD_PARSE_ERROR(rval__.error());
 
 parse_hopefully<std::string> parse_name(asc::lexer& L) {
     EXPECT_TOKEN(L, tok::lparen);
@@ -340,7 +340,7 @@ parse_hopefully<std::string> parse_name(asc::lexer& L) {
     return name;
 }
 
-#define PARSE_NAME(L, X) {if (auto rval__ = parse_name(L)) X=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
+#define PARSE_NAME(L, X) {if (auto rval__ = parse_name(L)) (X)=*rval__; else return FORWARD_PARSE_ERROR(rval__.error());}
 
 struct marker_set {
     asc_color color;
@@ -387,7 +387,7 @@ parse_hopefully<marker_set> parse_markers(asc::lexer& L) {
     return markers;
 }
 
-#define PARSE_MARKER(L, X) if (auto rval__ = parse_markers(L)) X=std::move(*rval__); else return FORWARD_PARSE_ERROR(rval__.error());
+#define PARSE_MARKER(L, X) if (auto rval__ = parse_markers(L)) (X)=std::move(*rval__); else return FORWARD_PARSE_ERROR(rval__.error());
 
 struct branch {
     std::vector<arb::mpoint> samples;
@@ -463,11 +463,8 @@ parse_hopefully<branch> parse_branch(asc::lexer& L) {
             }
             finished = true;
         }
-        else if (branch_end(t)) {
-            finished = true;
-        }
-        // The end of the branch followed by an explicit fork point.
-        else if (t.kind==tok::lparen) {
+        else if (branch_end(t)
+              || t.kind==tok::lparen) {// The end of the branch followed by an explicit fork point.
             finished = true;
         }
         else {
@@ -636,15 +633,9 @@ ARB_ARBORIO_API arb::segment_tree parse_asc_string_raw(const char* input) {
         //      Sections
         //      Description
         t = lexer.peek();
-        if (symbol_matches("Description", t)) {
-            lexer.next();
-            parse_to_closing_paren(lexer);
-        }
-        else if (symbol_matches("ImageCoords", t)) {
-            lexer.next();
-            parse_to_closing_paren(lexer);
-        }
-        else if (symbol_matches("Sections", t)) {
+        if (symbol_matches("Description", t)
+         || symbol_matches("ImageCoords", t)
+         || symbol_matches("Sections", t)) {
             lexer.next();
             parse_to_closing_paren(lexer);
         }
@@ -702,7 +693,7 @@ ARB_ARBORIO_API arb::segment_tree parse_asc_string_raw(const char* input) {
         }
         else {
             // The soma is described by a contour.
-            const auto ns = samples.size();
+            const auto ns = static_cast<double>(samples.size());
             soma_0.x = std::accumulate(samples.begin(), samples.end(), 0., [](double a, auto& s) {return a+s.x;}) / ns;
             soma_0.y = std::accumulate(samples.begin(), samples.end(), 0., [](double a, auto& s) {return a+s.y;}) / ns;
             soma_0.z = std::accumulate(samples.begin(), samples.end(), 0., [](double a, auto& s) {return a+s.z;}) / ns;

--- a/arborio/neurolucida.cpp
+++ b/arborio/neurolucida.cpp
@@ -786,7 +786,7 @@ ARB_ARBORIO_API asc_morphology parse_asc_string(const char* input) {
 }
 
 
-inline std::string read_file(std::string filename) {
+inline std::string read_file(const std::string& filename) {
     std::ifstream fid(filename);
 
     if (!fid.good()) {
@@ -805,13 +805,13 @@ inline std::string read_file(std::string filename) {
 }
 
 
-ARB_ARBORIO_API asc_morphology load_asc(std::string filename) {
+ARB_ARBORIO_API asc_morphology load_asc(const std::string& filename) {
     std::string fstr = read_file(filename);
     return parse_asc_string(fstr.c_str());
 }
 
 
-ARB_ARBORIO_API arb::segment_tree load_asc_raw(std::string filename) {
+ARB_ARBORIO_API arb::segment_tree load_asc_raw(const std::string& filename) {
     std::string fstr = read_file(filename);
     return parse_asc_string_raw(fstr.c_str());
 }

--- a/arborio/neuroml.cpp
+++ b/arborio/neuroml.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <arborio/neuroml.hpp>
@@ -51,10 +52,10 @@ struct ARB_ARBORIO_API neuroml_impl {
 };
 
 neuroml::neuroml(): impl_(new neuroml_impl) {}
-neuroml::neuroml(std::string nml_document): impl_(new neuroml_impl{nml_document}) {}
+neuroml::neuroml(std::string nml_document): impl_(new neuroml_impl{std::move(nml_document)}) {}
 
-neuroml::neuroml(neuroml&&) = default;
-neuroml& neuroml::operator=(neuroml&&) = default;
+neuroml::neuroml(neuroml&&) noexcept = default;
+neuroml& neuroml::operator=(neuroml&&) noexcept = default;
 
 neuroml::~neuroml() = default;
 

--- a/arborio/neuroml.cpp
+++ b/arborio/neuroml.cpp
@@ -42,9 +42,9 @@ struct ARB_ARBORIO_API neuroml_impl {
     xml_doc doc;
     std::string raw;
 
-    neuroml_impl() {}
+    neuroml_impl() = default;
 
-    explicit neuroml_impl(std::string text): raw{text} {
+    explicit neuroml_impl(std::string text): raw{std::move(text)} {
         auto res = doc.load_buffer_inplace(raw.data(), raw.size()+1);
         if (res.status) throw nml_parse_error{res.description()};
     }
@@ -63,7 +63,7 @@ std::vector<std::string> neuroml::cell_ids() const {
     std::vector<std::string> result;
     result.reserve(matches.size());
     for (const auto& it: matches) {
-        result.push_back(it.attribute().as_string());
+        result.emplace_back(it.attribute().as_string());
     }
     return result;
 }
@@ -73,7 +73,7 @@ std::vector<std::string> neuroml::morphology_ids() const {
     std::vector<std::string> result;
     result.reserve(matches.size());
     for (const auto& it: matches) {
-        result.push_back(it.attribute().as_string());
+        result.emplace_back(it.attribute().as_string());
     }
     return result;
 }

--- a/arborio/nml_parse_morphology.cpp
+++ b/arborio/nml_parse_morphology.cpp
@@ -19,8 +19,6 @@
 #include "nml_parse_morphology.hpp"
 #include "xml.hpp"
 
-using arb::region;
-using arb::stitched_morphology;
 using arb::util::expected;
 using arb::util::unexpected;
 using std::optional;
@@ -251,10 +249,10 @@ private:
     std::unordered_map<non_negative, std::vector<non_negative>> children_;
 };
 
-static std::unordered_map<std::string, std::vector<non_negative>> evaluate_segment_groups(
-    std::vector<neuroml_segment_group_info> groups,
-    const neuroml_segment_tree& segtree)
-{
+namespace {
+std::unordered_map<std::string, std::vector<non_negative>>
+evaluate_segment_groups(std::vector<neuroml_segment_group_info> groups,
+                        const neuroml_segment_tree& segtree) {
     const std::size_t n_group = groups.size();
 
     // Expand subTree/path specifications:
@@ -360,7 +358,7 @@ static std::unordered_map<std::string, std::vector<non_negative>> evaluate_segme
     return group_seg_map;
 }
 
-static arb::stitched_morphology construct_morphology(const neuroml_segment_tree& segtree) {
+arb::stitched_morphology construct_morphology(const neuroml_segment_tree& segtree) {
     arb::stitch_builder builder;
     if (segtree.empty()) return arb::stitched_morphology{builder};
 
@@ -397,6 +395,7 @@ static arb::stitched_morphology construct_morphology(const neuroml_segment_tree&
     }
 
     return {std::move(builder)};
+}
 }
 
 nml_morphology_data nml_parse_morphology_element(const xml_node& morph,
@@ -461,7 +460,7 @@ nml_morphology_data nml_parse_morphology_element(const xml_node& morph,
     if (segments.empty()) return M;
 
     // Compute tree now to save further parsing if something goes wrong.
-    neuroml_segment_tree segtree(std::move(segments));
+    neuroml_segment_tree segtree(segments);
 
     const char* q_member = "./member";
     const char* q_include = "./include";

--- a/arborio/nml_parse_morphology.cpp
+++ b/arborio/nml_parse_morphology.cpp
@@ -19,10 +19,11 @@
 #include "nml_parse_morphology.hpp"
 #include "xml.hpp"
 
-using std::optional;
 using arb::region;
+using arb::stitched_morphology;
 using arb::util::expected;
 using arb::util::unexpected;
+using std::optional;
 
 using namespace std::literals;
 
@@ -395,7 +396,7 @@ static arb::stitched_morphology construct_morphology(const neuroml_segment_tree&
         }
     }
 
-    return arb::stitched_morphology(std::move(builder));
+    return {std::move(builder)};
 }
 
 nml_morphology_data nml_parse_morphology_element(const xml_node& morph,
@@ -424,10 +425,10 @@ nml_morphology_data nml_parse_morphology_element(const xml_node& morph,
 
             auto prox = n.select_node(q_proximal).node();
             if (!prox.empty()) {
-                double x = get_attr<double>(prox, "x");
-                double y = get_attr<double>(prox, "y");
-                double z = get_attr<double>(prox, "z");
-                double diameter = get_attr<double>(prox, "diameter");
+                auto x = get_attr<double>(prox, "x");
+                auto y = get_attr<double>(prox, "y");
+                auto z = get_attr<double>(prox, "z");
+                auto diameter = get_attr<double>(prox, "diameter");
                 if (diameter<0) throw nml_bad_segment(seg.id);
                 seg.proximal = arb::mpoint{x, y, z, diameter/2};
             }
@@ -436,10 +437,10 @@ nml_morphology_data nml_parse_morphology_element(const xml_node& morph,
 
             auto dist = n.select_node(q_distal).node();
             if (!dist.empty()) {
-                double x = get_attr<double>(dist, "x");
-                double y = get_attr<double>(dist, "y");
-                double z = get_attr<double>(dist, "z");
-                double diameter = get_attr<double>(dist, "diameter");
+                auto x = get_attr<double>(dist, "x");
+                auto y = get_attr<double>(dist, "y");
+                auto z = get_attr<double>(dist, "z");
+                auto diameter = get_attr<double>(dist, "diameter");
                 if (diameter<0) throw nml_bad_segment(seg.id);
                 seg.distal = arb::mpoint{x, y, z, diameter/2};
 

--- a/arborio/parse_helpers.hpp
+++ b/arborio/parse_helpers.hpp
@@ -12,6 +12,7 @@
 #include <arbor/morph/locset.hpp>
 #include <arbor/morph/region.hpp>
 #include <arbor/iexpr.hpp>
+#include <arbor/s_expr.hpp>
 
 namespace arborio {
 using namespace arb;
@@ -71,7 +72,7 @@ struct call_match {
     }
 
     template <std::size_t I>
-    bool match_args_impl(const std::vector<std::any>& args) const {
+    bool match_args_impl(const std::vector<std::any>&) const {
         return true;
     }
 
@@ -197,6 +198,9 @@ template <typename... Args>
 struct make_call {
     evaluator state;
 
+    make_call(make_call&&) = delete;
+    make_call(const make_call&) = delete;
+
     template <typename F>
     make_call(F&& f, const char* msg="call"):
         state(call_eval<Args...>(std::forward<F>(f)), call_match<Args...>(), msg)
@@ -210,6 +214,9 @@ struct make_call {
 template <typename T>
 struct make_fold {
     evaluator state;
+
+    make_fold(make_fold&&) = delete;
+    make_fold(const make_fold&) = delete;
 
     template <typename F>
     make_fold(F&& f, const char* msg="fold"):
@@ -225,6 +232,8 @@ struct make_fold {
 template <typename T, typename... Types>
 struct make_conversion_fold {
     evaluator state;
+
+    make_conversion_fold(make_conversion_fold&&) = delete;
 
     template <typename F>
     make_conversion_fold(F&& f, const char* msg = "fold_conversion"):
@@ -294,6 +303,9 @@ struct arg_vec_eval {
 template <typename... Args>
 struct make_arg_vec_call {
     evaluator state;
+
+    make_arg_vec_call(make_arg_vec_call&&) = delete;
+    make_arg_vec_call(const make_arg_vec_call&) = delete;
 
     template <typename F>
     make_arg_vec_call(F&& f, const char* msg="argument vector"):

--- a/arborio/swcio.cpp
+++ b/arborio/swcio.cpp
@@ -82,8 +82,8 @@ ARB_ARBORIO_API std::istream& operator>>(std::istream& in, swc_record& record) {
 }
 
 // Parse SWC format data (comments and sequence of SWC records).
-
-static std::vector<swc_record> sort_and_validate_swc(std::vector<swc_record> records) {
+namespace {
+std::vector<swc_record> sort_and_validate_swc(std::vector<swc_record> records) {
     if (records.empty()) return {};
 
     std::unordered_set<int> seen;
@@ -111,6 +111,7 @@ static std::vector<swc_record> sort_and_validate_swc(std::vector<swc_record> rec
     }
 
     return records;
+}
 }
 
 // swc_data

--- a/arborio/xml.hpp
+++ b/arborio/xml.hpp
@@ -43,33 +43,37 @@ T get_attr(const xml_node& n,
 inline
 std::string xpath_escape(const std::string& x) {
     auto npos = std::string::npos;
-     if (x.find_first_of("'")==npos) {
-         return "'"+x+"'";
-     }
-     else if (x.find_first_of("\"")==npos) {
-         return "\""+x+"\"";
-     }
-     else {
-         std::string r = "concat(";
-         std::string::size_type i = 0;
-         for (;;) {
-             auto j = x.find_first_of("'", i);
-             r += "'";
-             r.append(x, i, j==npos? j: j-i);
-             r += "'";
-             if (j==npos) break;
-             r += ",\"";
-             i = j+1;
-             j = x.find_first_not_of("'",i);
-             r.append(x, i, j==npos? j: j-i);
-             r += "\"";
-             if (j==npos) break;
-             r += ",";
-             i = j+1;
-         }
-         r += ")";
-         return r;
-     }
+
+    auto constexpr squote = '\'';
+    auto constexpr dquote = '\'';
+
+    if (x.find_first_of(squote)==npos) {
+        return "'"+x+"'";
+    }
+    else if (x.find_first_of(dquote)==npos) {
+        return "\""+x+"\"";
+    }
+    else {
+        std::string r = "concat(";
+        std::string::size_type i = 0;
+        for (;;) {
+            auto j = x.find_first_of(squote, i);
+            r += "'";
+            r.append(x, i, j==npos? j: j-i);
+            r += "'";
+            if (j==npos) break;
+            r += ",\"";
+            i = j+1;
+            j = x.find_first_not_of(squote, i);
+            r.append(x, i, j==npos? j: j-i);
+            r += "\"";
+            if (j==npos) break;
+            r += ",";
+            i = j+1;
+        }
+        r += ")";
+        return r;
+    }
 }
 
 }

--- a/ext/.clang-tidy
+++ b/ext/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: "-*"

--- a/lmorpho/lmorpho.cpp
+++ b/lmorpho/lmorpho.cpp
@@ -35,7 +35,7 @@ const char* usage_str =
 "    purkinje      Guinea pig Purkinje cells, basd on models and data\n"
 "                  from Rapp 1994 and Ascoli 2001.\n";
 
-int main(int argc, char** argv) {
+int main(int, char** argv) {
     // options
     int n_morph = 1;
     std::optional<unsigned> rng_seed = 0;

--- a/lmorpho/lsystem.cpp
+++ b/lmorpho/lsystem.cpp
@@ -351,7 +351,7 @@ std::vector<section_geometry> generate_sections(double soma_radius, lsys_param P
     return sections;
 }
 
-arb::segment_tree generate_morphology(const lsys_distribution_param& soma, std::vector<lsys_param> Ps, lsys_generator &g) {
+arb::segment_tree generate_morphology(const lsys_distribution_param& soma, const std::vector<lsys_param>& Ps, lsys_generator &g) {
 
     double const soma_diameter = lsys_distribution(soma)(g);
     double const soma_radius = 0.5*soma_diameter;

--- a/lmorpho/lsystem.hpp
+++ b/lmorpho/lsystem.hpp
@@ -9,7 +9,7 @@ struct lsys_param;
 using lsys_generator = std::minstd_rand;
 
 struct lsys_distribution_param;
-arb::segment_tree generate_morphology(const lsys_distribution_param& soma, std::vector<lsys_param> Ps, lsys_generator& g);
+arb::segment_tree generate_morphology(const lsys_distribution_param& soma, const std::vector<lsys_param>& Ps, lsys_generator& g);
 
 // The distribution parameters used in the specification of the L-system parameters.
 // The distribution can be a constant, uniform over an interval, or truncated normal.

--- a/modcc/.clang-tidy
+++ b/modcc/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: "-*"

--- a/python/strprintf.hpp
+++ b/python/strprintf.hpp
@@ -95,7 +95,7 @@ std::string strprintf(const char* fmt, Args&&... args) {
             throw std::system_error(errno, std::generic_category());
         }
         else if ((unsigned)n<buffer.size()) {
-            return std::string(buffer.data(), n);
+            return {buffer.data(), static_cast<std::size_t>(n)};
         }
         buffer.resize(2*n);
     }

--- a/python/strprintf.hpp
+++ b/python/strprintf.hpp
@@ -97,7 +97,7 @@ std::string strprintf(const char* fmt, Args&&... args) {
         else if ((unsigned)n<buffer.size()) {
             return {buffer.data(), static_cast<std::size_t>(n)};
         }
-        buffer.resize(2*n);
+        buffer.resize(2ull*n);
     }
 }
 

--- a/sup/include/sup/ioutil.hpp
+++ b/sup/include/sup/ioutil.hpp
@@ -23,14 +23,14 @@ namespace sup {
 template <typename charT, typename traitsT = std::char_traits<charT> >
 class basic_null_streambuf: public std::basic_streambuf<charT, traitsT> {
 private:
-    typedef typename std::basic_streambuf<charT, traitsT> streambuf_type;
+    using streambuf_type = typename std::basic_streambuf<charT, traitsT>;
 
 public:
-    typedef typename streambuf_type::char_type char_type;
-    typedef typename streambuf_type::int_type int_type;
-    typedef typename streambuf_type::pos_type pos_type;
-    typedef typename streambuf_type::off_type off_type;
-    typedef typename streambuf_type::traits_type traits_type;
+    using char_type = typename streambuf_type::char_type;
+    using int_type = typename streambuf_type::int_type;
+    using pos_type = typename streambuf_type::pos_type;
+    using off_type = typename streambuf_type::off_type;
+    using traits_type = typename streambuf_type::traits_type;
 
     virtual ~basic_null_streambuf() = default;
 
@@ -55,8 +55,7 @@ public:
     operator<<(std::basic_ostream<charT, traitsT>& O, const mask_stream& F) {
         int xindex = get_xindex();
 
-        std::basic_streambuf<charT, traitsT>* saved_streambuf =
-            static_cast<std::basic_streambuf<charT, traitsT>*>(O.pword(xindex));
+        auto* saved_streambuf = static_cast<std::basic_streambuf<charT, traitsT>*>(O.pword(xindex));
 
         if (F.mask_ && saved_streambuf) {
             // re-enable by restoring saved streambuf

--- a/sup/include/sup/ioutil.hpp
+++ b/sup/include/sup/ioutil.hpp
@@ -32,10 +32,10 @@ public:
     using off_type = typename streambuf_type::off_type;
     using traits_type = typename streambuf_type::traits_type;
 
-    virtual ~basic_null_streambuf() = default;
+    ~basic_null_streambuf() override = default;
 
 protected:
-    std::streamsize xsputn(const char_type* s, std::streamsize count) override {
+    std::streamsize xsputn(const char_type*, std::streamsize count) override {
         return count;
     }
 
@@ -59,7 +59,7 @@ public:
 
         if (F.mask_ && saved_streambuf) {
             // re-enable by restoring saved streambuf
-            O.pword(xindex) = 0;
+            O.pword(xindex) = nullptr;
             O.rdbuf(saved_streambuf);
         }
         else if (!F.mask_ && !saved_streambuf) {

--- a/sup/include/sup/path.hpp
+++ b/sup/include/sup/path.hpp
@@ -350,10 +350,10 @@ public:
     filesystem_error(const std::string& what_arg, std::error_code ec):
         std::system_error(ec, what_arg) {}
 
-    filesystem_error(const std::string& what_arg, path  p1, std::error_code ec):
+    filesystem_error(const std::string& what_arg, path p1, std::error_code ec):
         std::system_error(ec, what_arg), p1_(std::move(p1)) {}
 
-    filesystem_error(const std::string& what_arg, path  p1, path  p2, std::error_code ec):
+    filesystem_error(const std::string& what_arg, path p1, path p2, std::error_code ec):
         std::system_error(ec, what_arg), p1_(std::move(p1)), p2_(std::move(p2)) {}
 
     const path& path1() const { return p1_; }
@@ -507,7 +507,7 @@ struct directory_entry {
     directory_entry(const path& p, std::error_code& ec) { assign(p, ec); }
 
     // Set file type explicity: interface for directory_iterator.
-    directory_entry(path  p, file_type type, std::error_code& ec):
+    directory_entry(path p, file_type type, std::error_code& ec):
         path_(std::move(p)), status_(type)
     {
         if (type==file_type::unknown) { // no information from readdir()
@@ -533,7 +533,7 @@ struct directory_entry {
         refresh(ec);
     }
 
-    const sup::path& path() const noexcept { return path_; }
+    const sup::path& to_path() const noexcept { return path_; }
     operator const sup::path&() const noexcept { return path_; }
 
     bool is_block_file() const     { return sup::is_block_file(status_); }

--- a/sup/include/sup/path.hpp
+++ b/sup/include/sup/path.hpp
@@ -59,7 +59,7 @@ public:
     posix_path(Iter b, Iter e) { assign(b, e); }
 
     template <typename Source>
-    posix_path& operator=(Source&& source) { return assign(std::forward<Source>(source)); }
+    posix_path& operator=(Source&& source) { assign(std::forward<Source>(source)); return *this; }
 
     posix_path& assign(const posix_path& other) {
         p_ = other.p_;
@@ -177,19 +177,19 @@ public:
     }
 
     posix_path filename() const {
-        auto i = p_.rfind('/');
+        auto i = p_.rfind(preferred_separator);
         return i==std::string::npos? *this: posix_path(p_.substr(i+1));
     }
 
     bool has_filename() const {
         if (p_.empty()) return false;
 
-        auto i = p_.rfind('/');
+        auto i = p_.rfind(preferred_separator);
         return i==std::string::npos || i+1<p_.length();
     }
 
     posix_path parent_path() const {
-        auto i = p_.rfind('/');
+        auto i = p_.rfind(preferred_separator);
 
         if (i==0) return {"/"};
         else if (i==std::string::npos) return {};
@@ -197,7 +197,7 @@ public:
     }
 
     bool has_parent_path() const {
-        return p_.rfind('/')!=std::string::npos;
+        return p_.rfind(preferred_separator)!=std::string::npos;
     }
 
     // Non-member functions
@@ -253,7 +253,7 @@ public:
 
 protected:
     static bool is_separator(value_type c) {
-        return c=='/' || c==preferred_separator;
+        return c == preferred_separator;
     }
 
     std::string canonical() const {
@@ -262,7 +262,7 @@ protected:
         for (value_type c: p_) {
             if (is_separator(c)) {
                 if (!is_separator(prev)) {
-                    n += '/';
+                    n += preferred_separator;
                 }
             }
             else {
@@ -639,7 +639,7 @@ private:
 
 using directory_iterator = posix_directory_iterator;
 inline directory_iterator begin(directory_iterator i) noexcept { return i; }
-inline directory_iterator end(const directory_iterator& i) noexcept { return directory_iterator{}; }
+inline directory_iterator end(const directory_iterator&) noexcept { return directory_iterator{}; }
 
 } // namespace sup
 

--- a/sup/include/sup/path.hpp
+++ b/sup/include/sup/path.hpp
@@ -191,9 +191,9 @@ public:
     posix_path parent_path() const {
         auto i = p_.rfind('/');
 
-        if (i==0) return posix_path("/");
-        else if (i==std::string::npos) return posix_path();
-        else return posix_path(p_.substr(0, i));
+        if (i==0) return {"/"};
+        else if (i==std::string::npos) return {};
+        else return {p_.substr(0, i)};
     }
 
     bool has_parent_path() const {
@@ -350,11 +350,11 @@ public:
     filesystem_error(const std::string& what_arg, std::error_code ec):
         std::system_error(ec, what_arg) {}
 
-    filesystem_error(const std::string& what_arg, const path& p1, std::error_code ec):
-        std::system_error(ec, what_arg), p1_(p1) {}
+    filesystem_error(const std::string& what_arg, path  p1, std::error_code ec):
+        std::system_error(ec, what_arg), p1_(std::move(p1)) {}
 
-    filesystem_error(const std::string& what_arg, const path& p1, const path& p2, std::error_code ec):
-        std::system_error(ec, what_arg), p1_(p1), p2_(p2) {}
+    filesystem_error(const std::string& what_arg, path  p1, path  p2, std::error_code ec):
+        std::system_error(ec, what_arg), p1_(std::move(p1)), p2_(std::move(p2)) {}
 
     const path& path1() const { return p1_; }
     const path& path2() const { return p2_; }
@@ -507,8 +507,8 @@ struct directory_entry {
     directory_entry(const path& p, std::error_code& ec) { assign(p, ec); }
 
     // Set file type explicity: interface for directory_iterator.
-    directory_entry(const path& p, file_type type, std::error_code& ec):
-        path_(p), status_(type)
+    directory_entry(path  p, file_type type, std::error_code& ec):
+        path_(std::move(p)), status_(type)
     {
         if (type==file_type::unknown) { // no information from readdir()
             refresh(ec);

--- a/sup/include/sup/strsub.hpp
+++ b/sup/include/sup/strsub.hpp
@@ -21,7 +21,7 @@ namespace sup {
 
 // Stream-writing strsub(...):
 
-inline std::ostream& strsub(std::ostream& o, char c, const char* templ) {
+inline std::ostream& strsub(std::ostream& o, char, const char* templ) {
     return o << templ;
 }
 

--- a/sup/json_meter.cpp
+++ b/sup/json_meter.cpp
@@ -4,7 +4,8 @@
 
 namespace sup {
 
-static nlohmann::json to_json(const arb::profile::measurement& mnt) {
+namespace {
+nlohmann::json to_json(const arb::profile::measurement& mnt) {
     nlohmann::json measurements;
     for (const auto& m: mnt.measurements) {
         measurements.push_back(m);
@@ -15,6 +16,7 @@ static nlohmann::json to_json(const arb::profile::measurement& mnt) {
         {"units", mnt.units},
         {"measurements", measurements}
     };
+}
 }
 
 ARB_SUP_API nlohmann::json to_json(const arb::profile::meter_report& report) {

--- a/sup/path.cpp
+++ b/sup/path.cpp
@@ -1,5 +1,6 @@
 // POSIX headers
 extern "C" {
+/* Needed for gettimeofday on Linux */
 #define _DEFAULT_SOURCE
 #include <sys/stat.h>
 #include <dirent.h>

--- a/sup/path.cpp
+++ b/sup/path.cpp
@@ -85,7 +85,8 @@ posix_directory_iterator::posix_directory_iterator(const path& p, directory_opti
     state_(new posix_directory_state())
 {
     ec.clear();
-    if ((state_->dir = opendir(p.c_str()))) {
+    state_->dir = opendir(p.c_str());
+    if (state_->dir) {
         state_->dir_path = p;
         increment(ec);
         return;
@@ -95,8 +96,10 @@ posix_directory_iterator::posix_directory_iterator(const path& p, directory_opti
     ec = std::error_code(errno, std::generic_category());
 }
 
-static inline bool is_dot_or_dotdot(const char* s) {
+namespace {
+inline bool is_dot_or_dotdot(const char* s) {
     return *s=='.' && (!s[1] || (s[1]=='.' && !s[2]));
+}
 }
 
 posix_directory_iterator& posix_directory_iterator::increment(std::error_code &ec) {

--- a/sup/path.cpp
+++ b/sup/path.cpp
@@ -16,7 +16,7 @@ namespace impl {
         if (!r) {
             // Success:
             ec.clear();
-            perms p = static_cast<perms>(st.st_mode&07777);
+            auto p = static_cast<perms>(st.st_mode&07777);
             switch (st.st_mode&S_IFMT) {
             case S_IFSOCK:
                 return file_status{file_type::socket, p};

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: "-*"

--- a/test/unit/test_filter.cpp
+++ b/test/unit/test_filter.cpp
@@ -51,13 +51,13 @@ TEST(filter, const_sentinel) {
 }
 
 TEST(filter, modify_regular) {
-    int nums[] = {1, -2, 3, -4, -5};
+    std::array nums{1, -2, 3, -4, -5};
 
     for (auto& n: filter(nums, [](int i) { return i<0; })) {
         n *= n;
     }
 
-    int check[] = {1, 4, 3, 16, 25};
+    std::array check = {1, 4, 3, 16, 25};
     for (unsigned i = 0; i<5; ++i) {
         EXPECT_EQ(check[i], nums[i]);
     }

--- a/test/unit/test_path.cpp
+++ b/test/unit/test_path.cpp
@@ -405,9 +405,9 @@ TEST(path, posix_directory_iterators) {
 
     bool found_dev_null = false;
     for (; it!=directory_iterator(); ++it) {
-        if (it->path()=="/dev/null") found_dev_null = true;
+        if (it->to_path()=="/dev/null") found_dev_null = true;
 
-        file_status st = symlink_status(it->path());
+        file_status st = symlink_status(it->to_path());
 
         // Check file type tests match up.
         EXPECT_EQ(it->is_block_file(), is_block_file(st));


### PR DESCRIPTION
To improve our Static Analysis story:
- add .clang-tidy with some salient checks.
- add an ignore-list for the checks I think are less useful in Arbor's code.
- ignore -- for now -- some dark places: ext, text, and modcc
- fix many of the issues found

I have used PVS Studio in the past (and I still think it's the better tool) but they require
some weird contortions wrt README acknowledgements.

I found some potential bugs
- use-after-move in nml_parse_morph 
- (dubious) use-after-move in locked_ostream that seems unfixable
- incorrect erase/remove_if in communicator
- no check against self-assignment in any_ptr
- some incorrect/redundant `moves`
- missing includes