### PR TITLE
Workaround for failing MacOS wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   get_timestamp:
     name: Prep VERSION
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Get Arbor
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-22.04, macos-13]
 
     steps:
       - name: Get Arbor
@@ -61,7 +61,7 @@ jobs:
   build_sdist:
     name: Build sdist
     needs: get_timestamp
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Get packages
@@ -93,7 +93,7 @@ jobs:
 
   upload_test_pypi:
     name: upload to test pypi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build_binary_wheels, build_sdist]
     steps:
       - uses: actions/download-artifact@v3
@@ -110,7 +110,7 @@ jobs:
   make_release:
     name: draft new GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build_binary_wheels, build_sdist]
     steps:
       - name: "Clone w/ submodules"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Update pip and setup venv
+        run: python -m pip install --upgrade pip && python -m venv ~/env && . ~/env/bin/activate && echo PATH=$PATH >> $GITHUB_ENV
       - name: Get packages
         run: python3 -m pip install build
       - name: Get Arbor

--- a/.github/workflows/test-everything.yml
+++ b/.github/workflows/test-everything.yml
@@ -75,7 +75,7 @@ jobs:
           }
         - {
             name:  "MacOS Max",
-            os:    "macos-12",
+            os:    "macos-13",
             cc:    "clang",
             cxx:   "clang++",
             py:    "3.10",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![ci](https://github.com/arbor-sim/arbor/actions/workflows/test-everything.yml/badge.svg)](https://github.com/arbor-sim/arbor/actions/workflows/test-everything.yml)
-[![pythonwheels](https://github.com/arbor-sim/arbor/actions/workflows/ciwheel.yml/badge.svg)](https://github.com/arbor-sim/arbor/actions/workflows/ciwheel.yml)
+[![pythonwheels](https://github.com/arbor-sim/arbor/actions/workflows/release.yml/badge.svg)](https://github.com/arbor-sim/arbor/actions/workflows/release.yml)
 [![gitpod](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/arbor-sim/arbor)
 [![docs](https://readthedocs.org/projects/arbor/badge/?version=latest)](https://docs.arbor-sim.org/en/latest/)
 [![gitter](https://badges.gitter.im/arbor-sim/community.svg)](https://gitter.im/arbor-sim/community)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ MACOSX_DEPLOYMENT_TARGET = "10.15"
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux2014"
 # repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
-repair-wheel-command = repairwheel -o {dest_dir} {wheel}
+repair-wheel-command = "repairwheel -o {dest_dir} {wheel}"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-repair-wheel-command = repairwheel -o {dest_dir} {wheel}
+repair-wheel-command = "repairwheel -o {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ test-command = "python3 -m unittest discover -v -s {project}/python"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
+repair-wheel-command = ""
 
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.15"
@@ -72,7 +73,8 @@ MACOSX_DEPLOYMENT_TARGET = "10.15"
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux2014"
-repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
+# repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
+repair-wheel-command = ""
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ requires = [
     "scikit-build",
     "cmake>=3.19",
     "ninja",
-    "repairwheel",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -79,4 +78,4 @@ repair-wheel-command = ""
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-# do sth TBD
+# TBD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ requires = [
     "scikit-build",
     "cmake>=3.19",
     "ninja",
+    "repairwheel",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,9 @@ MACOSX_DEPLOYMENT_TARGET = "10.15"
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux2014"
-repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
+# repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
+repair-wheel-command = repairwheel -o {dest_dir} {wheel}
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
+repair-wheel-command = repairwheel -o {dest_dir} {wheel}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ build-backend = "setuptools.build_meta"
 build-frontend = "build"
 build = ["cp3*-manylinux_x86_64","cp3*-macosx_universal2"]#,"cp3*-musllinux_x86_64","cp3*-musllinux_aarch64"]
 skip = "cp36-*"
+test-requires = "numpy"
 test-command = "python3 -m unittest discover -v -s {project}/python"
 
 [tool.cibuildwheel.macos]
@@ -78,3 +79,4 @@ repair-wheel-command = ""
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
+# do sth TBD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ build-backend = "setuptools.build_meta"
 build-frontend = "build"
 build = ["cp3*-manylinux_x86_64","cp3*-macosx_universal2"]#,"cp3*-musllinux_x86_64","cp3*-musllinux_aarch64"]
 skip = "cp36-*"
-test-requires = "numpy"
 test-command = "python3 -m unittest discover -v -s {project}/python"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,7 @@ MACOSX_DEPLOYMENT_TARGET = "10.15"
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux2014"
-# repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
-repair-wheel-command = "repairwheel -o {dest_dir} {wheel}"
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && python3 /project/scripts/patchwheel.py {dest_dir}"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-repair-wheel-command = "repairwheel -o {dest_dir} {wheel}"

--- a/python/example/example_requirements.txt
+++ b/python/example/example_requirements.txt
@@ -1,5 +1,5 @@
 # pip requirements file
-numpy!=1.24.0 # See https://github.com/numpy/numpy/issues/22826
+numpy
 LFPykit>=0.3
 pandas
 seaborn


### PR DESCRIPTION
Arbor does not rely on any dynamically linked libraries anymore, so the repair-wheel action is actually not doing anything useful for us. Thus, setting it to `""` solves the issue. Nevertheless I've [asked](https://github.com/pypa/cibuildwheel/issues/1497) what might be going on.

Also: some version bumps.

Don't merge if #2121 already is.