### PR TITLE
Fix incorrect mention of attribute `catalogue` in `single_cell_model`

### DIFF
--- a/doc/python/single_cell_model.rst
+++ b/doc/python/single_cell_model.rst
@@ -42,7 +42,7 @@ Single cell model
 
    .. attribute:: properties
 
-      The :class:`cable_global_properties` of the model, including the :class:`catalogue`.
+      The :class:`~arbor.cable_global_properties` of the model, including the :class:`~arbor.catalogue`.
 
 .. class:: trace
 

--- a/doc/python/single_cell_model.rst
+++ b/doc/python/single_cell_model.rst
@@ -42,11 +42,7 @@ Single cell model
 
    .. attribute:: properties
 
-      The :class:`cable_global_properties` of the model.
-
-   .. attribute:: catalogue
-
-      The :class:`mechanism_catalogue` of the model.
+      The :class:`cable_global_properties` of the model, including the :class:`catalogue`.
 
 .. class:: trace
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/mnt/d/DATA/stefarb/purkinje.py", line 130, in <module>
    model.catalogue = glia.catalogue("dbbs")
AttributeError: 'arbor._arbor.single_cell_model' object has no attribute 'catalogue'
```