### PR TITLE
Avoid crash when integrating over empty branch.

### DIFF
--- a/arbor/morph/embed_pwlin.cpp
+++ b/arbor/morph/embed_pwlin.cpp
@@ -88,6 +88,11 @@ struct embed_pwlin_data {
         area(n_branch),
         ixa(n_branch)
     {}
+
+    embed_pwlin_data(const embed_pwlin_data&) = delete;
+    embed_pwlin_data(embed_pwlin_data&&) = delete;
+    embed_pwlin_data& operator=(const embed_pwlin_data&) = delete;
+    embed_pwlin_data& operator=(embed_pwlin_data&&) = delete;
 };
 
 // Interpolation
@@ -127,13 +132,15 @@ double integrate(const pw_constant_fn& g, const pw_ratpoly<p, q>& f) {
 template <unsigned p, unsigned q>
 double integrate(const pw_constant_fn& g, const pw_elements<pw_ratpoly<p, q>>& fs) {
     double sum = 0;
-    for (auto&& [extent, pw_pair]: pw_zip_range(g, fs)) {
-        auto [left, right] = extent;
-        if (left==right) continue;
+    if (!fs.empty()) {
+        for (auto&& [extent, pw_pair]: pw_zip_range(g, fs)) {
+            auto [left, right] = extent;
+            if (left==right) continue;
 
-        double gval = pw_pair.first;
-        pw_ratpoly<p, q> f = pw_pair.second;
-        sum += gval*(interpolate(right, f)-interpolate(left, f));
+            double gval = pw_pair.first;
+            pw_ratpoly<p, q> f = pw_pair.second;
+            sum += gval*(interpolate(right, f)-interpolate(left, f));
+        }
     }
     return sum;
 }
@@ -270,8 +277,8 @@ mcable_list embed_pwlin::projection_cmp(msize_t bid, double val, comp_op op) con
 // Initialization, creation of geometric data.
 
 embed_pwlin::embed_pwlin(const arb::morphology& m) {
-    constexpr double pi = math::pi<double>;
-    msize_t n_branch = m.num_branches();
+    constexpr auto pi = math::pi<double>;
+    auto n_branch = m.num_branches();
     data_ = std::make_shared<embed_pwlin_data>(n_branch);
 
     if (!n_branch) return;
@@ -400,7 +407,6 @@ embed_pwlin::embed_pwlin(const arb::morphology& m) {
             auto [left, right] = ixa_pw.bounds();
             data_->ixa[bid].push_back(left, right, ixa_pw);
         }
-
         arb_assert((data_->radius[bid].size()>0));
         if (branch_length!=0) {
             arb_assert((data_->radius[bid].bounds()==std::pair<double, double>(0., 1.)));

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+
 // Create/manipulate 1-d piecewise defined objects.
 //
 // A `pw_element<A>` describes a _value_ of type `A` and an _extent_ of
@@ -381,13 +382,8 @@ struct pw_elements {
 
     template <typename U>
     void push_back(double left, double right, U&& v) {
-        if (!empty() && left!=vertex_.back()) {
-            throw std::runtime_error("noncontiguous element");
-        }
-
-        if (right<left) {
-            throw std::runtime_error("inverted element");
-        }
+        if (!empty() && left != vertex_.back()) throw std::runtime_error("noncontiguous element");
+        if (right<left) throw std::runtime_error("inverted element");
 
         // Extend value_ first in case a conversion/copy/move throws.
         value_.push_back(std::forward<U>(v));
@@ -726,16 +722,51 @@ struct pw_zip_iterator {
 
     pw_zip_iterator() = default;
     pw_zip_iterator(const pw_elements<A>& a, const pw_elements<B>& b) {
-        double lmax = std::max(a.lower_bound(), b.lower_bound());
-        double rmin = std::min(a.upper_bound(), b.upper_bound());
+        // Default, both a and b are empty
+        is_end = true;
+        ai = a_end = a.end();
+        bi = b_end = b.end();
 
-        is_end = rmin<lmax;
-        if (!is_end) {
-            ai = a.equal_range(lmax).first;
-            a_end = a.equal_range(rmin).second;
-            bi = b.equal_range(lmax).first;
-            b_end = b.equal_range(rmin).second;
-            left = lmax;
+        if (!a.empty() && !b.empty()) {
+            const auto& [al, ah] = a.bounds();
+            const auto& [bl, bh] = b.bounds();
+            double lmax = std::max(al, bl);
+            double rmin = std::min(ah, bh);
+            is_end = rmin < lmax;
+
+            if (!is_end) {
+                ai = a.equal_range(lmax).first;
+                a_end = a.equal_range(rmin).second;
+                bi = b.equal_range(lmax).first;
+                b_end = b.equal_range(rmin).second;
+                left = lmax;
+            }
+        }
+        else if (!a.empty()) { // b must be empty
+            const auto& [al, ah] = a.bounds();
+            double lmax = al;
+            double rmin = ah;
+            is_end = rmin < lmax;
+            if (!is_end) {
+                ai = a.equal_range(lmax).first;
+                a_end = a.equal_range(rmin).second;
+                left = lmax;
+            }
+        }
+        else if (!b.empty()) { // a must be empty
+            const auto& [bl, bh] = b.bounds();
+            double lmax = bl;
+            double rmin = bh;
+            is_end = rmin < lmax;
+
+            if (!is_end) {
+                bi = b.equal_range(lmax).first;
+                b_end = b.equal_range(rmin).second;
+                left = lmax;
+            }
+        }
+        else {
+            // impossible
         }
     }
 
@@ -788,7 +819,6 @@ struct pw_zip_iterator {
         double a_right = ai->upper_bound();
         double b_right = bi->upper_bound();
         double right = std::min(a_right, b_right);
-
         return value_type{{left, right}, {*ai, *bi}};
     }
 


### PR DESCRIPTION
In #2123 a bug was hit where the `ixa` component in `embed_pwlin` was empty, leading to a crash.
Changes the `integrate` function to bail if the integration interval is vacuous.

Closes #2123. 
