### PR TITLE
Add an error on NET_RECEIVE w/ > 1 args.

### DIFF
--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -571,6 +571,10 @@ bool Module::semantic() {
 
     if (has_symbol("net_receive", symbolKind::procedure)) {
         auto net_rec_api = make_empty_api_method("net_rec_api", "net_receive");
+        // handle Arbor specifics
+        if (net_rec_api.second->args().size() > 1) {
+            error(pprintf("NET_RECEIVE does take at most one argument (Arbor limitation!)"));
+        }
         net_rec_api.first->body(net_rec_api.second->body()->clone());
         if (net_rec_api.second) {
             for (auto &s: net_rec_api.second->body()->statements()) {

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -573,7 +573,7 @@ bool Module::semantic() {
         auto net_rec_api = make_empty_api_method("net_rec_api", "net_receive");
         // handle Arbor specifics
         if (net_rec_api.second->args().size() > 1) {
-            error(pprintf("NET_RECEIVE does take at most one argument (Arbor limitation!)"));
+            error(pprintf("NET_RECEIVE does take at most one argument (Arbor limitation!)"), net_rec_api.first->location());
         }
         net_rec_api.first->body(net_rec_api.second->body()->clone());
         if (net_rec_api.second) {

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -573,7 +573,7 @@ bool Module::semantic() {
         auto net_rec_api = make_empty_api_method("net_rec_api", "net_receive");
         // handle Arbor specifics
         if (net_rec_api.second->args().size() > 1) {
-            error(pprintf("NET_RECEIVE does take at most one argument (Arbor limitation!)"), net_rec_api.first->location());
+            error(pprintf("NET_RECEIVE takes at most one argument (Arbor limitation!)"), net_rec_api.first->location());
         }
         net_rec_api.first->body(net_rec_api.second->body()->clone());
         if (net_rec_api.second) {

--- a/test/unit-modcc/mod_files/net_receive.mod
+++ b/test/unit-modcc/mod_files/net_receive.mod
@@ -1,0 +1,19 @@
+NEURON {
+  POINT_PROCESS net_rec_tst
+  NONSPECIFIC_CURRENT i
+}
+
+PARAMETER { foo e }
+
+ASSIGNED { g }
+
+INITIAL { g = 0 }
+
+BREAKPOINT {
+  i = g*(v - e)
+}
+
+
+NET_RECEIVE(w, foo) {
+     g = g + foo
+}

--- a/test/unit-modcc/mod_files/net_receive.mod
+++ b/test/unit-modcc/mod_files/net_receive.mod
@@ -13,7 +13,6 @@ BREAKPOINT {
   i = g*(v - e)
 }
 
-
 NET_RECEIVE(w, foo) {
      g = g + foo
 }

--- a/test/unit-modcc/test_module.cpp
+++ b/test/unit-modcc/test_module.cpp
@@ -206,3 +206,13 @@ TEST(Module, stochastic_conditional) {
     EXPECT_EQ(wnb.parameters.size(), 1u);
     EXPECT_EQ(wnb.used.size(), 0u);
 }
+
+TEST(Module, net_receive) {
+    Module m(io::read_all(DATADIR "/mod_files/net_receive.mod"), "net_receive.mod");
+    EXPECT_NE(m.buffer().size(), 0u);
+
+    Parser p(m, false);
+    EXPECT_TRUE(p.parse());
+
+    EXPECT_FALSE(m.semantic());
+}


### PR DESCRIPTION
NEURON allows NET_RECEIVE to take more than one argument (`weight` being always the first).
These arguments can then be set when connecting to the POINT_PROCESS (per _connection_ not
target synapse); similar to parameters.

Arbor doesn't allow this, but `modcc` compiles 
```
NET_RECEIVE(w, foo) {
     g = g + foo
}
```
just fine. Except it will use an undefined variable `foo` in the generated C++ leading to a compilation
error when building the native object.

This PR fixes this and generates an error instead
```
❯  modcc net_receive.mod
error trace:
  * net_receive.mod:(line 1,col 1) NET_RECEIVE does take at most one argument (Arbor limitation!)
```
