### PR TITLE
Fix enumeration in docs

### DIFF
--- a/doc/concepts/simulation.rst
+++ b/doc/concepts/simulation.rst
@@ -25,10 +25,8 @@ Configuring data extraction
 
 Two kinds of data extraction can be set up:
 
-# certain state variables can be :ref:`sampled <probesample>` by attaching a
-  sampler to a probe.
-# spikes can be recorded by either a callback (C++) or a preset recording model
-  (Python), see the API docs linked below.
+1. certain state variables can be :ref:`sampled <probesample>` by attaching a sampler to a probe.
+2. spikes can be recorded by either a callback (C++) or a preset recording model (Python), see the API docs linked below.
 
 Simulation execution and interaction
 ------------------------------------


### PR DESCRIPTION
Use 1., 2. instead of `#`.
