### PR TITLE
Spack: add dev version

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -32,6 +32,6 @@ jobs:
         run: arbor/scripts/build_spack_package.sh arbor develop
 
       - name: Run Python examples
-        run: scripts/run_python_examples.sh
+        run: arbor/scripts/run_python_examples.sh
       - name: Test executables
-        run: scripts/test_executables.sh
+        run: arbor/scripts/test_executables.sh

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -32,10 +32,10 @@ jobs:
         run: arbor/scripts/build_spack_package.sh arbor develop
 
       - name: Run Python examples
-        run: scripts/run_python_examples.sh
-        with:
-            path: arbor
+        run: |
+          cd arbor
+          scripts/run_python_examples.sh
       - name: Test executables
-        run: scripts/test_executables.sh
-        with:
-            path: arbor
+        run: |
+          cd arbor
+          scripts/test_executables.sh

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -32,6 +32,10 @@ jobs:
         run: arbor/scripts/build_spack_package.sh arbor develop
 
       - name: Run Python examples
-        run: arbor/scripts/run_python_examples.sh
+        with:
+            path: arbor
+        run: scripts/run_python_examples.sh
       - name: Test executables
-        run: arbor/scripts/test_executables.sh
+        with:
+            path: arbor
+        run: scripts/test_executables.sh

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Build Arbor's Spack package against the develop branch
         run: arbor/scripts/build_spack_package.sh arbor develop
 
-      - name: Run Python examples
-        run: |
-          cd arbor
-          scripts/run_python_examples.sh
-      - name: Test executables
-        run: |
-          cd arbor
-          scripts/test_executables.sh
+      # build_spack_package.sh only builds, does not install, therefore can't run Python code.
+      # - name: Run Python examples
+      #   run: |
+      #     cd arbor
+      #     scripts/run_python_examples.sh
+      # - name: Test executables
+      #   run: |
+      #     cd arbor
+      #     scripts/test_executables.sh

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -32,10 +32,10 @@ jobs:
         run: arbor/scripts/build_spack_package.sh arbor develop
 
       - name: Run Python examples
-        with:
-            path: arbor
         run: scripts/run_python_examples.sh
-      - name: Test executables
         with:
             path: arbor
+      - name: Test executables
         run: scripts/test_executables.sh
+        with:
+            path: arbor

--- a/scripts/build_spack_package.sh
+++ b/scripts/build_spack_package.sh
@@ -62,4 +62,4 @@ spack reindex
 cp $ARBOR_DIR/spack/package.py $SPACK_CUSTOM_REPO/packages/arbor
 cd $ARBOR_DIR
 ARBOR_VERSION=$(cat "$ARBOR_DIR/VERSION")
-spack dev-build arbor@dev
+spack dev-build arbor@${ARBOR_VERSION} +python

--- a/scripts/build_spack_package.sh
+++ b/scripts/build_spack_package.sh
@@ -20,46 +20,16 @@ cleanup() {
 TMP_DIR=$(mktemp -d)
 ARBOR_SOURCE=$1
 
-ARBOR_DIR=$TMP_DIR/arbor
-mkdir $ARBOR_DIR
-cp -r $ARBOR_SOURCE/* $ARBOR_DIR
-
 cd "$TMP_DIR"
+git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+# ./spack/bin/spack install libelf
+. spack/share/spack/setup-env.sh
+cp ./spack/package.py spack/var/spack/repos/builtin/packages/arbor/
 
-SPACK_DIR=spack
-SPACK_REPO=https://github.com/spack/spack
-SPACK_CUSTOM_REPO=custom_repo
-
-SPACK_VERSION=$2 # latest_release or develop
-SPACK_BRANCH=develop # only used for develop
-
-case $SPACK_VERSION in
-    "develop")
-        git clone --depth 1 --branch $SPACK_BRANCH $SPACK_REPO $SPACK_DIR
-        ;;
-    "latest_release")
-        wget "$(curl -sH "Accept: application/vnd.github.v3+json" https://api.github.com/repos/spack/spack/releases/latest | grep browser_download_url |  cut -d '"' -f 4)"
-        tar xfz spack*.tar.gz
-        ln -s spack*/ $SPACK_DIR
-        ;;
-    *)
-        echo "SPACK_VERSION" must be \"latest_release\" or \"develop\"
-        exit 1
-esac
-
-mkdir ~/.spack
-cp $ARBOR_DIR/spack/config.yaml ~/.spack
-
-source $SPACK_DIR/share/spack/setup-env.sh
-spack repo create $SPACK_CUSTOM_REPO
-
-mkdir -p $SPACK_CUSTOM_REPO/packages/arbor
-spack repo add $SPACK_CUSTOM_REPO
-
-# to make use of the cached installations
-spack reindex
-
-cp $ARBOR_DIR/spack/package.py $SPACK_CUSTOM_REPO/packages/arbor
-cd $ARBOR_DIR
-ARBOR_VERSION=$(cat "$ARBOR_DIR/VERSION")
-spack dev-build arbor@${ARBOR_VERSION} +python
+spack env create -d ./spack_env
+spacktivate ./spack_env
+spack add arbor
+ARBOR_VERSION=$(cat "$ARBOR_SOURCE/VERSION")
+spack develop --path "$ARBOR_SOURCE" --no-clone arbor@${ARBOR_VERSION} +python
+spack concretize -f
+spack install

--- a/scripts/build_spack_package.sh
+++ b/scripts/build_spack_package.sh
@@ -24,12 +24,12 @@ cd "$TMP_DIR"
 git clone -c feature.manyFiles=true https://github.com/spack/spack.git
 # ./spack/bin/spack install libelf
 . spack/share/spack/setup-env.sh
-cp ./spack/package.py spack/var/spack/repos/builtin/packages/arbor/
+cp ${ARBOR_SOURCE}/spack/package.py spack/var/spack/repos/builtin/packages/arbor/
 
 spack env create -d ./spack_env
 spacktivate ./spack_env
 spack add arbor
 ARBOR_VERSION=$(cat "$ARBOR_SOURCE/VERSION")
-spack develop --path "$ARBOR_SOURCE" --no-clone arbor@${ARBOR_VERSION} +python
+spack develop --path ${ARBOR_SOURCE} --no-clone arbor@${ARBOR_VERSION} +python
 spack concretize -f
 spack install

--- a/scripts/build_spack_package.sh
+++ b/scripts/build_spack_package.sh
@@ -62,4 +62,4 @@ spack reindex
 cp $ARBOR_DIR/spack/package.py $SPACK_CUSTOM_REPO/packages/arbor
 cd $ARBOR_DIR
 ARBOR_VERSION=$(cat "$ARBOR_DIR/VERSION")
-spack dev-build arbor@${ARBOR_VERSION}
+spack dev-build arbor@dev

--- a/spack/package.py
+++ b/spack/package.py
@@ -5,10 +5,6 @@
 
 from spack.package import *
 
-DEVVERSION = None
-with open("VERSION", "r") as file:
-    DEVVERSION = file.readline().strip()
-
 
 class Arbor(CMakePackage, CudaPackage):
     """Arbor is a high-performance library for computational neuroscience
@@ -20,7 +16,7 @@ class Arbor(CMakePackage, CudaPackage):
     maintainers = ["thorstenhater", "brenthuisman", "haampie"]
 
     version("master", branch="master", submodules=True)
-    version(DEVVERSION)
+    version("dev")
     version(
         "0.8.1",
         sha256="caebf96676ace6a9c50436541c420ca4bb53f0639dcab825de6fa370aacf6baa",

--- a/spack/package.py
+++ b/spack/package.py
@@ -6,8 +6,9 @@
 from spack.package import *
 
 DEVVERSION = None
-with open('VERSION', 'r') as file:
+with open("VERSION", "r") as file:
     DEVVERSION = file.readline().strip()
+
 
 class Arbor(CMakePackage, CudaPackage):
     """Arbor is a high-performance library for computational neuroscience

--- a/spack/package.py
+++ b/spack/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 DEVVERSION = None
-with open('../VERSION', 'r') as file:
+with open('VERSION', 'r') as file:
     DEVVERSION = file.readline().strip()
 
 class Arbor(CMakePackage, CudaPackage):

--- a/spack/package.py
+++ b/spack/package.py
@@ -16,6 +16,7 @@ class Arbor(CMakePackage, CudaPackage):
     maintainers = ["thorstenhater", "brenthuisman", "haampie"]
 
     version("master", branch="master", submodules=True)
+    version("0.8.2-dev")
     version(
         "0.8.1",
         sha256="caebf96676ace6a9c50436541c420ca4bb53f0639dcab825de6fa370aacf6baa",

--- a/spack/package.py
+++ b/spack/package.py
@@ -5,6 +5,9 @@
 
 from spack.package import *
 
+DEVVERSION = None
+with open('../VERSION', 'r') as file:
+    DEVVERSION = file.readline().strip()
 
 class Arbor(CMakePackage, CudaPackage):
     """Arbor is a high-performance library for computational neuroscience
@@ -16,7 +19,7 @@ class Arbor(CMakePackage, CudaPackage):
     maintainers = ["thorstenhater", "brenthuisman", "haampie"]
 
     version("master", branch="master", submodules=True)
-    version("0.8.2-dev")
+    version(DEVVERSION)
     version(
         "0.8.1",
         sha256="caebf96676ace6a9c50436541c420ca4bb53f0639dcab825de6fa370aacf6baa",

--- a/spack/package.py
+++ b/spack/package.py
@@ -5,6 +5,12 @@
 
 from spack.package import *
 
+try:
+    with open("VERSION", "r") as file:
+        DEVVERSION = file.readline().strip()
+except:
+    DEVVERSION = None
+
 
 class Arbor(CMakePackage, CudaPackage):
     """Arbor is a high-performance library for computational neuroscience
@@ -16,7 +22,8 @@ class Arbor(CMakePackage, CudaPackage):
     maintainers = ["thorstenhater", "brenthuisman", "haampie"]
 
     version("master", branch="master", submodules=True)
-    version("dev")
+    if DEVVERSION:
+        version(DEVVERSION)
     version(
         "0.8.1",
         sha256="caebf96676ace6a9c50436541c420ca4bb53f0639dcab825de6fa370aacf6baa",


### PR DESCRIPTION
- Upstream Spack changes forces any version that will be built to be explicitly listed in `package.py`. See https://github.com/spack/spack/pull/36273
- This version is only provided if a local `VERSION` is found (implying presence of Arbor source). If not, building that version would fail.
- Temporarily disabled recently added Python tests in the workflow file, because `dev-build`s don't install the package, and thus the tests and examples won't run. I'm looking into a solution, but don't want to hold merging this PR up.