### PR TITLE
Python3.12: Replace `distutils.version.LooseVersion`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ changelog = "https://github.com/arbor-sim/arbor/releases"
 [build-system]
 requires = [
     "scikit-build-core",
+    "looseversion",
 ]
 build-backend = "scikit_build_core.build"
 

--- a/scripts/tsplot
+++ b/scripts/tsplot
@@ -11,7 +11,7 @@ import matplotlib as M
 import matplotlib.pyplot as P
 import numbers
 from functools import reduce
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 from itertools import chain, islice, cycle
 
 # Run-time check for matplot lib version for line style functionality.


### PR DESCRIPTION
Python3.12 dropped distutils.
