### PR TITLE
Less frequent sanitizer runs

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -71,7 +71,8 @@ jobs:
       - name: Try to fail
         run: exit 1
       - name: Ouput File
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        #if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() }}
         run: |
           cat > issue.md <<EOF
           <details>
@@ -87,7 +88,8 @@ jobs:
           </details>
           EOF
       - name: Create Issue From File
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        #if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() }}
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: '[AUTOMATED] Sanitize checks failed'

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -6,7 +6,8 @@ on:
     paths-ignore: 'doc/**'
 
   schedule:
-    - cron: '0 2 * * 0' # run at 2 AM every sunday
+    - cron: '30 14 * * 1' # run at 14:30 every Monday
+    #- cron: '0 2 * * 0' # run at 2 AM every sunday
 
 jobs:
   build:
@@ -67,6 +68,8 @@ jobs:
       - name: Run examples
         run: scripts/run_cpp_examples.sh 2>&1 | tee -a output.log
         shell: bash
+      - name: Try to fail
+        run: exit 1
       - name: Ouput File
         if: ${{ failure() && github.event_name == 'schedule' }}
         run: |

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -1,9 +1,12 @@
 name: Sanitize
 
 on:
-  pull_request:
+  push:
     branches: [ master ]
     paths-ignore: 'doc/**'
+
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM every day
 
 jobs:
   build:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Create Issue From File
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v3
         with:
           title: '[AUTOMATED] Sanitize checks failed'
           content-filepath: ./issue.md

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -77,20 +77,25 @@ jobs:
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}
         run: |
-          fence='```'
-          cat > issue.md <<EOF
+          FENCE='```'
+          HEADER=$(cat << EOF
           <details>
           
           <summary>output from test runs</summary>
           
-          ${fence}
+          ${FENCE}
           EOF
-          cat output.log >> issue.md
-          cat >> issue.md <<EOF
-          ${fence}
+          )
+          FOOTER=$(cat << EOF
+          ${FENCE}
           
           </details>
           EOF
+          )
+          cat HEADER > issue.md
+          cat output.log >> issue.md
+          cat FOOTER >> issue.md
+          cat issue.md
       - name: Create Issue From File
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -88,7 +88,7 @@ jobs:
           FENCE='```'
           HEADER=$(cat << EOF
           ---
-          title: [AUTOMATED] Sanitize checks failed {{ date | date(\'dddd, MMMM Do\') }}
+          title: AUTOMATED Sanitize checks failed
           labels: automated issue
           ---
           <details>

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -77,16 +77,17 @@ jobs:
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}
         run: |
+          fence='```'
           cat > issue.md <<EOF
           <details>
           
           <summary>output from test runs</summary>
           
-          ```
+          ${fence}
           EOF
           cat output.log >> issue.md
           cat >> issue.md <<EOF
-          ```
+          ${fence}
           
           </details>
           EOF

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -12,6 +12,11 @@ on:
     - cron: '30 14 * * 1' # run at 14:30 every Monday
     #- cron: '0 2 * * 0' # run at 2 AM every sunday
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
 jobs:
   build:
     name: "Sanitize"
@@ -63,16 +68,19 @@ jobs:
           cmake .. -GNinja -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS="$SAN" -DCMAKE_C_FLAGS="$SAN" -DCMAKE_EXE_LINKER_FLAGS="$SAN" -DCMAKE_MODULE_LINKER_FLAGS="$SAN" -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DARB_VECTORIZE=${{ matrix.simd }} -DARB_WITH_MPI=OFF -DARB_USE_BUNDLED_LIBS=ON -DARB_WITH_PYTHON=ON -DPython3_EXECUTABLE=`which python`
           ninja -j4 -v tests examples pyarb
           cd -
-      - name: Run unit tests
-        run: |
-          build/bin/unit --gtest_filter=-*DeathTest 2>&1 | tee output.log
-          build/bin/unit-modcc 2>&1 | tee -a output.log
-        shell: bash
-      - name: Run examples
-        run: scripts/run_cpp_examples.sh 2>&1 | tee -a output.log
-        shell: bash
+      #- name: Run unit tests
+      #  run: |
+      #    build/bin/unit --gtest_filter=-*DeathTest 2>&1 | tee output.log
+      #    build/bin/unit-modcc 2>&1 | tee -a output.log
+      #  shell: bash
+      #- name: Run examples
+      #  run: scripts/run_cpp_examples.sh 2>&1 | tee -a output.log
+      #  shell: bash
       - name: Try to fail
-        run: exit 1
+        run: |
+          pwd
+          echo "test output" 2>&1 | tee output.log
+          exit 1
       - name: Ouput File
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}
@@ -92,16 +100,16 @@ jobs:
           </details>
           EOF
           )
-          echo HEADER > issue.md
+          echo ${HEADER} > issue.md
           cat output.log >> issue.md
-          echo FOOTER >> issue.md
+          echo ${FOOTER} >> issue.md
           cat issue.md
       - name: Create Issue From File
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: '[AUTOMATED] Sanitize checks failed'
-          content-filepath: ./issue.md
+          title: [AUTOMATED] Sanitize checks failed
+          content-filepath: issue.md
           labels: |
             automated issue

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -108,15 +108,6 @@ jobs:
           cat output.log >> issue.md
           echo ${FOOTER} >> issue.md
           cat issue.md
-      #- name: Create Issue From File
-      #  #if: ${{ failure() && github.event_name == 'schedule' }}
-      #  if: ${{ failure() }}
-      #  uses: peter-evans/create-issue-from-file@v3
-      #  with:
-      #    title: '[AUTOMATED] Sanitize checks failed'
-      #    content-filepath: ./issue.md
-      #    labels: |
-      #      automated issue
       - name: Create Issue From File
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore: 'doc/**'
 
   schedule:
-    - cron: '0 2 * * *' # run at 2 AM every day
+    - cron: '0 2 * * 0' # run at 2 AM every sunday
 
 jobs:
   build:
@@ -61,7 +61,33 @@ jobs:
           cd -
       - name: Run unit tests
         run: |
-          build/bin/unit --gtest_filter=-*DeathTest
-          build/bin/unit-modcc
+          build/bin/unit --gtest_filter=-*DeathTest 2>&1 | tee output.log
+          build/bin/unit-modcc 2>&1 | tee -a output.log
+        shell: bash
       - name: Run examples
-        run: scripts/run_cpp_examples.sh
+        run: scripts/run_cpp_examples.sh 2>&1 | tee -a output.log
+        shell: bash
+      - name: Ouput File
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        run: |
+          cat > issue.md <<EOF
+<details>
+
+<summary>output from test runs</summary>
+
+```
+EOF
+          cat output.log >> issue.md
+          cat >> issue.md <<EOF
+```
+
+</details>
+EOF
+      - name: Create Issue From File
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: '[AUTOMATED] Sanitize checks failed'
+          content-filepath: ./issue.md
+          labels: |
+            automated issue

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
     paths-ignore: 'doc/**'
+  pull_request:
+    branches: [ master ]
+    paths-ignore: 'doc/**'
 
   schedule:
     - cron: '30 14 * * 1' # run at 14:30 every Monday

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -121,9 +121,9 @@ jobs:
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}
         - uses: dblock/create-a-github-issue@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: ./issue.md
-          update_existing: true
-          search_existing: all
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            filename: ./issue.md
+            update_existing: true
+            search_existing: all

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -92,9 +92,9 @@ jobs:
           </details>
           EOF
           )
-          cat HEADER > issue.md
+          echo HEADER > issue.md
           cat output.log >> issue.md
-          cat FOOTER >> issue.md
+          echo FOOTER >> issue.md
           cat issue.md
       - name: Create Issue From File
         #if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -109,7 +109,7 @@ jobs:
         if: ${{ failure() }}
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: [AUTOMATED] Sanitize checks failed
-          content-filepath: issue.md
+          title: '[AUTOMATED] Sanitize checks failed'
+          content-filepath: ./issue.md
           labels: |
             automated issue

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -88,7 +88,7 @@ jobs:
           FENCE='```'
           HEADER=$(cat << EOF
           ---
-          title: [AUTOMATED] Sanitize checks failed {{ date | date('dddd, MMMM Do') }}
+          title: [AUTOMATED] Sanitize checks failed {{ date | date(\'dddd, MMMM Do\') }}
           labels: automated issue
           ---
           <details>

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -71,18 +71,18 @@ jobs:
         if: ${{ failure() && github.event_name == 'schedule' }}
         run: |
           cat > issue.md <<EOF
-<details>
-
-<summary>output from test runs</summary>
-
-```
-EOF
+          <details>
+          
+          <summary>output from test runs</summary>
+          
+          ```
+          EOF
           cat output.log >> issue.md
           cat >> issue.md <<EOF
-```
-
-</details>
-EOF
+          ```
+          
+          </details>
+          EOF
       - name: Create Issue From File
         if: ${{ failure() && github.event_name == 'schedule' }}
         uses: peter-evans/create-issue-from-file@v4

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -87,6 +87,10 @@ jobs:
         run: |
           FENCE='```'
           HEADER=$(cat << EOF
+          ---
+          title: [AUTOMATED] Sanitize checks failed {{ date | date('dddd, MMMM Do') }}
+          labels: automated issue
+          ---
           <details>
           
           <summary>output from test runs</summary>
@@ -104,12 +108,22 @@ jobs:
           cat output.log >> issue.md
           echo ${FOOTER} >> issue.md
           cat issue.md
+      #- name: Create Issue From File
+      #  #if: ${{ failure() && github.event_name == 'schedule' }}
+      #  if: ${{ failure() }}
+      #  uses: peter-evans/create-issue-from-file@v3
+      #  with:
+      #    title: '[AUTOMATED] Sanitize checks failed'
+      #    content-filepath: ./issue.md
+      #    labels: |
+      #      automated issue
       - name: Create Issue From File
         #if: ${{ failure() && github.event_name == 'schedule' }}
         if: ${{ failure() }}
-        uses: peter-evans/create-issue-from-file@v3
+        - uses: dblock/create-a-github-issue@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: '[AUTOMATED] Sanitize checks failed'
-          content-filepath: ./issue.md
-          labels: |
-            automated issue
+          filename: ./issue.md
+          update_existing: true
+          search_existing: all


### PR DESCRIPTION
Reduce CI times by only running the sanitizer tests when we commit to master and once a day.