### PR TITLE
Treat some corner cases in modcc

### DIFF
--- a/doc/fileformat/nmodl.rst
+++ b/doc/fileformat/nmodl.rst
@@ -141,7 +141,66 @@ Unsupported features
 * ``LOCAL`` variables outside blocks are not supported.
 * free standing blocks are not supported.
 * ``INDEPENDENT`` variables are not supported.
-* arrays and pointers are not supported by Arbor.
+* loops, arrays, and pointers are not supported by Arbor.
+
+Alternating normal and reaction statements in KINETIC
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is not so much a feature as a bug that Arbor's ``modcc`` does not reproduce
+from NEURON. Given a file like:
+
+.. code-block::
+
+   NEURON { SUFFIX test_kinetic_alternating_reaction }
+
+   STATE { A B C D }
+
+   BREAKPOINT {
+     SOLVE foobar METHOD sparse
+   }
+
+   KINETIC foobar {
+     LOCAL x, y
+
+     x = 23*v
+     y = 42*v
+
+     ~ A <-> B (x, y)
+
+     x = sin(y)
+     y = cos(x)
+
+     ~ C <-> D (x, y)
+   }
+
+one might expect that the reaction between ``C`` and ``D`` occurs with a rate
+proportional to ``sin(x)`` and ``cos(y)``. However, this file is equivalent to
+
+.. code-block::
+
+   NEURON { SUFFIX test_kinetic_alternating_reaction }
+
+   STATE { A B C D }
+
+   BREAKPOINT {
+     SOLVE foobar METHOD sparse
+   }
+
+   KINETIC foobar {
+     LOCAL x, y
+
+     x = 23*v
+     y = 42*v
+     x = sin(y)
+     y = cos(x)
+
+     ~ A <-> B (x, y)
+     ~ C <-> D (x, y)
+   }
+
+which is almost never what the author would expect. Thus, this construction constitutes
+an error in ``modcc``; if want this particular behaviour, please state this explicit by
+writing code similar to the second example.
 
 .. _arbornmodl:
 

--- a/modcc/expression.cpp
+++ b/modcc/expression.cpp
@@ -582,6 +582,9 @@ void ProcedureExpression::semantic(scope_ptr scp) {
         if (kind_ != procedureKind::linear && e->is_linear()) {
             error("linear statement not allowed inside "+::to_string(kind_)+" definition");
         }
+        if (kind_ != procedureKind::linear && e->is_derivative()) {
+            error("derivative statement not allowed inside "+::to_string(kind_)+" definition");
+        }
     }
 
     // We start a new loop here for preserving our sanity

--- a/modcc/kineticrewriter.cpp
+++ b/modcc/kineticrewriter.cpp
@@ -26,6 +26,7 @@ protected:
     virtual void finalize() override;
 
 private:
+
     // Acccumulated terms for derivative expressions, keyed by id name.
     std::map<std::string, expression_ptr> dterms;
 };

--- a/test/unit-modcc/mod_files/test_alternating_derivative.mod
+++ b/test/unit-modcc/mod_files/test_alternating_derivative.mod
@@ -1,0 +1,21 @@
+NEURON { SUFFIX test_derivative_alternating }
+
+STATE { A B }
+
+BREAKPOINT { : NOTE we need a newline here :/
+  SOLVE foobar METHOD sparse
+}
+
+: NOTE this is OK to do, while alternating normal and reaction statements is not!
+
+DERIVATIVE foobar {
+  LOCAL x
+
+  x = 23*v
+
+  A' = B*x
+
+  x = sin(x)
+
+  B' = x*A
+}

--- a/test/unit-modcc/mod_files/test_alternating_differential.mod
+++ b/test/unit-modcc/mod_files/test_alternating_differential.mod
@@ -1,0 +1,18 @@
+NEURON { SUFFIX test_kinetic_alternating_differential }
+
+STATE { A B C D }
+
+BREAKPOINT { : NOTE we need a newline here :/
+  SOLVE foobar METHOD sparse
+}
+
+KINETIC foobar {
+  LOCAL x, y
+
+  x = 23*v
+  y = 42*v
+
+  ~ A <-> B (x, y)
+  C' = 0.1
+  ~ C <-> D (x, y)
+}

--- a/test/unit-modcc/mod_files/test_alternating_reaction.mod
+++ b/test/unit-modcc/mod_files/test_alternating_reaction.mod
@@ -1,0 +1,21 @@
+NEURON { SUFFIX test_kinetic_alternating_reaction }
+
+STATE { A B C D }
+
+BREAKPOINT { : NOTE we need a newline here :/
+  SOLVE foobar METHOD sparse
+}
+
+KINETIC foobar {
+  LOCAL x, y
+
+  x = 23*v
+  y = 42*v
+
+  ~ A <-> B (x, y)
+
+  x = sin(y)
+  y = cos(x)
+
+  ~ C <-> D (x, y)
+}

--- a/test/unit-modcc/mod_files/test_kinetic_under_conditional.mod
+++ b/test/unit-modcc/mod_files/test_kinetic_under_conditional.mod
@@ -1,0 +1,21 @@
+NEURON { SUFFIX test_kinetic_under_conditional }
+
+STATE { A B }
+
+BREAKPOINT { : NOTE we need a newline here :/
+  SOLVE foobar METHOD sparse
+}
+
+KINETIC foobar {
+  LOCAL x, y
+
+  x = 23*v
+  y = 42*v
+
+  if (v<0) {
+    ~ A <-> B (x, y)
+  }
+  else {
+    ~ A <-> B (y, x)
+  }
+}

--- a/test/unit-modcc/mod_files/test_misplaced_reaction.mod
+++ b/test/unit-modcc/mod_files/test_misplaced_reaction.mod
@@ -1,0 +1,15 @@
+NEURON { SUFFIX test_misplaced_reaction }
+
+STATE { A B }
+
+BREAKPOINT { : NOTE we need a newline here :/
+  SOLVE foobar METHOD sparse
+}
+
+: NOTE this is OK to do, while alternating normal and reaction statements is not!
+
+DERIVATIVE foobar {
+  LOCAL x
+
+  ~ A <-> B (x, 1/x)
+}

--- a/test/unit-modcc/test_module.cpp
+++ b/test/unit-modcc/test_module.cpp
@@ -216,3 +216,53 @@ TEST(Module, net_receive) {
 
     EXPECT_FALSE(m.semantic());
 }
+
+TEST(Module, kinetic_footgun_alternating_reac) {
+    Module m(io::read_all(DATADIR "/mod_files/test_alternating_reaction.mod"), "test_alternating_reaction.mod");
+    EXPECT_NE(m.buffer().size(), 0u);
+
+    Parser p(m, false);
+    EXPECT_TRUE(p.parse());
+
+    EXPECT_FALSE(m.semantic());
+}
+
+TEST(Module, kinetic_footgun_alternating_diff) {
+    Module m(io::read_all(DATADIR "/mod_files/test_alternating_differential.mod"), "test_alternating_differential.mod");
+    EXPECT_NE(m.buffer().size(), 0u);
+
+    Parser p(m, false);
+    EXPECT_TRUE(p.parse());
+
+    EXPECT_FALSE(m.semantic());
+}
+
+TEST(Module, derivative_alternating) {
+    Module m(io::read_all(DATADIR "/mod_files/test_alternating_derivative.mod"), "test_alternating_derivative.mod");
+    EXPECT_NE(m.buffer().size(), 0u);
+
+    Parser p(m, false);
+    EXPECT_TRUE(p.parse());
+
+    EXPECT_TRUE(m.semantic());
+}
+
+TEST(Module, misplaced_reaction) {
+    Module m(io::read_all(DATADIR "/mod_files/test_misplaced_reaction.mod"), "test_misplaced_reaction.mod");
+    EXPECT_NE(m.buffer().size(), 0u);
+
+    Parser p(m, false);
+    EXPECT_TRUE(p.parse());
+
+    EXPECT_FALSE(m.semantic());
+}
+
+TEST(Module, reaction_under_conditional) {
+    Module m(io::read_all(DATADIR "/mod_files/test_kinetic_under_conditional.mod"), "test_kinetic_under_conditional.mod");
+    EXPECT_NE(m.buffer().size(), 0u);
+
+    Parser p(m, false);
+    EXPECT_FALSE(p.parse());
+
+    EXPECT_FALSE(m.semantic());
+}


### PR DESCRIPTION
These tests and fixes cover a few cases related to kinetic blocks:

#  Non-reaction statement in between reaction statements
This leads to the 'normal' statements being hoisted to the top resulting 
in unexpected semantics. This is now an error.

#  Reaction statements under conditional
This has always been an error; add a test for it.

# Reaction/Linear statements in non-KINETIC/LINEAR context
This is now an error; did SEGV before.

# Derivative statements in KINETIC/LINEAR/PROCEDURE
These are now error, they were before, but resulted in a confusing ICE message.