### PR TITLE
Rethrow a more informative error if cell kind is not a `cell_kind`

### DIFF
--- a/python/example/diffusion.py
+++ b/python/example/diffusion.py
@@ -17,7 +17,7 @@ class recipe(A.recipe):
         return 1
 
     def cell_kind(self, gid):
-        return A.cell_kind.cable
+        return A.cable_cell
 
     def cell_description(self, gid):
         return self.the_cell

--- a/python/example/diffusion.py
+++ b/python/example/diffusion.py
@@ -17,7 +17,7 @@ class recipe(A.recipe):
         return 1
 
     def cell_kind(self, gid):
-        return A.cable_cell
+        return A.cell_kind.cable
 
     def cell_description(self, gid):
         return self.the_cell

--- a/python/recipe.cpp
+++ b/python/recipe.cpp
@@ -188,7 +188,8 @@ void register_recipe(pybind11::module& m) {
         .def("cell_description", &py_recipe::cell_description, pybind11::return_value_policy::copy,
             "gid"_a,
             "High level description of the cell with global identifier gid.")
-        .def("cell_kind", &py_recipe::cell_kind,
+        .def("cell_kind",
+             &py_recipe::cell_kind,
             "gid"_a,
             "The kind of cell with global identifier gid.")
         .def("event_generators", &py_recipe::event_generators,

--- a/python/recipe.hpp
+++ b/python/recipe.hpp
@@ -64,7 +64,12 @@ public:
     }
 
     arb::cell_kind cell_kind(arb::cell_gid_type gid) const override {
-        PYBIND11_OVERRIDE_PURE(arb::cell_kind, py_recipe, cell_kind, gid);
+        try {
+            PYBIND11_OVERRIDE_PURE(arb::cell_kind, py_recipe, cell_kind, gid);
+        }
+        catch (const pybind11::cast_error& e) {
+            throw pybind11::type_error{"Couldn't convert return value of recipe.cell_kind(gid) to a cell_kind. Please check your recipe."};
+        }
     }
 
     std::vector<pybind11::object> event_generators(arb::cell_gid_type gid) const override {


### PR DESCRIPTION
Fixes #2138.