### PR TITLE
Fix a few integer type mismatches in for loops.

### DIFF
--- a/arbor/include/arbor/util/hash_def.hpp
+++ b/arbor/include/arbor/util/hash_def.hpp
@@ -55,7 +55,7 @@ inline constexpr std::size_t internal_hash(T&& data) {
     if constexpr (std::is_integral_v<D>) {
         unsigned long long bytes = data;
         std::size_t hash = offset_basis;
-        for (int ix = 0; ix < sizeof(data); ++ix) {
+        for (std::size_t ix = 0; ix < sizeof(data); ++ix) {
             uint8_t byte = bytes & 255;
             bytes >>= 8;
             hash = hash ^ byte;
@@ -66,7 +66,7 @@ inline constexpr std::size_t internal_hash(T&& data) {
     if constexpr (std::is_pointer_v<D>) {
         unsigned long long bytes = reinterpret_cast<unsigned long long>(data);
         std::size_t hash = offset_basis;
-        for (int ix = 0; ix < sizeof(data); ++ix) {
+        for (std::size_t ix = 0; ix < sizeof(data); ++ix) {
             uint8_t byte = bytes & 255;
             bytes >>= 8;
             hash = hash ^ byte;

--- a/test/unit/test_probe.cpp
+++ b/test/unit/test_probe.cpp
@@ -842,7 +842,7 @@ void run_axial_and_ion_current_sampled_probe_test(context ctx) {
                 ASSERT_NE(nullptr, s);
                 auto [s_beg, s_end] = *s;
                 ASSERT_EQ(s_end - s_beg, n_cv);
-                for (int ix = 0; ix < n_cv; ++ix) i_memb[ix] = *s_beg++;
+                for (unsigned ix = 0; ix < n_cv; ++ix) i_memb[ix] = *s_beg++;
             }
             else if (pm.id.tag == "I-stimulus") {
                 auto m = any_cast<const mcable_list*>(pm.meta);
@@ -853,7 +853,7 @@ void run_axial_and_ion_current_sampled_probe_test(context ctx) {
                 ASSERT_NE(nullptr, s);
                 auto [s_beg, s_end] = *s;
                 ASSERT_EQ(s_end - s_beg, n_cv);
-                for (int ix = 0; ix < n_cv; ++ix) i_stim[ix] = *s_beg++;
+                for (unsigned ix = 0; ix < n_cv; ++ix) i_stim[ix] = *s_beg++;
             }
             else {
                 // Probe id tells us which axial current this is.


### PR DESCRIPTION
* Use size_t to iterate size_t-bounded loops in `internal_hash()`.
* Use unsigned to iterate unsigned-bounded loops in `test_probe.cpp`.

Fixes #2240