### PR TITLE
Backport tinyopt pr#16 EOF comparison fix

### DIFF
--- a/ext/tinyopt/include/tinyopt/tinyopt.h
+++ b/ext/tinyopt/include/tinyopt/tinyopt.h
@@ -892,7 +892,7 @@ struct saved_options: private std::vector<std::string> {
         bool quote = false; // true => within single quotes.
         bool escape = false; // true => previous character was backslash.
         while (in) {
-            char c = in.get();
+            int c = in.get();
             if (c==EOF) break;
 
             if (quote) {


### PR DESCRIPTION
* Use `int` for `istream::get()` result for correct EOF checks when char is unsigned.

Fixes #2059.
