### PR TITLE
disable spack latest_release

### DIFF
--- a/.github/workflows/test-spack.yml
+++ b/.github/workflows/test-spack.yml
@@ -19,7 +19,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10']
-        spack-version: ['develop', 'latest_release']
+        # disable latest_release for now, pending a compatible buildcache
+        #spack-version: ['develop', 'latest_release']
+        spack-version: ['develop']
 
       fail-fast: false
 


### PR DESCRIPTION
The spack CI test fails when a point release (`latest_release`) for `spack` is selected, but works for the `develop` branch. This is most likely connected to the external `spack` buildcache, maintained by spack developers (https://github.com/spack/github-actions-buildcache).
Therefore, we disable the `latest_release` case until a workaround is implemented or a compatible `spack` buildcache is available.