### PR TITLE
Avoid `bash\r` from shebang by calling `bash` directly on custom command

### DIFF
--- a/arbor/include/CMakeLists.txt
+++ b/arbor/include/CMakeLists.txt
@@ -66,7 +66,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" arb_config_str)
 add_custom_command(
     OUTPUT version.hpp-test
     DEPENDS _always_rebuild
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
 )
 
 set(version_hpp_path arbor/version.hpp)


### PR DESCRIPTION
Building arbor on WSL from a clone checked out with Windows line endings causes the following error:

```
[  0%] Generating _always_rebuild
[  2%] Generating version.hpp-test
/usr/bin/env: ‘bash\r’: No such file or directory
make[2]: *** [arbor/include/CMakeFiles/generate_version_hpp.dir/build.make:77: arbor/include/version.hpp-test] Error 127
make[2]: *** Deleting file 'arbor/include/version.hpp-test'
make[1]: *** [CMakeFiles/Makefile2:1613: arbor/include/CMakeFiles/generate_version_hpp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[  2%] Building CXX object ext/units/units/CMakeFiles/units.dir/units.cpp.o
[  2%] Building CXX object ext/units/units/CMakeFiles/units.dir/commodities.cpp.o
[  4%] Building CXX object ext/units/units/CMakeFiles/units.dir/x12_conv.cpp.o
[  4%] Building CXX object ext/units/units/CMakeFiles/units.dir/r20_conv.cpp.o
[  4%] Linking CXX static library ../../../lib/libunits.a
[  4%] Built target units
make: *** [Makefile:136: all] Error 2
```

The shebang line in `arbor/include/git-source-id` of the following custom command is misinterpreted:

```
add_custom_command(
    OUTPUT version.hpp-test
    DEPENDS _always_rebuild
    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
)
```

Prepending `bash` directly to the custom command seems to fix the problem. I don't know how to confirm whether the `version.hpp-test` mechanism still works as intended, so someone should probably review that.