### PR TITLE
fix auto detect of sve length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,18 @@ set(arbor_supported_components)
 # Target microarchitecture for building arbor libraries, tests and examples
 #---------------------------------------------------------------------------
 
+# Set the full set of target flags in ARB_CXX_FLAGS_TARGET_FULL, which
+# will include target-specific -march flags if ARB_ARCH is not "none".
+if(ARB_ARCH STREQUAL "none")
+    set(ARB_CXX_FLAGS_TARGET_FULL ${ARB_CXX_FLAGS_TARGET})
+    set(ARB_CXX_FLAGS_TARGET_FULL_CPU ${ARB_CXX_FLAGS_TARGET})
+else()
+    set_arch_target(ARB_CXXOPT_ARCH_CPU ARB_CXXOPT_ARCH ${ARB_ARCH})
+    set(ARB_CXX_FLAGS_TARGET_FULL ${ARB_CXX_FLAGS_TARGET} ${ARB_CXXOPT_ARCH})
+    set(ARB_CXX_FLAGS_TARGET_FULL_CPU ${ARB_CXX_FLAGS_TARGET} ${ARB_CXXOPT_ARCH_CPU})
+endif()
+
+# Add SVE compiler flags if detected/desired
 set(ARB_SVE_WIDTH "auto" CACHE STRING "Default SVE vector length in bits. Default: auto (detection during configure time).")
 mark_as_advanced(ARB_SVE_WIDTH)
 if (ARB_SVE_WIDTH STREQUAL "auto")
@@ -337,15 +349,8 @@ else()
     set(ARB_SVE_BITS ${ARB_SVE_WIDTH})
     set(ARB_CXX_SVE_FLAGS " -msve-vector-bits=${ARB_SVE_BITS}")
 endif()
-
-# Set the full set of target flags in ARB_CXX_FLAGS_TARGET_FULL, which
-# will include target-specific -march flags if ARB_ARCH is not "none".
-if(ARB_ARCH STREQUAL "none")
-    set(ARB_CXX_FLAGS_TARGET_FULL ${ARB_CXX_FLAGS_TARGET} ${ARB_CXX_SVE_FLAGS})
-else()
-    set_arch_target(ARB_CXXOPT_ARCH ${ARB_ARCH})
-    set(ARB_CXX_FLAGS_TARGET_FULL ${ARB_CXX_FLAGS_TARGET} ${ARB_CXXOPT_ARCH} ${ARB_CXX_SVE_FLAGS})
-endif()
+list(APPEND ARB_CXX_FLAGS_TARGET_FULL
+    "$<$<BUILD_INTERFACE:$<COMPILE_LANGUAGE:CXX>>:${ARB_CXX_SVE_FLAGS}>")
 
 # Compile with `-fvisibility=hidden` to ensure that the symbols of the generated
 # arbor static libraries are hidden from the dynamic symbol tables of any shared

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -111,7 +111,7 @@ function(set_arch_target optvar optvar_cuda_guarded arch)
         string(REGEX REPLACE "-.*" "" target_model "${target}")
 
         # Use -mcpu for all supported targets _except_ for x86 and Apple arm64, where it should be -march.
-        
+
         if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang" AND CMAKE_CXX_COMPILER_VERSION LESS 15)
             set(arch_opt "")
         else()
@@ -136,6 +136,8 @@ function(set_arch_target optvar optvar_cuda_guarded arch)
         endforeach()
 
         set("${optvar_cuda_guarded}" "${arch_opt_cuda_guarded}" PARENT_SCOPE)
+    else()
+        set("${optvar_cuda_guarded}" "${arch_opt}" PARENT_SCOPE)
     endif()
 
 endfunction()

--- a/cmake/vls_sve_bits.hpp.in
+++ b/cmake/vls_sve_bits.hpp.in
@@ -15,7 +15,7 @@ static constexpr unsigned vls_sve_width = @ARB_SVE_BITS@/64;
 
 // Check required compiler features for VLS_SVE
 #if (!defined(__ARM_FEATURE_SVE_BITS) || __ARM_FEATURE_SVE_BITS != @ARB_SVE_BITS@)
-#error "Vector length specific scalable vector extension (VLS_SVE) not enabled - did you compile with -msve-vector-bits=@ARB_SVE_BITS@?" 
+#error "Vector length specific scalable vector extension (VLS_SVE) not enabled - consider setting ARB_SVE_LENGTH=@ARB_SVE_BITS@"
 #endif
 
 // We currently do not rely on GNU vector extension, __attribute__((vector_size(vls_sve_width)). If defined, we could


### PR DESCRIPTION
- apply pertinent compiler flags when trying to compile the detection code
- improve compiler error message when sve length is not set