### PR TITLE
Remove skip of Python 3.12 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ build-frontend = "build"
 build = ["*linux*","*macosx*"]
 skip = ["cp36*", "cp37*", "*musllinux*"]
 test-command = "python -m unittest discover -v -s {project}/python"
-test-skip = "cp312*"
 dependency-versions = "latest"
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
We have numpy for 3.12, so we can test it.

Closes #2203 