### PR TITLE
🐙  Decline magic variables in `ASSIGNED`

### DIFF
--- a/doc/fileformat/nmodl.rst
+++ b/doc/fileformat/nmodl.rst
@@ -243,7 +243,7 @@ Arbor-specific features
   step_left(x)        left-continuous heaviside step            :math:`\begin{align*} 1 & ~~ \text{if} ~x \gt 0, \\ 0 & ~~ \text{otherwise}. \end{align*}`
   step(x)             heaviside step with half value            :math:`\begin{align*} 1 & ~~ \text{if} ~x \gt 0, \\ 0 & ~~ \text{if} ~x \lt 0, \\ 0.5 & ~~ \text{otherwise}. \end{align*}`
   signum(x)           sign of argument                          :math:`\begin{align*} +1 & ~~ \text{if} ~x \gt 0, \\ -1 & ~~ \text{if} ~x \lt 0, \\ 0 & ~~ \text{otherwise}. \end{align*}`
-  exprelr(x)          smooth continuation over :math:`x=0` of   :math:`x/(1 - e^{-x})`
+  exprelr(x)          smooth continuation over :math:`x=0` of   :math:`x/(e^x - 1)`
   sigmoid(x)          sigmoidal function                        :math:`\frac{1}{1+e^{-x}}`
   relu(x)             rectified linear function                 :math:`max(0, x)`
   tanh(x)             hyperbolic tangent                        :math:`tanh(x)`
@@ -563,7 +563,7 @@ A common pattern is the use of a guarded exponential of the form
 .. code::
 
    if (x != 0) {
-     r = a*x/(exp(-x) - 1)
+     r = a*x/(exp(x) - 1)
    } else {
      r = a
    }

--- a/mechanisms/allen/Ih.mod
+++ b/mechanisms/allen/Ih.mod
@@ -23,7 +23,7 @@ STATE {
 
 BREAKPOINT {
     SOLVE states METHOD cnexp
-    ihcn = gbar*m*(v-ehcn)
+    ihcn = gbar*m*(v - ehcn)
 }
 
 DERIVATIVE states {

--- a/mechanisms/allen/Im.mod
+++ b/mechanisms/allen/Im.mod
@@ -1,58 +1,49 @@
 : Reference:        Adams et al. 1982 - M-currents and other potassium currents in bullfrog sympathetic neurones
 : Comment: corrected rates using q10 = 2.3, target temperature 34, orginal 21
 
-NEURON  {
+NEURON {
     SUFFIX Im
     USEION k READ ek WRITE ik
     RANGE gbar, g, ik
 }
 
-UNITS   {
+UNITS {
     (S) = (siemens)
     (mV) = (millivolt)
     (mA) = (milliamp)
 }
 
-PARAMETER   {
+PARAMETER {
     gbar = 0.00001 (S/cm2) 
-}
-
-ASSIGNED    {
     v   (mV)
-    g   (S/cm2)
     celsius (degC)
-    mInf
-    mTau
-    mAlpha
-    mBeta
 }
 
-STATE   { 
-    m
-}
+ASSIGNED { qt }
 
-BREAKPOINT  {
+STATE { m }
+
+BREAKPOINT {
     SOLVE states METHOD cnexp
+    LOCAL g
     g = gbar*m
     ik = g*(v-ek)
 }
 
-DERIVATIVE states   {
-    rates(v)
-    m' = (mInf-m)/mTau
+DERIVATIVE states {
+    LOCAL a, b
+    a = alpha(v)
+    b = beta(v)
+    m' = (a - m*(a + b))*qt
 }
 
-INITIAL{
-    rates(v)
-    m = mInf
-}
-
-PROCEDURE rates(v){
-    LOCAL qt
+INITIAL {
+    LOCAL a, b
+    a = alpha(v)
+    b = beta(v)
     qt = 2.3^((celsius-21)/10)
-
-    mAlpha = 3.3e-3*exp(2.5*0.04*(v - -35))
-    mBeta = 3.3e-3*exp(-2.5*0.04*(v - -35))
-    mInf = mAlpha/(mAlpha + mBeta)
-    mTau = (1/(mAlpha + mBeta))/qt
+    m = a/(a + b)
 }
+
+FUNCTION alpha(v) { alpha = 0.0033*exp( 0.1*(v + 35)) }
+FUNCTION beta(v)  { beta  = 0.0033*exp(-0.1*(v + 35)) }

--- a/mechanisms/allen/Im.mod
+++ b/mechanisms/allen/Im.mod
@@ -4,7 +4,7 @@
 NEURON {
     SUFFIX Im
     USEION k READ ek WRITE ik
-    RANGE gbar, g, ik
+    RANGE gbar
 }
 
 UNITS {

--- a/mechanisms/allen/Im_v2.mod
+++ b/mechanisms/allen/Im_v2.mod
@@ -3,7 +3,7 @@
 NEURON   {
    SUFFIX Im_v2
    USEION k READ ek WRITE ik
-   RANGE gbar, ik
+   RANGE gbar
 }
 
 UNITS {

--- a/mechanisms/allen/Kd.mod
+++ b/mechanisms/allen/Kd.mod
@@ -3,7 +3,7 @@
 NEURON {
    SUFFIX Kd
    USEION k READ ek WRITE ik
-   RANGE gbar, ik
+   RANGE gbar
 }
 
 UNITS {

--- a/mechanisms/allen/Kv3_1.mod
+++ b/mechanisms/allen/Kv3_1.mod
@@ -3,7 +3,7 @@
 NEURON {
     SUFFIX Kv3_1
     USEION k READ ek WRITE ik
-    RANGE gbar, ik 
+    RANGE gbar
 }
 
 UNITS {

--- a/mechanisms/allen/NaTa.mod
+++ b/mechanisms/allen/NaTa.mod
@@ -1,93 +1,77 @@
 : Reference: Colbert and Pan 2002
 
-NEURON	{
-	SUFFIX NaTa
-	USEION na READ ena WRITE ina
-	RANGE gbar, g, ina
+NEURON {
+    SUFFIX NaTa
+    USEION na READ ena WRITE ina
+    RANGE gbar, qt
 }
 
-UNITS	{
-	(S) = (siemens)
-	(mV) = (millivolt)
-	(mA) = (milliamp)
+UNITS {
+    (S) = (siemens)
+    (mV) = (millivolt)
+    (mA) = (milliamp)
 }
 
-PARAMETER	{
-	gbar = 0.00001 (S/cm2)
+PARAMETER {
+    v    (mV)
+    celsius (degC)
 
-	malphaF = 0.182
-	mbetaF = 0.124
-	mvhalf = -48 (mV)
-	mk = 6 (mV)
+    gbar = 0.00001 (S/cm2)
 
-	halphaF = 0.015
-	hbetaF = 0.015
-	hvhalf = -69 (mV)
-	hk = 6 (mV)
+    malphaF = 0.182
+    mbetaF = 0.124
+    mvhalf = -48 (mV)
+    mk = 6 (mV)
+
+    halphaF = 0.015
+    hbetaF = 0.015
+    hvhalf = -69 (mV)
+    hk = 6 (mV)
 }
 
-ASSIGNED	{
-	v	(mV)
-	g	(S/cm2)
-	celsius (degC)
-	mInf
-	mTau
-	mAlpha
-	mBeta
-	hInf
-	hTau
-	hAlpha
-	hBeta
+ASSIGNED { qt }
+
+STATE { m h }
+
+BREAKPOINT {
+    SOLVE states METHOD cnexp
+	LOCAL g
+    g = gbar*m*m*m*h
+    ina = g*(v-ena)
 }
 
-STATE	{
-	m
-	h
+DERIVATIVE states {
+    LOCAL ma, mb, ha, hb
+    ma = m_alpha(v)
+    mb = m_beta(v)
+    ha = h_alpha(v)
+    hb = h_beta(v)
+    m' = qt*(ma - m*(ma + mb))
+    h' = qt*(ha - h*(ha + hb))
 }
 
-BREAKPOINT	{
-	SOLVE states METHOD cnexp
-	g = gbar*m*m*m*h
-	ina = g*(v-ena)
-}
-
-DERIVATIVE states	{
-	rates(v)
-	m' = (mInf-m)/mTau
-	h' = (hInf-h)/hTau
-}
-
-INITIAL{
-	rates(v)
-	m = mInf
-	h = hInf
-}
-
-PROCEDURE rates(v){
-  LOCAL qt
+INITIAL {
+  LOCAL ma, mb, ha, hb
   qt = 2.3^((celsius-23)/10)
+  ma = m_alpha(v)
+  ha = h_alpha(v)
+  mb = m_beta(v)
+  hb = h_beta(v)
 
-	UNITSOFF
-		mAlpha = malphaF * vtrap(-(v - mvhalf), mk)
-		mBeta = mbetaF * vtrap((v - mvhalf), mk)
-
-		mInf = mAlpha/(mAlpha + mBeta)
-		mTau = (1/(mAlpha + mBeta))/qt
-
-		hAlpha = halphaF * vtrap(v - hvhalf, hk) : ng - adjusted this to match actual Colbert & Pan values for soma model
-		hBeta = hbetaF * vtrap(-(v - hvhalf), hk) : ng - adjusted this to match actual Colbert & Pan values for soma model
-
-		hInf = hAlpha/(hAlpha + hBeta)
-		hTau = (1/(hAlpha + hBeta))/qt
-	UNITSON
+  m = ma/(ma + mb)
+  h = ha/(ha + hb)
 }
+
+FUNCTION m_alpha(v) { m_alpha = malphaF * vtrap(-(v - mvhalf), mk) }
+FUNCTION m_beta(v)  { m_beta  = mbetaF  * vtrap(  v - mvhalf,  mk) }
+: ng - adjusted this to match actual Colbert & Pan values for soma model
+FUNCTION h_alpha(v) { h_alpha = halphaF * vtrap(  v - hvhalf,  hk) }
+FUNCTION h_beta(v)  { h_beta  = hbetaF  * vtrap(-(v - hvhalf), hk) }
 
 FUNCTION vtrap(x, y) { : Traps for 0 in denominator of rate equations
-	UNITSOFF
-	if (fabs(x / y) < 1e-6) {
-		vtrap = y * (1 - x / y / 2)
-	} else {
-		vtrap = x / (exp(x / y) - 1)
-	}
-	UNITSON
+    if (fabs(x / y) < 1e-6) {
+        vtrap = y * (1 - x / y / 2)
+    } else {
+        vtrap = x / (exp(x / y) - 1)
+    }
 }

--- a/mechanisms/allen/NaTs.mod
+++ b/mechanisms/allen/NaTs.mod
@@ -1,93 +1,75 @@
 : Reference: Colbert and Pan 2002
 
-NEURON	{
-	SUFFIX NaTs
-	USEION na READ ena WRITE ina
-	RANGE gbar, g, ina
+NEURON {
+    SUFFIX NaTs
+    USEION na READ ena WRITE ina
+    RANGE gbar, qt
 }
 
-UNITS	{
-	(S) = (siemens)
-	(mV) = (millivolt)
-	(mA) = (milliamp)
+UNITS {
+    (S) = (siemens)
+    (mV) = (millivolt)
+    (mA) = (milliamp)
 }
 
-PARAMETER	{
-	gbar = 0.00001 (S/cm2)
+PARAMETER {
+    gbar = 0.00001 (S/cm2)
 
-	malphaF = 0.182
-	mbetaF = 0.124
-	mvhalf = -40 (mV)
-	mk = 6 (mV)
+    malphaF = 0.182
+    mbetaF = 0.124
+    mvhalf = -40 (mV)
+    mk = 6 (mV)
 
-	halphaF = 0.015
-	hbetaF = 0.015
-	hvhalf = -66 (mV)
-	hk = 6 (mV)
+    halphaF = 0.015
+    hbetaF = 0.015
+    hvhalf = -66 (mV)
+    hk = 6 (mV)
+
+    v    (mV)
+    celsius (degC)
 }
 
-ASSIGNED	{
-	v	(mV)
-	g	(S/cm2)
-	celsius (degC)
-	mInf
-	mTau
-	mAlpha
-	mBeta
-	hInf
-	hTau
-	hAlpha
-	hBeta
+ASSIGNED { qt }
+
+STATE { m h }
+
+BREAKPOINT {
+    SOLVE states METHOD cnexp
+	LOCAL g
+    g = gbar*m*m*m*h
+    ina = g*(v-ena)
 }
 
-STATE	{
-	m
-	h
+DERIVATIVE states {
+  LOCAL ma, mb, ha, hb
+  ma = m_alpha(v)
+  ha = h_alpha(v)
+  mb = m_beta(v)
+  hb = h_beta(v)
+  m' = (ma - m*(ma + mb))*qt
+  h' = (ha - h*(ha + hb))*qt
 }
 
-BREAKPOINT	{
-	SOLVE states METHOD cnexp
-	g = gbar*m*m*m*h
-	ina = g*(v-ena)
-}
-
-DERIVATIVE states	{
-	rates(v)
-	m' = (mInf-m)/mTau
-	h' = (hInf-h)/hTau
-}
-
-INITIAL{
-	rates(v)
-	m = mInf
-	h = hInf
-}
-
-PROCEDURE rates(v){
-  LOCAL qt
+INITIAL {
   qt = 2.3^((celsius-23)/10)
-
-	UNITSOFF
-		mAlpha = malphaF * vtrap(-(v - mvhalf), mk)
-		mBeta = mbetaF * vtrap((v - mvhalf), mk)
-
-		mInf = mAlpha/(mAlpha + mBeta)
-		mTau = (1/(mAlpha + mBeta))/qt
-
-		hAlpha = halphaF * vtrap(v - hvhalf, hk)
-		hBeta = hbetaF * vtrap(-(v - hvhalf), hk)
-
-		hInf = hAlpha/(hAlpha + hBeta)
-		hTau = (1/(hAlpha + hBeta))/qt
-	UNITSON
+  LOCAL ma, mb, ha, hb
+  ma = m_alpha(v)
+  ha = h_alpha(v)
+  mb = m_beta(v)
+  hb = h_beta(v)
+  m = ma/(ma + mb)
+  h = ha/(ha + hb)
 }
+
+FUNCTION m_alpha(v) { m_alpha = malphaF * vtrap(-(v - mvhalf), mk) }
+FUNCTION m_beta(v)  { m_beta  = mbetaF  * vtrap(  v - mvhalf,  mk) }
+FUNCTION h_alpha(v) { h_alpha = halphaF * vtrap(  v - hvhalf,  hk) }
+FUNCTION h_beta(v)  { h_beta  = hbetaF  * vtrap(-(v - hvhalf), hk) }
 
 FUNCTION vtrap(x, y) { : Traps for 0 in denominator of rate equations
-	UNITSOFF
-	if (fabs(x / y) < 1e-6) {
-		vtrap = y * (1 - x / y / 2)
-	} else {
-		vtrap = x / (exp(x / y) - 1)
-	}
-	UNITSON
+    if (fabs(x / y) < 1e-6) {
+        vtrap = y * (1 - x / y / 2)
+    } else {
+        vtrap = x / (exp(x / y) - 1)
+    }
 }

--- a/mechanisms/allen/Nap.mod
+++ b/mechanisms/allen/Nap.mod
@@ -1,75 +1,55 @@
 :Reference : Modeled according to kinetics derived from Magistretti & Alonso 1999
 :Comment: corrected rates using q10 = 2.3, target temperature 34, orginal 21
 
-NEURON	{
-	SUFFIX Nap
-	USEION na READ ena WRITE ina
-	RANGE gbar, g, ina
+NEURON {
+  SUFFIX Nap
+  RANGE gbar, qt
+  USEION na READ ena WRITE ina
 }
 
-UNITS	{
-	(S) = (siemens)
-	(mV) = (millivolt)
-	(mA) = (milliamp)
+UNITS {
+  (S)  = (siemens)
+  (mV) = (millivolt)
+  (mA) = (milliamp)
 }
 
-PARAMETER	{
-	gbar = 0.00001 (S/cm2)
+PARAMETER {
+  gbar    = 0.00001
+  celsius           (degC)
+  v                 (mV)
 }
 
-ASSIGNED	{
-	v	(mV)
-	g	(S/cm2)
-	celsius (degC)
-	mInf
-	hInf
-	hTau
-	hAlpha
-	hBeta
-}
+STATE { h }
 
-STATE	{
-	h
-}
-
-BREAKPOINT	{
-	SOLVE states METHOD cnexp
-	rates(v)
-	g = gbar*mInf*h
-	ina = g*(v-ena)
-}
-
-DERIVATIVE states	{
-	rates(v)
-	h' = (hInf-h)/hTau
-}
+ASSIGNED { qt }
 
 INITIAL {
-   rates(v)
-   h = hInf
+  qt = 2.3 ^ ((celsius - 21) / 10)
+  h = h_inf(v)
 }
 
-PROCEDURE rates(v){
-  LOCAL qt
-  qt = 2.3^((celsius-21)/10)
-
-	UNITSOFF
-		mInf = 1.0/(1+exp((v- -52.6)/-4.6)) : assuming instantaneous activation as modeled by Magistretti and Alonso
-
-		hInf = 1.0/(1+exp((v- -48.8)/10))
-		hAlpha = 2.88e-6 * vtrap(v + 17, 4.63)
-		hBeta = 6.94e-6 * vtrap(-(v + 64.4), 2.63)
-
-		hTau = (1/(hAlpha + hBeta))/qt
-	UNITSON
+BREAKPOINT {
+  SOLVE states METHOD cnexp
+  LOCAL g, m_inf
+  m_inf = 1.0 / (1 + exp(-(v + 52.6)/4.6))
+  g = gbar * m_inf * h
+  ina = g * (v - ena)
 }
 
-FUNCTION vtrap(x, y) { : Traps for 0 in denominator of rate equations
-	UNITSOFF
-	if (fabs(x / y) < 1e-6) {
-		vtrap = y * (1 - x / y / 2)
-	} else {
-		vtrap = x / (exp(x / y) - 1)
-	}
-	UNITSON
+DERIVATIVE states {
+  LOCAL ha, hb
+  ha = 2.88e-6 * vtrap(  v + 17.0,  4.63)
+  hb = 6.94e-6 * vtrap(-(v + 64.4), 2.63)
+  h' = (h_inf(v) - h) * (ha + hb) * qt
+}
+
+FUNCTION h_inf(v) { h_inf = 1.0 / (1 + exp( (v + 48.8)/10)) }
+
+FUNCTION vtrap(x, y) {
+  if (fabs(x / y) < 1e-6) {
+    vtrap = y * (1 - x / y / 2)
+  }
+  else {
+    vtrap = x / (exp(x / y) - 1)
+  }
 }

--- a/mechanisms/allen/SK.mod
+++ b/mechanisms/allen/SK.mod
@@ -5,7 +5,7 @@ NEURON {
     SUFFIX SK
     USEION k READ ek WRITE ik
     USEION ca READ cai
-    RANGE gbar, ik
+    RANGE gbar
 }
 
 UNITS {
@@ -19,37 +19,25 @@ PARAMETER {
     zTau = 1       (ms)
 }
 
-ASSIGNED {
-    zInf
-    g     (S/cm2)
-}
+CONSTANT { eps = 1e-7  }
 
-STATE {
-    z FROM 0 TO 1
-}
+STATE { z }
 
 BREAKPOINT {
     SOLVE states METHOD cnexp
-    ik   =  gbar*z*(v - ek)
+    LOCAL g
+    g = gbar*z
+    ik =  g*(v - ek)
 }
 
-DERIVATIVE states {
-    LOCAL l_ca
-    l_ca = cai
-    if(l_ca < 1e-7){
-        l_ca = l_ca + 1e-07
-    }
-    zInf = 1/(1 + (0.00043 / l_ca)^4.8)
-    
-    z' = (zInf - z) / zTau
-}
+DERIVATIVE states { z' = (z_inf(cai) - z) / zTau }
 
-INITIAL {
-    LOCAL l_ca
-    l_ca = cai
-    if(l_ca < 1e-7) {
-      l_ca = l_ca + 1e-07
+INITIAL { z = z_inf(cai) }
+
+FUNCTION z_inf(cai) {
+    if(cai < eps) {
+         z_inf = 1/(1 + (0.00043 / (cai + eps))^4.8)
+    } else {
+         z_inf = 1/(1 + (0.00043 / cai)^4.8)
     }
-    
-    z = 1/(1 + (0.00043 / l_ca)^4.8)
 }

--- a/mechanisms/default/kamt.mod
+++ b/mechanisms/default/kamt.mod
@@ -12,9 +12,10 @@ NEURON {
 }
 
 PARAMETER {
+    celsius
+    v (mV)
     gbar   =  0.002    (mho/cm2)
 
-    celsius
     a0m    =  0.04
     vhalfm = -45
     zetam  =  0.1
@@ -35,8 +36,6 @@ UNITS {
     (pS) = (picosiemens)
     (um) = (micron)
 }
-
-ASSIGNED { v (mV) }
 
 STATE { m h }
 

--- a/mechanisms/default/kdrmt.mod
+++ b/mechanisms/default/kdrmt.mod
@@ -13,8 +13,9 @@ NEURON {
 }
 
 PARAMETER {
-    gbar   =  0.002    (mho/cm2)
+    v(mV)
     celsius
+    gbar   =  0.002    (mho/cm2)
     a0m    =  0.0035
     vhalfm = -50
     zetam  =  0.055
@@ -31,8 +32,6 @@ UNITS {
     (pS) = (picosiemens)
     (um) = (micron)
 }
-
-ASSIGNED { v(mV) }
 
 STATE { m }
 

--- a/mechanisms/default/nax.mod
+++ b/mechanisms/default/nax.mod
@@ -32,6 +32,7 @@ PARAMETER {
     qinf  = 4     (mV)  : inact inf slope
 
     celsius
+    v (mV)
 }
 
 
@@ -41,8 +42,6 @@ UNITS {
     (pS) = (picosiemens)
     (um) = (micron)
 }
-
-ASSIGNED { v (mV) }
 
 STATE { m h }
 

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -871,20 +871,31 @@ bool Module::add_variables_to_symbols() {
 
     // then RANGE variables
     for(auto const& var : neuron_block_.ranges) {
-        if(!symbols_.count(var.spelling)) {
-            error( yellow(var.spelling) +
+        const auto& name = var.spelling;
+        if(!symbols_.count(name)) {
+            error( yellow(name) +
                    " is declared as RANGE, but has not been declared in the" +
                    " ASSIGNED or PARAMETER block",
                    var.location);
             return false;
         }
-        auto& sym = symbols_[var.spelling];
+        if (is_ion_var(name)) {
+            warning( yellow(name) + " is declared as RANGE, but is an ion variable", var.location);
+
+        }
+        if (is_builtin(name)) {
+            warning( yellow(name) + " is declared as RANGE, but is a builtin variable", var.location);
+        }
+        auto& sym = symbols_[name];
         if(auto id = sym->is_variable()) {
+            if (id->is_state()) {
+                warning( yellow(name) + " is declared as RANGE, but is a STATE variable", var.location);
+            }
             id->range(rangeKind::range);
         }
         else if (!sym->is_indexed_variable()){
             throw compiler_exception(
-                "unable to find symbol " + yellow(var.spelling) + " in symbols",
+                "unable to find symbol " + yellow(name) + " in symbols",
                 var.location);
         }
     }

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -626,8 +626,57 @@ bool Module::semantic() {
     return !has_error();
 }
 
+struct builtin_info {
+    std::string name;
+    sourceKind source;
+    accessKind access;
+    std::string channel;
+    Location location;
+};
+
+auto make_builtin_variables(moduleKind mod_kind) {
+    std::vector<builtin_info> result = {
+        {"v",       sourceKind::voltage,      mod_kind == moduleKind::voltage ? accessKind::write : accessKind::read, "", {}},
+        {"v_peer",  sourceKind::peer_voltage, accessKind::read,                                                       "", {}},
+        {"celsius", sourceKind::temperature,  accessKind::read,                                                       "", {}},
+        {"diam",    sourceKind::diameter,     accessKind::read,                                                       "", {}},
+        {"area",    sourceKind::area,         accessKind::read,                                                       "", {}},
+    };
+    return result;
+}
+
+auto make_ion_variables(moduleKind mod_kind, const std::vector<IonDep>& ions) {
+    std::vector<builtin_info> result;
+    for(auto const& ion: ions) {
+        auto channel = ion.name;
+        for(auto const& var: ion.write) {
+            auto name = var.spelling;
+            result.push_back({name, ion_source(channel, name, mod_kind), accessKind::write, channel, var.location});
+        }
+        for(auto const& var: ion.read) {
+            auto name = var.spelling;
+            result.push_back({name, ion_source(channel, name, mod_kind), accessKind::read, channel, var.location});
+        }
+    }
+    return result;
+}
+
 /// populate the symbol table with class scope variables
 void Module::add_variables_to_symbols() {
+    auto builtins = make_builtin_variables(kind_);
+    auto ion_vars = make_ion_variables(kind_, neuron_block_.ions);
+
+    auto is_builtin = [&](auto& nm) -> bool {
+        return std::count_if(builtins.begin(), builtins.end(),
+                            [&](auto& v) { return v.name == nm; });
+    };
+
+    auto is_ion_var = [&](auto& nm) -> bool {
+        return std::count_if(ion_vars.begin(), ion_vars.end(),
+                            [&](auto& v) { return v.name == nm; });
+    };
+
+
     auto create_variable =
         [this](const Token& token, accessKind a, visibilityKind v, linkageKind l,
                rangeKind r, bool is_state = false) -> symbol_ptr& {
@@ -662,14 +711,19 @@ void Module::add_variables_to_symbols() {
 
     auto current_kind     = kind_ == moduleKind::density ? sourceKind::current_density : sourceKind::current;
     auto conductance_kind = kind_ == moduleKind::density ? sourceKind::conductivity    : sourceKind::conductance;
-    auto v_access         = kind_ == moduleKind::voltage ? accessKind::write : accessKind::read;
 
-    create_indexed_variable("current_", current_kind, accessKind::write, "", Location());
+    create_indexed_variable("current_",      current_kind,     accessKind::write, "", Location());
     create_indexed_variable("conductivity_", conductance_kind, accessKind::write, "", Location());
-    create_indexed_variable("v",      sourceKind::voltage, v_access,  "", Location());
-    create_indexed_variable("v_peer", sourceKind::peer_voltage, accessKind::read,  "", Location());
-    create_variable(Token{tok::identifier, "dt", Location()},
-        accessKind::read, visibilityKind::global, linkageKind::local, rangeKind::scalar);
+    create_variable(Token{tok::identifier, "dt", Location()}, accessKind::read, visibilityKind::global, linkageKind::local, rangeKind::scalar);
+
+    for (const auto& [name, source, access, channel, location]: builtins) {
+        create_indexed_variable(name, source, access, channel, location);
+    }
+    parameter_block_.parameters.erase(
+        std::remove_if(parameter_block_.begin(), parameter_block_.end(),
+                       [&](const Id& id) { return is_builtin(id.name()); }),
+        parameter_block_.end()
+    );
 
     // If we put back support for accessing cell time again from NMODL code,
     // add indexed_variable also for "time" with appropriate cell-index based
@@ -677,57 +731,36 @@ void Module::add_variables_to_symbols() {
 
     // Add state variables.
     for (const Id& id: state_block_) {
-        create_variable(id.token,
-            accessKind::readwrite, visibilityKind::local, linkageKind::local, rangeKind::range, true);
+        create_variable(id.token, accessKind::readwrite, visibilityKind::local, linkageKind::local, rangeKind::range, true);
     }
 
     // Add parameters, ignoring built-in voltage variables "v" and "v_peer".
     for (const Id& id: parameter_block_) {
-        if (id.name() == "v" || id.name() == "v_peer") {
+        if (is_builtin(id.name())) {
+            std::cerr << "Skipping builtin " << id.name() << '\n';
             continue;
         }
 
-        // Special cases: 'celsius', 'diam', and 'area' are external indexed-variables with special
-        // data sources. Retrieval of their values is handled especially by printers.
+        // Parameters are scalar by default, but may later be changed to range.
+        auto& sym = create_variable(id.token, accessKind::read, visibilityKind::global, linkageKind::local, rangeKind::scalar);
 
-        if (id.name() == "celsius") {
-            create_indexed_variable("celsius", sourceKind::temperature, accessKind::read, "", Location());
-        }
-        else if (id.name() == "diam") {
-            create_indexed_variable("diam", sourceKind::diameter, accessKind::read, "", Location());
-        }
-        else if (id.name() == "area") {
-            create_indexed_variable("area", sourceKind::area, accessKind::read, "", Location());
-        }
-        else {
-            // Parameters are scalar by default, but may later be changed to range.
-            auto& sym = create_variable(id.token,
-                accessKind::read, visibilityKind::global, linkageKind::local, rangeKind::scalar);
-
-            // Set default value if one was specified.
-            if (id.has_value()) {
-                sym->is_variable()->value(std::stod(id.value));
-            }
-        }
+        // Set default value if one was specified.
+        if (id.has_value()) sym->is_variable()->value(std::stod(id.value));
     }
 
-    // Remove `celsius`, `diam` and `area` from the parameter block, as they are not true parameters anymore.
-    parameter_block_.parameters.erase(
-        std::remove_if(parameter_block_.begin(), parameter_block_.end(),
-            [](const Id& id) { return (id.name() == "celsius")
-                                   || (id.name() == "area")
-                                   || (id.name() == "diam"); }),
-        parameter_block_.end()
-    );
 
     // Add 'assigned' variables, ignoring built-in voltage variables "v" and "v_peer".
     for (const Id& id: assigned_block_) {
-        if (id.name() == "v" || id.name() == "v_peer") {
-            continue;
+        auto builtin = std::find_if(builtins.begin(), builtins.end(),
+                                    [&] (auto& v) { return v.name == id.name(); });
+        if (builtin != builtins.end()) {
+                error(pprintf("the symbol '%' is defined as a builtin and cannot be used as an ASSIGNED here %.",
+                              yellow(id.name()), id.token.location),
+                      id.token.location);
+                return;
         }
 
-        create_variable(id.token,
-            accessKind::readwrite, visibilityKind::local, linkageKind::local, rangeKind::range);
+        create_variable(id.token, accessKind::readwrite, visibilityKind::local, linkageKind::local, rangeKind::range);
     }
 
     ////////////////////////////////////////////////////

--- a/modcc/module.hpp
+++ b/modcc/module.hpp
@@ -139,7 +139,7 @@ private:
     bool generate_initial_api();
     bool generate_current_api();
     bool generate_state_api();
-    void add_variables_to_symbols();
+    bool add_variables_to_symbols();
 
     bool has_symbol(const std::string& name) {
         return symbols_.find(name) != symbols_.end();

--- a/test/unit-modcc/mod_files/test7.mod
+++ b/test/unit-modcc/mod_files/test7.mod
@@ -11,17 +11,12 @@ NEURON {
 INITIAL {}
 
 PARAMETER {
-     g = .001 (S/cm2)
-     e = -65  (mV) : we use -65 for the ball and stick model, instead of Neuron default of -70
-}
-
-STATE {
-    s
-}
-
-ASSIGNED {
+    g = .001 (S/cm2)
+    e = -65  (mV) : we use -65 for the ball and stick model, instead of Neuron default of -70
     v (mV)
 }
+
+STATE { s }
 
 BREAKPOINT {
     foo(i)

--- a/test/unit/testing/test_kin1.mod
+++ b/test/unit/testing/test_kin1.mod
@@ -11,15 +11,12 @@ UNITS {
 
 PARAMETER {
     tau = 10 (ms)
+    v (mV)
 }
 
 STATE {
     a (mA/cm2)
     b (mA/cm2)
-}
-
-ASSIGNED {
-    v (mV)
 }
 
 BREAKPOINT {


### PR DESCRIPTION
We found that this
```
ASSIGNED { qt celsius }

INITIAL { qt = 2.3^(celsius - T) }
```
results in undefined/NaN `qt`, since `modcc` generates a new, assignable variable `celsius`
instead of accessing the built-in 'magic' variable.

This PR fixes this miscompilation by reporting an error and overhauls the relevant catalogues.