### PR TITLE
Fix embarrassingly quadratic bug in fvm-layout.

### DIFF
--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -947,6 +947,7 @@ fvm_build_mechanism_data(const cable_cell_global_properties& gprop,
         else {
             throw cable_cell_error("unrecognized ion '"+ion+"' in mechanism.");
         }
+
     }
     return combined;
 }
@@ -1016,11 +1017,9 @@ fvm_mechanism_data fvm_build_mechanism_data(const cable_cell_global_properties& 
     // Track ion usage of mechanisms so that ions are only instantiated where required.
     fvm_ion_map ion_build_data;
 
-    // add diffusive ions to support: If diffusive, it's everywhere.
-    for (const auto& [ion, data]: D.diffusive_ions) {
-        auto& s = ion_build_data[ion].support;
-        s.resize(D.geometry.size());
-        std::iota(s.begin(), s.end(), 0);
+    // pre-extend support of diffusive ions, if diffusive, it's everywhere.
+    for (auto& [ion, data]: D.diffusive_ions) {
+        assign(ion_build_data[ion].support, D.geometry.cell_cvs(cell_idx));
     }
 
     fvm_mechanism_data M;

--- a/test/unit/test_diffusion.cpp
+++ b/test/unit/test_diffusion.cpp
@@ -86,7 +86,9 @@ struct linear: public recipe {
 using result_t = std::vector<std::tuple<double, double, double>>;
 
 testing::AssertionResult all_near(const result_t& a, const result_t& b, double eps) {
-    if (a.size() != b.size()) return testing::AssertionFailure() << "sequences differ in length";
+    if (a.size() != b.size()) return testing::AssertionFailure() << "sequences differ in length"
+                                                                 << " #expected=" << b.size()
+                                                                 << " #received=" << a.size();
     std::stringstream res;
     for (size_t ix = 0; ix < a.size(); ++ix) {
         const auto&[ax, ay, az] = a[ix];


### PR DESCRIPTION
Fixes accidentally quadratic memory use in `fvm_layout` where every cell allocates space for the whole cell group
when an ion is diffusive.