### PR TITLE
Refactor discretization.

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -43,8 +43,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Update pip
-        run: python -m pip install --upgrade pip
       # figure out vector extensions for ccache key
       - name: Check vector extensions
         run: |

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build:
     name: "Sanitize"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -27,8 +27,8 @@ jobs:
         sanitizer: ["address", "undefined", "thread"]
         simd:      ["ON", "OFF"]
     env:
-        CC:           clang-14
-        CXX:          clang++-14
+        CC:           clang-18
+        CXX:          clang++-18
         ASAN_OPTIONS: detect_leaks=1
     steps:
       - name: Get build dependencies

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -29,8 +29,8 @@ jobs:
         - {
             name:  "Linux Min Clang",
             os:    "ubuntu-22.04",
-            cc:    "clang-12",
-            cxx:   "clang++-12",
+            cc:    "clang-13",
+            cxx:   "clang++-13",
             py:    "3.9",
             cmake: "3.19.x",
             mpi:   "ON",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ install(FILES mechanisms/BuildModules.cmake DESTINATION ${ARB_INSTALL_DATADIR})
 
 # First make ourselves less chatty
 set(_saved_CMAKE_MESSAGE_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL})
-set(CMAKE_MESSAGE_LOG_LEVEL WARNING)
+set(CMAKE_MESSAGE_LOG_LEVEL STATUS)
 
 # in the event we can find hwloc, just add it
 find_package(hwloc QUIET)
@@ -344,6 +344,8 @@ CPMAddPackage(NAME fmt
               VERSION 10.0.0
               GIT_TAG 10.0.0)
 
+add_library(ext-gtest INTERFACE)
+add_library(ext-bench INTERFACE)
 if (BUILD_TESTING)
     CPMAddPackage(NAME benchmark
                   GITHUB_REPOSITORY google/benchmark
@@ -354,6 +356,18 @@ if (BUILD_TESTING)
                   GIT_TAG release-1.12.1
                   VERSION 1.12.1
                   OPTIONS "INSTALL_GTEST OFF" "BUILD_GMOCK OFF")
+    if(benchmark_ADDED)
+        target_link_libraries(ext-bench INTERFACE benchmark)
+    else()
+        find_package(benchmark REQUIRED)
+        target_link_libraries(ext-bench INTERFACE benchmark::benchmark)
+    endif()
+    if(googletest_ADDED)
+        target_link_libraries(ext-gtest INTERFACE )
+    else()
+        find_package(googletest REQUIRED)
+        target_link_libraries(ext-gtest INTERFACE gtest gtest_main)
+    endif()
 endif()
 
 CPMAddPackage(NAME units

--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -83,18 +83,22 @@ struct cable_cell_impl {
     // The decorations on the cell.
     decor decorations;
 
+    // Discretization
+    std::optional<cv_policy> discretization_;
+
     // The placeable label to lid_range map
     dynamic_typed_map<constant_type<std::unordered_multimap<hash_type, lid_range>>::type> labeled_lid_ranges;
 
-    cable_cell_impl(const arb::morphology& m, const label_dict& labels, const decor& decorations):
+    cable_cell_impl(const arb::morphology& m, const label_dict& labels, const decor& decorations, const std::optional<cv_policy>& cvp):
         provider(m, labels),
         dictionary(labels),
-        decorations(decorations)
+        decorations(decorations),
+        discretization_{cvp}
     {
         init();
     }
 
-    cable_cell_impl(): cable_cell_impl({},{},{}) {}
+    cable_cell_impl(): cable_cell_impl({}, {}, {}, {}) {}
 
     cable_cell_impl(const cable_cell_impl& other) = default;
 
@@ -203,6 +207,10 @@ struct cable_cell_impl {
     }
 };
 
+const std::optional<cv_policy>& cable_cell::discretization() const { return impl_->discretization_; }
+void cable_cell::discretization(cv_policy cvp) { impl_->discretization_ = std::move(cvp); }
+
+
 using impl_ptr = std::unique_ptr<cable_cell_impl, void (*)(cable_cell_impl*)>;
 impl_ptr make_impl(cable_cell_impl* c) {
     return impl_ptr(c, [](cable_cell_impl* p){delete p;});
@@ -232,8 +240,8 @@ void cable_cell_impl::init() {
     }
 }
 
-cable_cell::cable_cell(const arb::morphology& m, const decor& decorations, const label_dict& dictionary):
-    impl_(make_impl(new cable_cell_impl(m, dictionary, decorations)))
+cable_cell::cable_cell(const arb::morphology& m, const decor& decorations, const label_dict& dictionary, const std::optional<cv_policy>& cvp):
+    impl_(make_impl(new cable_cell_impl(m, dictionary, decorations, cvp)))
 {}
 
 cable_cell::cable_cell(): impl_(make_impl(new cable_cell_impl())) {}

--- a/arbor/cable_cell_param.cpp
+++ b/arbor/cable_cell_param.cpp
@@ -105,11 +105,6 @@ std::vector<defaultable> cable_cell_parameter_set::serialize() const {
     for (const auto& [name, mech]: reversal_potential_method) {
         D.push_back(ion_reversal_potential_method{name, mech});
     }
-
-    if (discretization) {
-        D.push_back(*discretization);
-    }
-
     return D;
 }
 
@@ -162,9 +157,6 @@ decor& decor::set_default(defaultable what) {
                 }
                 else if constexpr (std::is_same_v<ion_reversal_potential_method, T>) {
                     defaults_.reversal_potential_method[p.ion] = p.method;
-                }
-                else if constexpr (std::is_same_v<cv_policy, T>) {
-                    defaults_.discretization = std::forward<cv_policy>(p);
                 }
                 else if constexpr (std::is_same_v<ion_diffusivity, T>) {
                     if (p.scale.type() != iexpr_type::scalar) throw cable_cell_error{"Default values cannot have a scale."};

--- a/arbor/cv_policy.cpp
+++ b/arbor/cv_policy.cpp
@@ -40,6 +40,8 @@ struct cvp_cv_policy_plus {
         return os;
     }
 
+    cvp_cv_policy_plus(const cv_policy& lhs, const cv_policy& rhs): lhs_{lhs}, rhs_(rhs) {}
+
     cv_policy lhs_, rhs_;
 };
 

--- a/arbor/cv_policy.cpp
+++ b/arbor/cv_policy.cpp
@@ -8,35 +8,34 @@
 #include <arbor/morph/region.hpp>
 
 #include "util/rangeutil.hpp"
-#include "util/span.hpp"
-
-// Discretization policy implementations:
 
 namespace arb {
+
+static std::string print_flag(cv_policy_flag flag) {
+    switch (flag) {
+        case arb::cv_policy_flag::none: return "(flag-none)";
+        case arb::cv_policy_flag::interior_forks: return "(flag-interior-forks)";
+    }
+    throw std::runtime_error("UNREACHABLE");
+}
+
+static bool has_flag(cv_policy_flag lhs, cv_policy_flag rhs) {
+    return static_cast<bool>(static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs));
+}
+
 
 static auto unique_sum = [](auto&&... lss) {
     return ls::support(sum(std::forward<decltype(lss)>(lss)...));
 };
 
-// Combinators:
-// cv_policy_plus_ represents the result of operator+,
-// cv_policy_bar_ represents the result of operator|.
-
-struct cv_policy_plus_: cv_policy_base {
-    cv_policy_plus_(const cv_policy& lhs, const cv_policy& rhs):
-        lhs_(lhs), rhs_(rhs) {}
-
-    cv_policy_base_ptr clone() const override {
-        return cv_policy_base_ptr(new cv_policy_plus_(*this));
-    }
-
-    locset cv_boundary_points(const cable_cell& c) const override {
+struct cvp_cv_policy_plus {
+    locset cv_boundary_points(const cable_cell& c) const {
         return unique_sum(lhs_.cv_boundary_points(c), rhs_.cv_boundary_points(c));
     }
 
-    region domain() const override { return join(lhs_.domain(), rhs_.domain()); }
+    region domain() const { return join(lhs_.domain(), rhs_.domain()); }
 
-    std::ostream& print(std::ostream& os) override {
+    std::ostream& format(std::ostream& os) const {
         os << "(join " << lhs_ << ' ' << rhs_ << ')';
         return os;
     }
@@ -45,24 +44,19 @@ struct cv_policy_plus_: cv_policy_base {
 };
 
 ARB_ARBOR_API cv_policy operator+(const cv_policy& lhs, const cv_policy& rhs) {
-    return cv_policy_plus_(lhs, rhs);
+    return cv_policy{cvp_cv_policy_plus(lhs, rhs)};
 }
 
-struct cv_policy_bar_: cv_policy_base {
-    cv_policy_bar_(const cv_policy& lhs, const cv_policy& rhs):
-        lhs_(lhs), rhs_(rhs) {}
-
-    cv_policy_base_ptr clone() const override {
-        return cv_policy_base_ptr(new cv_policy_bar_(*this));
+struct cvp_cv_policy_bar {
+    locset cv_boundary_points(const cable_cell& c) const {
+        return unique_sum(ls::restrict_to(lhs_.cv_boundary_points(c),
+                                          complement(rhs_.domain())),
+                          rhs_.cv_boundary_points(c));
     }
 
-    locset cv_boundary_points(const cable_cell& c) const override {
-        return unique_sum(ls::restrict_to(lhs_.cv_boundary_points(c), complement(rhs_.domain())), rhs_.cv_boundary_points(c));
-    }
+    region domain() const { return join(lhs_.domain(), rhs_.domain()); }
 
-    region domain() const override { return join(lhs_.domain(), rhs_.domain()); }
-
-    std::ostream& print(std::ostream& os) override {
+    std::ostream& format(std::ostream& os) const {
         os << "(replace " << lhs_ << ' ' << rhs_ << ')';
         return os;
     }
@@ -71,131 +65,181 @@ struct cv_policy_bar_: cv_policy_base {
 };
 
 ARB_ARBOR_API cv_policy operator|(const cv_policy& lhs, const cv_policy& rhs) {
-    return cv_policy_bar_(lhs, rhs);
+    return cv_policy{cvp_cv_policy_bar(lhs, rhs)};
 }
 
-// Public policy implementations:
+struct cvp_cv_policy_max_extent {
+    double max_extent_;
+    region domain_;
+    cv_policy_flag flags_;
 
-// cv_policy_explicit
-locset cv_policy_explicit::cv_boundary_points(const cable_cell& cell) const {
-    return
-        ls::support(
+    std::ostream& format(std::ostream& os) const {
+        os << "(max-extent " << max_extent_ << ' ' << domain_ << ' ' << print_flag(flags_) << ')';
+        return os;
+    }
+
+    locset cv_boundary_points(const cable_cell& cell) const {
+        const unsigned nbranch = cell.morphology().num_branches();
+        const auto& embed = cell.embedding();
+        if (!nbranch || max_extent_<=0) return ls::nil();
+
+        std::vector<mlocation> points;
+        double oomax_extent = 1./max_extent_;
+        auto comps = components(cell.morphology(), thingify(domain_, cell.provider()));
+
+        for (auto& comp: comps) {
+            for (mcable c: comp) {
+                double cable_length = embed.integrate_length(c);
+                unsigned ncv = std::ceil(cable_length*oomax_extent);
+                double scale = (c.dist_pos-c.prox_pos)/ncv;
+
+                if (has_flag(flags_, cv_policy_flag::interior_forks)) {
+                    for (unsigned i = 0; i<ncv; ++i) {
+                        points.push_back({c.branch, c.prox_pos+(1+2*i)*scale/2});
+                    }
+                }
+                else {
+                    for (unsigned i = 0; i<ncv; ++i) {
+                        points.push_back({c.branch, c.prox_pos+i*scale});
+                    }
+                    points.push_back({c.branch, c.dist_pos});
+                }
+            }
+        }
+
+        util::sort(points);
+        return unique_sum(locset(std::move(points)), ls::cboundary(domain_));
+    }
+
+    region domain() const { return domain_; }
+};
+
+ARB_ARBOR_API cv_policy cv_policy_max_extent(double ext, region reg, cv_policy_flag flag) {
+    return cv_policy{cvp_cv_policy_max_extent{ext, std::move(reg), flag}};
+}
+
+ARB_ARBOR_API cv_policy cv_policy_max_extent(double ext, cv_policy_flag flag) {
+    return cv_policy{cvp_cv_policy_max_extent{ext, reg::all(), flag}};
+}
+
+struct cvp_cv_policy_explicit {
+    locset locs_;
+    region domain_;
+
+    std::ostream& format(std::ostream& os) const {
+        os << "(explicit " << locs_ << ' ' << domain_ << ')';
+        return os;
+    }
+
+    locset cv_boundary_points(const cable_cell& cell) const {
+        return ls::support(
             util::foldl(
                 [this](locset l, const auto& comp) {
                     return sum(std::move(l), ls::restrict_to(locs_, comp));
                 },
                 ls::boundary(domain_),
                 components(cell.morphology(), thingify(domain_, cell.provider()))));
-}
-
-cv_policy_base_ptr cv_policy_explicit::clone() const {
-    return cv_policy_base_ptr(new cv_policy_explicit(*this));
-}
-
-region cv_policy_explicit::domain() const { return domain_; }
-
-// cv_policy_single
-locset cv_policy_single::cv_boundary_points(const cable_cell&) const {
-    return ls::cboundary(domain_);
-}
-
-cv_policy_base_ptr cv_policy_single::clone() const {
-    return cv_policy_base_ptr(new cv_policy_single(*this));
-}
-
-region cv_policy_single::domain() const { return domain_; }
-
-// cv_policy_max_extent
-locset cv_policy_max_extent::cv_boundary_points(const cable_cell& cell) const {
-    const unsigned nbranch = cell.morphology().num_branches();
-    const auto& embed = cell.embedding();
-    if (!nbranch || max_extent_<=0) return ls::nil();
-
-    std::vector<mlocation> points;
-    double oomax_extent = 1./max_extent_;
-    auto comps = components(cell.morphology(), thingify(domain_, cell.provider()));
-
-    for (auto& comp: comps) {
-        for (mcable c: comp) {
-            double cable_length = embed.integrate_length(c);
-            unsigned ncv = std::ceil(cable_length*oomax_extent);
-            double scale = (c.dist_pos-c.prox_pos)/ncv;
-
-            if (flags_&cv_policy_flag::interior_forks) {
-                for (unsigned i = 0; i<ncv; ++i) {
-                    points.push_back({c.branch, c.prox_pos+(1+2*i)*scale/2});
-                }
-            }
-            else {
-                for (unsigned i = 0; i<ncv; ++i) {
-                    points.push_back({c.branch, c.prox_pos+i*scale});
-                }
-                points.push_back({c.branch, c.dist_pos});
-            }
-        }
     }
 
-    util::sort(points);
-    return unique_sum(locset(std::move(points)), ls::cboundary(domain_));
+    region domain() const { return domain_; }
+};
+
+ARB_ARBOR_API cv_policy cv_policy_explicit(locset ls, region reg) {
+    return cv_policy{cvp_cv_policy_explicit{std::move(ls), std::move(reg)}};
 }
 
-cv_policy_base_ptr cv_policy_max_extent::clone() const {
-    return cv_policy_base_ptr(new cv_policy_max_extent(*this));
-}
+struct cvp_cv_policy_single {
+    region domain() const { return domain_; }
 
-region cv_policy_max_extent::domain() const { return domain_; }
-
-// cv_policy_fixed_per_branch
-locset cv_policy_fixed_per_branch::cv_boundary_points(const cable_cell& cell) const {
-    const unsigned nbranch = cell.morphology().num_branches();
-    if (!nbranch) return ls::nil();
-
-    std::vector<mlocation> points;
-    double ooncv = 1./cv_per_branch_;
-    auto comps = components(cell.morphology(), thingify(domain_, cell.provider()));
-
-    for (auto& comp: comps) {
-        for (mcable c: comp) {
-            double scale = (c.dist_pos-c.prox_pos)*ooncv;
-
-            if (flags_&cv_policy_flag::interior_forks) {
-                for (unsigned i = 0; i<cv_per_branch_; ++i) {
-                    points.push_back({c.branch, c.prox_pos+(1+2*i)*scale/2});
-                }
-            }
-            else {
-                for (unsigned i = 0; i<cv_per_branch_; ++i) {
-                    points.push_back({c.branch, c.prox_pos+i*scale});
-                }
-                points.push_back({c.branch, c.dist_pos});
-            }
-        }
+    std::ostream& format(std::ostream& os) const {
+        os << "(single " << domain_ << ')';
+        return os;
     }
 
-    util::sort(points);
-    return unique_sum(locset(std::move(points)), ls::cboundary(domain_));
+    locset cv_boundary_points(const cable_cell&) const {
+        return ls::cboundary(domain_);
+    }
+
+    region domain_;
+};
+
+ARB_ARBOR_API cv_policy cv_policy_single(region reg) {
+    return cv_policy{cvp_cv_policy_single{std::move(reg)}};
+}
+    
+struct cvp_cv_policy_fixed_per_branch {
+    region domain() const { return domain_; }
+
+    std::ostream& format(std::ostream& os) const {
+        os << "(fixed-per-branch " << cv_per_branch_ << ' ' << domain_ << ' ' << print_flag(flags_) << ')';
+        return os;
+    }
+
+    locset cv_boundary_points(const cable_cell& cell) const {
+        const unsigned nbranch = cell.morphology().num_branches();
+        if (!nbranch) return ls::nil();
+
+        std::vector<mlocation> points;
+        double ooncv = 1./cv_per_branch_;
+        auto comps = components(cell.morphology(), thingify(domain_, cell.provider()));
+
+        for (auto& comp: comps) {
+            for (mcable c: comp) {
+                double scale = (c.dist_pos-c.prox_pos)*ooncv;
+
+                if (has_flag(flags_, cv_policy_flag::interior_forks)) {
+                    for (unsigned i = 0; i<cv_per_branch_; ++i) {
+                        points.push_back({c.branch, c.prox_pos+(1+2*i)*scale/2});
+                    }
+                }
+                else {
+                    for (unsigned i = 0; i<cv_per_branch_; ++i) {
+                        points.push_back({c.branch, c.prox_pos+i*scale});
+                    }
+                    points.push_back({c.branch, c.dist_pos});
+                }
+            }
+        }
+
+        util::sort(points);
+        return unique_sum(locset(std::move(points)), ls::cboundary(domain_));
+    }
+
+    unsigned cv_per_branch_;
+    region domain_;
+    cv_policy_flag flags_;
+};
+
+ARB_ARBOR_API cv_policy cv_policy_fixed_per_branch(unsigned n, region reg, cv_policy_flag flag) {
+    return cv_policy{cvp_cv_policy_fixed_per_branch{n, std::move(reg), flag}};
 }
 
-cv_policy_base_ptr cv_policy_fixed_per_branch::clone() const {
-    return cv_policy_base_ptr(new cv_policy_fixed_per_branch(*this));
+ARB_ARBOR_API cv_policy cv_policy_fixed_per_branch(unsigned n, cv_policy_flag flag) {
+    return cv_policy{cvp_cv_policy_fixed_per_branch{n, reg::all(), flag}};
 }
 
-region cv_policy_fixed_per_branch::domain() const { return domain_; }
+struct cvp_cv_policy_every_segment {
+    region domain() const { return domain_; }
 
+    std::ostream& format(std::ostream& os) const {
+        os << "(every-segment " << domain_ << ')';
+        return os;
+    }
 
-// cv_policy_every_segment
-locset cv_policy_every_segment::cv_boundary_points(const cable_cell& cell) const {
-    const unsigned nbranch = cell.morphology().num_branches();
-    if (!nbranch) return ls::nil();
+    locset cv_boundary_points(const cable_cell& cell) const {
+        const unsigned nbranch = cell.morphology().num_branches();
+        if (!nbranch) return ls::nil();
 
-    return unique_sum(
-                ls::cboundary(domain_),
-                ls::restrict_to(ls::segment_boundaries(), domain_));
+        return unique_sum(
+            ls::cboundary(domain_),
+            ls::restrict_to(ls::segment_boundaries(), domain_));
+    }
+
+    region domain_;
+};
+
+ARB_ARBOR_API cv_policy cv_policy_every_segment(region reg) {
+    return cv_policy{cvp_cv_policy_every_segment{std::move(reg)}};
 }
-cv_policy_base_ptr cv_policy_every_segment::clone() const {
-    return cv_policy_base_ptr(new cv_policy_every_segment(*this));
-}
-
-region cv_policy_every_segment::domain() const { return domain_; }
 
 } // namespace arb

--- a/arbor/cv_policy.cpp
+++ b/arbor/cv_policy.cpp
@@ -40,7 +40,8 @@ struct cvp_cv_policy_plus {
         return os;
     }
 
-    cvp_cv_policy_plus(const cv_policy& lhs, const cv_policy& rhs): lhs_{lhs}, rhs_(rhs) {}
+    // TODO This is needed seemingly only for older compilers
+    cvp_cv_policy_plus(cv_policy lhs, cv_policy rhs): lhs_{std::move(lhs)}, rhs_(std::move(rhs)) {}
 
     cv_policy lhs_, rhs_;
 };
@@ -62,6 +63,9 @@ struct cvp_cv_policy_bar {
         os << "(replace " << lhs_ << ' ' << rhs_ << ')';
         return os;
     }
+
+    // TODO This is needed seemingly only for older compilers
+    cvp_cv_policy_bar(cv_policy lhs, cv_policy rhs): lhs_{std::move(lhs)}, rhs_(std::move(rhs)) {}
 
     cv_policy lhs_, rhs_;
 };

--- a/arbor/fvm_layout.cpp
+++ b/arbor/fvm_layout.cpp
@@ -244,17 +244,13 @@ ARB_ARBOR_API fvm_cv_discretization& append(fvm_cv_discretization& dczn, const f
 }
 
 // FVM discretization
-// ------------------
-
 ARB_ARBOR_API fvm_cv_discretization
-fvm_cv_discretize(const cable_cell& cell, const cable_cell_parameter_set& global_dflt) {
+fvm_cv_discretize(const cable_cell& cell,
+                  const cable_cell_parameter_set& global_dflt) {
     const auto& dflt = cell.default_parameters();
     fvm_cv_discretization D;
-
-    D.geometry = cv_geometry(cell,
-        dflt.discretization? dflt.discretization->cv_boundary_points(cell):
-        global_dflt.discretization? global_dflt.discretization->cv_boundary_points(cell):
-        default_cv_policy().cv_boundary_points(cell));
+    const auto& cvp = cell.discretization().value_or(global_dflt.discretization.value_or(default_cv_policy()));
+    D.geometry = cv_geometry(cell, cvp.cv_boundary_points(cell));
 
     if (D.geometry.empty()) return D;
 

--- a/arbor/include/arbor/cable_cell.hpp
+++ b/arbor/include/arbor/cable_cell.hpp
@@ -9,6 +9,7 @@
 #include <arbor/export.hpp>
 #include <arbor/arbexcept.hpp>
 #include <arbor/cable_cell_param.hpp>
+#include <arbor/cv_policy.hpp>
 #include <arbor/common_types.hpp>
 #include <arbor/constants.hpp>
 #include <arbor/iexpr.hpp>
@@ -237,9 +238,16 @@ using location_assignment =
         mlocation_map<T>>;
 
 using cable_cell_region_map = static_typed_map<region_assignment,
-    density, voltage_process, init_membrane_potential, axial_resistivity,
-    temperature, membrane_capacitance, init_int_concentration,
-    ion_diffusivity, init_ext_concentration, init_reversal_potential>;
+                                               density,
+                                               voltage_process,
+                                               init_membrane_potential,
+                                               axial_resistivity,
+                                               temperature,
+                                               membrane_capacitance,
+                                               init_int_concentration,
+                                               ion_diffusivity,
+                                               init_ext_concentration,
+                                               init_reversal_potential>;
 
 using cable_cell_location_map = static_typed_map<location_assignment,
     synapse, junction, i_clamp, threshold_detector>;
@@ -265,7 +273,10 @@ struct ARB_SYMBOL_VISIBLE cable_cell {
     }
 
     /// Construct from morphology, label and decoration descriptions.
-    cable_cell(const class morphology& m, const decor& d, const label_dict& l={});
+    cable_cell(const class morphology& m,
+               const decor& d,
+               const label_dict& l={},
+               const std::optional<cv_policy>& = {});
 
     /// Access to labels
     const label_dict& labels() const;
@@ -305,6 +316,10 @@ struct ARB_SYMBOL_VISIBLE cable_cell {
 
     // The decorations on the cell.
     const decor& decorations() const;
+
+    // The current cv_policy of this cell
+    const std::optional<cv_policy>& discretization() const;
+    void discretization(cv_policy);
 
     // The default parameter and ion settings on the cell.
     const cable_cell_parameter_set& default_parameters() const;

--- a/arbor/include/arbor/cable_cell_param.hpp
+++ b/arbor/include/arbor/cable_cell_param.hpp
@@ -8,8 +8,8 @@
 
 #include <arbor/export.hpp>
 #include <arbor/arbexcept.hpp>
-#include <arbor/cv_policy.hpp>
 #include <arbor/iexpr.hpp>
+#include <arbor/cv_policy.hpp>
 #include <arbor/mechcat.hpp>
 #include <arbor/morph/locset.hpp>
 #include <arbor/morph/primitives.hpp>
@@ -380,8 +380,7 @@ using defaultable =
                  init_int_concentration,
                  init_ext_concentration,
                  init_reversal_potential,
-                 ion_reversal_potential_method,
-                 cv_policy>;
+                 ion_reversal_potential_method>;
 
 // Cable cell ion and electrical defaults.
 

--- a/arbor/include/arbor/cv_policy.hpp
+++ b/arbor/include/arbor/cv_policy.hpp
@@ -74,7 +74,7 @@ struct ARB_SYMBOL_VISIBLE cv_policy {
     template <typename Impl, typename = std::enable_if_t<!std::is_same_v<std::remove_cvref_t<Impl>, cv_policy>>>
     explicit cv_policy(const Impl& impl): impl_(std::make_unique<wrap<Impl>>(impl)) {}
     template <typename Impl, typename = std::enable_if_t<!std::is_same_v<std::remove_cvref_t<Impl>, cv_policy>>>
-    explicit cv_policy(Impl&& impl): impl_(std::make_unique<wrap<Impl>>(std::move(impl))) {}
+    explicit cv_policy(Impl&& impl): impl_(std::make_unique<wrap<Impl>>(impl)) {}
     // move
     cv_policy(cv_policy&&) = default;
     cv_policy& operator=(cv_policy&&) = default;

--- a/arbor/include/arbor/cv_policy.hpp
+++ b/arbor/include/arbor/cv_policy.hpp
@@ -69,146 +69,77 @@ struct cv_policy_base {
     virtual std::ostream& print(std::ostream&) = 0;
 };
 
-using cv_policy_base_ptr = std::unique_ptr<cv_policy_base>;
-
 struct ARB_SYMBOL_VISIBLE cv_policy {
-    cv_policy(const cv_policy_base& ref) { // implicit
-        policy_ptr = ref.clone();
-    }
-
-    cv_policy(const cv_policy& other):
-        policy_ptr(other.policy_ptr->clone()) {}
-
+    // construct from anything except other policies
+    template <typename Impl, typename = std::enable_if_t<!std::is_same_v<std::remove_cvref_t<Impl>, cv_policy>>>
+    explicit cv_policy(const Impl& impl): impl_(std::make_unique<wrap<Impl>>(impl)) {}
+    template <typename Impl, typename = std::enable_if_t<!std::is_same_v<std::remove_cvref_t<Impl>, cv_policy>>>
+    explicit cv_policy(Impl&& impl): impl_(std::make_unique<wrap<Impl>>(std::move(impl))) {}
+    // move
+    cv_policy(cv_policy&&) = default;
+    cv_policy& operator=(cv_policy&&) = default;
+    // copy
+    cv_policy(const cv_policy& other): impl_(other.impl_->clone()) {}
     cv_policy& operator=(const cv_policy& other) {
-        policy_ptr = other.policy_ptr->clone();
+        impl_ = other.impl_->clone();
         return *this;
     }
 
-    cv_policy(cv_policy&&) = default;
-    cv_policy& operator=(cv_policy&&) = default;
+    // interface
+    locset cv_boundary_points(const cable_cell& cell) const { return impl_->cv_boundary_points(cell); }
+    region domain() const { return impl_->domain(); }
+    std::ostream& format(std::ostream& os) const { return impl_->format(os); }
 
-    locset cv_boundary_points(const cable_cell& cell) const {
-        return policy_ptr->cv_boundary_points(cell);
-    }
-
-    region domain() const {
-        return policy_ptr->domain();
-    }
-
-    friend std::ostream& operator<<(std::ostream& o, const cv_policy& p) {
-        return p.policy_ptr->print(o);
-    }
+    friend ARB_ARBOR_API std::ostream& operator<<(std::ostream& os, const cv_policy& cvp) { return cvp.format(os); }
 
 private:
-    cv_policy_base_ptr policy_ptr;
+    struct iface {
+        virtual locset cv_boundary_points(const cable_cell& cell) const = 0;
+        virtual region domain() const = 0;
+        virtual std::unique_ptr<iface> clone() const = 0;
+        virtual ~iface() {}
+        virtual std::ostream& format(std::ostream&) const = 0;
+    };
+
+    using iface_ptr = std::unique_ptr<iface>;
+
+    template <typename Impl>
+    struct wrap: iface {
+        explicit wrap(const Impl& impl): inner_(impl) {}
+        explicit wrap(Impl&& impl): inner_(std::move(impl)) {}
+
+        locset cv_boundary_points(const cable_cell& cell) const override { return inner_.cv_boundary_points(cell); }
+        region domain() const override { return inner_.domain(); };
+        iface_ptr clone() const override { return std::make_unique<wrap<Impl>>(inner_); }
+        std::ostream& format(std::ostream& os) const override { return inner_.format(os); };
+
+        Impl inner_;
+    };
+
+    iface_ptr impl_;
+};
+
+// Common flags for CV policies; bitwise composable.
+enum class cv_policy_flag: unsigned {
+  none = 0,
+  interior_forks = 1<<0
 };
 
 ARB_ARBOR_API cv_policy operator+(const cv_policy&, const cv_policy&);
 ARB_ARBOR_API cv_policy operator|(const cv_policy&, const cv_policy&);
 
+ARB_ARBOR_API cv_policy cv_policy_explicit(locset, region = reg::all());
 
-// Common flags for CV policies; bitwise composable.
-namespace cv_policy_flag {
-    using value = unsigned;
-    enum : unsigned {
-        none = 0,
-        interior_forks = 1<<0
-    };
-}
+ARB_ARBOR_API cv_policy cv_policy_max_extent(double, region, cv_policy_flag = cv_policy_flag::none);
+ARB_ARBOR_API cv_policy cv_policy_max_extent(double, cv_policy_flag = cv_policy_flag::none);
 
-struct ARB_ARBOR_API cv_policy_explicit: cv_policy_base {
-    explicit cv_policy_explicit(locset locs, region domain = reg::all()):
-        locs_(std::move(locs)), domain_(std::move(domain)) {}
+ARB_ARBOR_API cv_policy cv_policy_fixed_per_branch(unsigned, region, cv_policy_flag = cv_policy_flag::none);
+ARB_ARBOR_API cv_policy cv_policy_fixed_per_branch(unsigned, cv_policy_flag = cv_policy_flag::none);
 
-    cv_policy_base_ptr clone() const override;
-    locset cv_boundary_points(const cable_cell&) const override;
-    region domain() const override;
-    std::ostream& print(std::ostream& os) override {
-        os << "(explicit " << locs_ << ' ' << domain_ << ')';
-        return os;
-    }
+ARB_ARBOR_API cv_policy cv_policy_single(region domain = reg::all());
 
-private:
-    locset locs_;
-    region domain_;
-};
+ARB_ARBOR_API cv_policy cv_policy_every_segment(region domain = reg::all());
 
-struct ARB_ARBOR_API cv_policy_single: cv_policy_base {
-    explicit cv_policy_single(region domain = reg::all()):
-        domain_(domain) {}
-
-    cv_policy_base_ptr clone() const override;
-    locset cv_boundary_points(const cable_cell&) const override;
-    region domain() const override;
-    std::ostream& print(std::ostream& os) override {
-        os << "(single " << domain_ << ')';
-        return os;
-    }
-
-private:
-    region domain_;
-};
-
-struct ARB_ARBOR_API cv_policy_max_extent: cv_policy_base {
-    cv_policy_max_extent(double max_extent, region domain, cv_policy_flag::value flags = cv_policy_flag::none):
-         max_extent_(max_extent), domain_(std::move(domain)), flags_(flags) {}
-
-    explicit cv_policy_max_extent(double max_extent, cv_policy_flag::value flags = cv_policy_flag::none):
-         max_extent_(max_extent), domain_(reg::all()), flags_(flags) {}
-
-    cv_policy_base_ptr clone() const override;
-    locset cv_boundary_points(const cable_cell&) const override;
-    region domain() const override;
-    std::ostream& print(std::ostream& os) override {
-        os << "(max-extent " << max_extent_ << ' ' << domain_ << ' ' << flags_ << ')';
-        return os;
-    }
-
-private:
-    double max_extent_;
-    region domain_;
-    cv_policy_flag::value flags_;
-};
-
-struct ARB_ARBOR_API cv_policy_fixed_per_branch: cv_policy_base {
-    cv_policy_fixed_per_branch(unsigned cv_per_branch, region domain, cv_policy_flag::value flags = cv_policy_flag::none):
-         cv_per_branch_(cv_per_branch), domain_(std::move(domain)), flags_(flags) {}
-
-    explicit cv_policy_fixed_per_branch(unsigned cv_per_branch, cv_policy_flag::value flags = cv_policy_flag::none):
-         cv_per_branch_(cv_per_branch), domain_(reg::all()), flags_(flags) {}
-
-    cv_policy_base_ptr clone() const override;
-    locset cv_boundary_points(const cable_cell&) const override;
-    region domain() const override;
-    std::ostream& print(std::ostream& os) override {
-        os << "(fixed-per-branch " << cv_per_branch_ << ' ' << domain_ << ' ' << flags_ << ')';
-        return os;
-    }
-
-private:
-    unsigned cv_per_branch_;
-    region domain_;
-    cv_policy_flag::value flags_;
-};
-
-struct ARB_ARBOR_API cv_policy_every_segment: cv_policy_base {
-    explicit cv_policy_every_segment(region domain = reg::all()):
-         domain_(std::move(domain)) {}
-
-    cv_policy_base_ptr clone() const override;
-    locset cv_boundary_points(const cable_cell&) const override;
-    region domain() const override;
-    std::ostream& print(std::ostream& os) override {
-        os << "(every-segment " << domain_ << ')';
-        return os;
-    }
-
-private:
-    region domain_;
-};
-
-inline cv_policy default_cv_policy() {
-    return cv_policy_fixed_per_branch(1);
-}
+inline cv_policy default_cv_policy() { return cv_policy_fixed_per_branch(1); }
 
 } // namespace arb

--- a/arbor/include/arbor/cv_policy.hpp
+++ b/arbor/include/arbor/cv_policy.hpp
@@ -74,7 +74,7 @@ struct ARB_SYMBOL_VISIBLE cv_policy {
     template <typename Impl, typename = std::enable_if_t<!std::is_same_v<std::remove_cvref_t<Impl>, cv_policy>>>
     explicit cv_policy(const Impl& impl): impl_(std::make_unique<wrap<Impl>>(impl)) {}
     template <typename Impl, typename = std::enable_if_t<!std::is_same_v<std::remove_cvref_t<Impl>, cv_policy>>>
-    explicit cv_policy(Impl&& impl): impl_(std::make_unique<wrap<Impl>>(impl)) {}
+    explicit cv_policy(Impl&& impl): impl_(std::make_unique<wrap<Impl>>(std::move(impl))) {}
     // move
     cv_policy(cv_policy&&) = default;
     cv_policy& operator=(cv_policy&&) = default;

--- a/arbor/include/arbor/s_expr.hpp
+++ b/arbor/include/arbor/s_expr.hpp
@@ -7,9 +7,7 @@
 #include <string>
 #include <memory>
 #include <type_traits>
-#include <unordered_map>
 #include <variant>
-#include <vector>
 
 #include <arbor/export.hpp>
 

--- a/arbor/include/arbor/util/expected.hpp
+++ b/arbor/include/arbor/util/expected.hpp
@@ -486,7 +486,7 @@ struct expected<void, E> {
     // Swap ops.
 
     void swap(expected& other) {
-        data_.swap(other.data);
+        data_.swap(other.data_);
     }
 
     // Accessors.

--- a/arbor/morph/cv_data.cpp
+++ b/arbor/morph/cv_data.cpp
@@ -138,7 +138,7 @@ arb_size_type cell_cv_data::size() const {
 }
 
 ARB_ARBOR_API std::optional<cell_cv_data> cv_data(const cable_cell& cell) {
-    if (auto policy = cell.decorations().defaults().discretization) {
+    if (const auto& policy = cell.discretization()) {
         return cell_cv_data(cell, policy->cv_boundary_points(cell));
     }
     return {};

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <format>
-
 // Create/manipulate 1-d piecewise defined objects.
 //
 // A `pw_element<A>` describes a _value_ of type `A` and an _extent_ of
@@ -428,7 +426,8 @@ struct pw_elements {
         // check invariant
         if (!((es == 0 && es == vs)
            || (es != 0 && es + 1 == vs))) {
-            throw std::runtime_error{std::format("Vertices and values need to have matching lengths; #vertices={} #values={}.", vs, es)};
+            // TODO(fmt): Make a better error w/ format.
+            throw std::runtime_error{"Vertices and values need to have matching lengths"};
         }
 
         // clean-up

--- a/arbor/util/piecewise.hpp
+++ b/arbor/util/piecewise.hpp
@@ -429,16 +429,18 @@ struct pw_elements {
         auto ei = begin(values);
         auto ee = end(values);
 
-        if (ei == ee) { // empty case
+        // clean-up
+        clear();
+
+        // empty case
+        if (ei == ee) {
             if (vi != ve) throw std::runtime_error{"Vertices and values need to have same length; values too long."};
-            clear();
             return;
         }
-        clear();
         if (vi == ve) throw std::runtime_error{"Vertices and values need to have same length; values too short."};
-
         reserve(vertices.size());
         double left = *vi++;
+        if (vi == ve) throw std::runtime_error{"Vertices and values need to have same length; values too short."};
         double right = *vi++;
         push_back(left, right, *ei++);
 

--- a/arborio/cableio.cpp
+++ b/arborio/cableio.cpp
@@ -360,7 +360,7 @@ morphology make_morphology(const std::vector<std::variant<branch_tuple>>& args) 
 }
 
 // Define cable-cell maker
-// Accepts the morphology, decor and label_dict arguments in any order as a vector
+// Accepts the morphology, decor, label_dict and cv_policy arguments in any order as a vector
 cable_cell make_cable_cell4(const std::vector<std::variant<morphology, label_dict, decor, cv_policy>>& args) {
     decor dec;
     label_dict dict;

--- a/arborio/cv_policy_parse.cpp
+++ b/arborio/cv_policy_parse.cpp
@@ -1,6 +1,4 @@
 #include <any>
-#include <limits>
-#include <optional>
 
 #include <arborio/label_parse.hpp>
 #include <arborio/cv_policy_parse.hpp>
@@ -9,7 +7,6 @@
 #include <arbor/cv_policy.hpp>
 #include <arbor/s_expr.hpp>
 #include <arbor/util/expected.hpp>
-
 
 #include "parse_helpers.hpp"
 
@@ -29,43 +26,43 @@ template<typename T> using parse_hopefully = arb::util::expected<T, cv_policy_pa
 
 std::unordered_multimap<std::string, evaluator>
 eval_map {{"default",
-           make_call<>([] () { return arb::cv_policy{arb::default_cv_policy()}; },
+           make_call<>([] () { return arb::default_cv_policy(); },
                        "'default' with no arguments")},
           {"every-segment",
-           make_call<>([] () { return arb::cv_policy{arb::cv_policy_every_segment()}; },
+           make_call<>([] () { return arb::cv_policy_every_segment(); },
                        "'every-segment' with no arguments")},
           {"every-segment",
-           make_call<region>([] (const region& r) { return arb::cv_policy{arb::cv_policy_every_segment(r) }; },
+           make_call<region>([] (const region& r) { return arb::cv_policy_every_segment(r); },
                              "'every-segment' with one argument (every-segment (reg:region))")},
           {"fixed-per-branch",
-           make_call<int>([] (int i) { return arb::cv_policy{arb::cv_policy_fixed_per_branch(i) }; },
+           make_call<int>([] (int i) { return arb::cv_policy_fixed_per_branch(i); },
                           "'every-segment' with one argument (fixed-per-branch (count:int))")},
           {"fixed-per-branch",
-           make_call<int, region>([] (int i, const region& r) { return arb::cv_policy{arb::cv_policy_fixed_per_branch(i, r) }; },
+           make_call<int, region>([] (int i, const region& r) { return arb::cv_policy_fixed_per_branch(i, r); },
                                   "'every-segment' with two arguments (fixed-per-branch (count:int) (reg:region))")},
           {"fixed-per-branch",
-           make_call<int, region, int>([] (int i, const region& r, int f) { return arb::cv_policy{arb::cv_policy_fixed_per_branch(i, r, f) }; },
-                                       "'fixed-per-branch' with three arguments (fixed-per-branch (count:int) (reg:region) (flags:int))")},
+           make_call<int, region, cv_policy_flag>([] (int i, const region& r, cv_policy_flag f) { return arb::cv_policy_fixed_per_branch(i, r, f); },
+                                                  "'fixed-per-branch' with three arguments (fixed-per-branch (count:int) (reg:region) (flags:flag))")},
           {"max-extent",
-           make_call<double>([] (double i) { return arb::cv_policy{arb::cv_policy_max_extent(i) }; },
+           make_call<double>([] (double i) { return arb::cv_policy_max_extent(i); },
                              "'max-extent' with one argument (max-extent (length:double))")},
           {"max-extent",
-           make_call<double, region>([] (double i, const region& r) { return arb::cv_policy{arb::cv_policy_max_extent(i, r) }; },
+           make_call<double, region>([] (double i, const region& r) { return arb::cv_policy_max_extent(i, r); },
                                      "'max-extent' with two arguments (max-extent (length:double) (reg:region))")},
           {"max-extent",
-           make_call<double, region, int>([] (double i, const region& r, int f) { return arb::cv_policy{arb::cv_policy_max_extent(i, r, f) }; },
-                                          "'max-extent' with three arguments (max-extent (length:double) (reg:region) (flags:int))")},
+           make_call<double, region, cv_policy_flag>([] (double i, const region& r, cv_policy_flag f) { return arb::cv_policy_max_extent(i, r, f); },
+                                                     "'max-extent' with three arguments (max-extent (length:double) (reg:region) (flags:flag))")},
           {"single",
-           make_call<>([] () { return arb::cv_policy{arb::cv_policy_single()}; },
+           make_call<>([] () { return arb::cv_policy_single(); },
                        "'single' with no arguments")},
           {"single",
-           make_call<region>([] (const region& r) { return arb::cv_policy{arb::cv_policy_single(r) }; },
+           make_call<region>([] (const region& r) { return arb::cv_policy_single(r); },
                              "'single' with one argument (single (reg:region))")},
           {"explicit",
-           make_call<locset>([] (const locset& l) { return arb::cv_policy{arb::cv_policy_explicit(l) }; },
+           make_call<locset>([] (const locset& l) { return arb::cv_policy_explicit(l); },
                              "'explicit' with one argument (explicit (ls:locset))")},
           {"explicit",
-           make_call<locset, region>([] (const locset& l, const region& r) { return arb::cv_policy{arb::cv_policy_explicit(l, r) }; },
+           make_call<locset, region>([] (const locset& l, const region& r) { return arb::cv_policy_explicit(l, r); },
                                      "'explicit' with two arguments (explicit (ls:locset) (reg:region))")},
           {"join",
            make_fold<cv_policy>([](cv_policy l, cv_policy r) { return l + r; },
@@ -73,6 +70,12 @@ eval_map {{"default",
           {"replace",
            make_fold<cv_policy>([](cv_policy l, cv_policy r) { return l | r; },
                                 "'replace' with at least 2 arguments: (replace cv_policy cv_policy ...)")},
+          {"flag-none",
+           make_call<>([] () { return cv_policy_flag::none; },
+                       "'flag:none' with no arguments")},
+          {"flag-interior-forks",
+           make_call<>([] () { return cv_policy_flag::interior_forks; },
+                       "'flag-interior-forks' with no arguments")},
 };
 
 parse_hopefully<std::any> eval(const s_expr& e);

--- a/arborio/include/arborio/cv_policy_parse.hpp
+++ b/arborio/include/arborio/cv_policy_parse.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <any>
 #include <string>
 
 #include <arbor/cv_policy.hpp>

--- a/doc/concepts/cable_cell.rst
+++ b/doc/concepts/cable_cell.rst
@@ -7,17 +7,27 @@ An Arbor *cable cell* is a full :ref:`description <modelcelldesc>` of a cell
 with morphology and cell dynamics like ion species and their properties, ion
 channels, synapses, gap junction mechanisms, stimuli and threshold detectors.
 
-Cable cells are constructed from three components:
+Cable cells are constructed from four components:
 
-* :ref:`Morphology <morph>`: a description of the geometry and branching structure of the cell shape.
-* :ref:`Label dictionary <labels>`: a set of definitions and a :abbr:`DSL (domain specific language)` that refer to regions and locations on the cell morphology.
-* :ref:`Decor <cablecell-decoration>`: a description of the dynamics on the cell, placed according to the named rules in the dictionary. It can reference :ref:`mechanisms` from mechanism catalogues.
+* :ref:`Morphology <morph>`: a description of the geometry and branching
+  structure of the cell shape.
+* :ref:`Label dictionary <labels>`: a set of definitions and a :abbr:`DSL
+  (domain specific language)` that refer to regions and locations on the cell
+  morphology.
+* :ref:`Decor <cablecell-decoration>`: a description of the dynamics on the
+  cell, placed according to the named rules in the dictionary. It can reference
+  :ref:`mechanisms` from mechanism catalogues.
+* :ref:`Discretization <cablecell-discretization` a prescription of how to split
+  the cell into control volumes (CV) also known as compartments.
 
 When a cable cell is constructed the following steps are performed using the inputs:
 
-1. Concrete regions and locsets are generated for the morphology for each labelled region and locset in the dictionary
-2. The default values for parameters specified in the decor, such as ion species concentration, are instantiated.
-3. Dynamics (mechanisms, parameters, synapses, gap junctions etc.) are instantiated on the regions and locsets as specified by the decor.
+1. Concrete regions and locsets are generated for the morphology for each
+   labelled region and locset in the dictionary
+2. The default values for parameters specified in the decor, such as ion species
+   concentration, are instantiated.
+3. Dynamics (mechanisms, parameters, synapses, gap junctions etc.) are
+   instantiated on the regions and locsets as specified by the decor.
 
 Once constructed, the cable cell can be queried for specific information about the cell, but it can't be modified (it is *immutable*).
 
@@ -46,6 +56,7 @@ Once constructed, the cable cell can be queried for specific information about t
    labels
    mechanisms
    decor
+   discretization
 
 API
 ---

--- a/doc/concepts/discretization.rst
+++ b/doc/concepts/discretization.rst
@@ -1,0 +1,55 @@
+.. _discretization:
+
+.. _cablecell-discretization:
+
+Discretization
+==============
+
+Before Arbor can actually simulate the behavior of a cell using the interplay of
+morpholgy, mechanisms, etc it needs to turn the contiguous morphology into a
+collection of discrete, conical sub-volumes. These are called 'compartments' or
+'control volumes' (CV). The granularity of the subdivision controls the
+precision of the simulation and its computational cost.
+
+Arbor offers a set of composable discretization policies
+
+.. label:: (cv-policy-explicit locset region)
+
+   Use the subdivision as given by ``locset``
+
+.. label:: (cv-policy-max-extent ext region flags)
+
+   Subdivision into CVs of at most ``ext`` :math:`\mu m`. In the vicinity of
+   fork points, smaller CVs might be used to avoid producing CVs containing
+   forks, unless ``flags`` is ``(flag-interior-forks)``.
+
+.. label:: (cv-policy-fixed-per-branch n region)
+
+   Subdivide each branch into ``n`` equal CVs. In the vicinity of fork points,
+   smaller CVs might be used to avoid producing CVs containing forks, unless
+   ``flags`` is ``(flag-interior-forks)``.
+
+.. label:: (cv-policy-every-segment region)
+
+   Each segment --- as given during morphology construction --- will produce
+   one CV.
+
+.. label:: (cv-policy-default) = (cv-policy-fixed-per-branch 1)
+
+   Each branch will produce one CV.
+
+.. label:: (cv-policy-single region)
+
+   The whole region will produce one CV.
+
+In all cases ``region`` is optional and defaults to ``(all)``, i.e. the whole
+cell. These policies compose through
+
+.. label:: (join cvp1 cvp2)
+
+   Use the union of the boundary points defined by ``cvp1`` and ``cvp2``.
+
+.. label:: (replace cvp1 cvp2)
+
+   Use the boundary points defined by ``cvp1`` everywhere except where ``cvp2``
+   is defined. There, use those of ``cvp2``.

--- a/doc/dependencies.csv
+++ b/doc/dependencies.csv
@@ -4,7 +4,7 @@ Build option/target,Tool name,Minimum version,Notes,Update criteria
 --,C++ compiler,,C++17 support. See below,
 --,GCC,12.0.0,,"* it is supported by the minimum version of CUDA.
 * it is available either by default or can be installed using standard package manager on the supported Linux versions."
---,Clang,12.0,,
+--,Clang,13.0,,
 --,Apple Clang,15,Apple LLVM version 15.0.0 (clang-1500.x.y.z),
 ARB_GPU,Hip Clang,ROCm 3.9,HIP support is currently experimental.,
 ARB_GPU,CUDA,12.0,,"* It is available on all of the target HPC systems (Piz Daint, Juwels Booster)"

--- a/doc/fileformat/cable_cell.rst
+++ b/doc/fileformat/cable_cell.rst
@@ -396,7 +396,7 @@ Parsable arbor-components and meta-data
 The formats described above can be used to generate a :ref:`label dictionary <labels>`,
 :ref:`decoration <cablecell-decoration>`, :ref:`morphology <morph>`, or :ref:`cable cell <cablecell>`
 object. These are denoted as arbor-components. Arbor-components need to be accompanied by *meta-data*
-specifying the version of the format being used. The only version currently supported is ``0.9-dev``.
+specifying the version of the format being used. The only version currently supported is ``0.10-dev``.
 
 .. label:: (version val:string)
 
@@ -418,7 +418,7 @@ Label-dict
 .. code:: lisp
 
    (arbor-component
-     (meta-data (version "0.9-dev"))
+     (meta-data (version "0.10-dev"))
      (label-dict
        (region-def "my_soma" (tag 1))
        (locset-def "root" (root))))
@@ -429,7 +429,7 @@ Decoration
 .. code:: lisp
 
    (arbor-component
-     (meta-data (version "0.9-dev"))
+     (meta-data (version "0.10-dev"))
      (decor
        (default (membrane-potential -55.000000))
        (place (locset "root") (synapse (mechanism "expsyn")) "root_synapse")
@@ -441,7 +441,7 @@ Morphology
 .. code:: lisp
 
    (arbor-component
-     (meta-data (version "0.9-dev"))
+     (meta-data (version "0.10-dev"))
      (morphology
         (branch 0 -1
           (segment 0 (point 0 0 0 2) (point 4 0 0 2) 1)
@@ -454,7 +454,7 @@ Cable-cell
 .. code:: lisp
 
    (arbor-component
-     (meta-data (version "0.9-dev"))
+     (meta-data (version "0.10-dev"))
      (cable-cell
        (label-dict
          (region-def "my_soma" (tag 1))

--- a/doc/python/cable_cell.rst
+++ b/doc/python/cable_cell.rst
@@ -58,7 +58,7 @@ Cable cells
         :type decorations: :py:class:`decor`
         :param labels: dictionary of labeled regions and locsets
         :type labels: :py:class:`label_dict`
-        :param labels: discretization policy
+        :param discretization: discretization policy
         :type discretization: :py:class:`cv_policy`
 
     .. method:: discretization(policy)

--- a/doc/python/cable_cell.rst
+++ b/doc/python/cable_cell.rst
@@ -48,7 +48,7 @@ Cable cells
         # Construct a cable cell.
         cell = arbor.cable_cell(lmrf.morphology, decor, lmrf.labels)
 
-    .. method:: __init__(morphology, decorations, labels)
+    .. method:: __init__(morphology, decorations, labels=None, discretization=None)
 
         Constructor.
 
@@ -58,15 +58,23 @@ Cable cells
         :type decorations: :py:class:`decor`
         :param labels: dictionary of labeled regions and locsets
         :type labels: :py:class:`label_dict`
+        :param labels: discretization policy
+        :type discretization: :py:class:`cv_policy`
 
-    .. method:: placed_lid_range(index)
+    .. method:: discretization(policy)
 
-        Returns the range of local indexes assigned to a placement in the decorations as a tuple of two integers,
-        that define the range of indexes as a half open interval.
+        Set the cv_policy used to discretise the cell into control volumes for simulation.
 
-        :param index: the unique index of the placement.
-        :type index: int
-        :rtype: tuple(int, int)
+        :param policy: The cv_policy.
+        :type policy: :py:class:`cv_policy`
+
+    .. method:: discretization(policy)
+        :noindex:
+
+        Set the cv_policy used to discretise the cell into control volumes for simulation.
+
+        :param str policy: :ref:`string representation <morph-cv-sexpr>` of a cv_policy.
+
 
 .. py:class:: ion
 

--- a/doc/python/decor.rst
+++ b/doc/python/decor.rst
@@ -173,20 +173,6 @@ Cable cell decoration
         :type d: :py:class:`threshold_detector`
         :param str label: the label of the group of detectors on the locset.
 
-    .. method:: discretization(policy)
-
-        Set the cv_policy used to discretise the cell into control volumes for simulation.
-
-        :param policy: The cv_policy.
-        :type policy: :py:class:`cv_policy`
-
-    .. method:: discretization(policy)
-        :noindex:
-
-        Set the cv_policy used to discretise the cell into control volumes for simulation.
-
-        :param str policy: :ref:`string representation <morph-cv-sexpr>` of a cv_policy.
-
     .. method:: paintings()
 
         Returns a list of tuples ``(region, painted_object)`` for inspection.

--- a/doc/tutorial/single_cell_detailed.rst
+++ b/doc/tutorial/single_cell_detailed.rst
@@ -30,8 +30,8 @@ geometry and dynamics which is constructed from 3 components:
 2. A **label dictionary** storing labelled expressions which define regions and locations of
    interest on the cell.
 3. A **decor** defining various properties and dynamics on these  regions and locations.
-   The decor also includes hints about how the cell is to be modelled under the hood, by
-   splitting it into discrete control volumes (CV).
+4. Finally, the cell needs to know how we will be splitting it into discrete
+   control volumes (CV).
 
 The morphology
 ^^^^^^^^^^^^^^^

--- a/example/busyring/ring.cpp
+++ b/example/busyring/ring.cpp
@@ -421,9 +421,7 @@ arb::cable_cell complex_cell(arb::cell_gid_type gid, const cell_parameters& para
 
     if (params.synapses>1) decor.place(syns, arb::synapse("expsyn"), "s");
 
-    decor.set_default(arb::cv_policy_every_segment());
-
-    return {arb::morphology(tree), decor};
+    return {arb::morphology(tree), decor, {}, arb::cv_policy_every_segment()};
 }
 
 arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) {
@@ -453,7 +451,5 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     }
 
     // Make a CV between every sample in the sample tree.
-    decor.set_default(arb::cv_policy_every_segment());
-
-    return {arb::morphology(tree), decor};
+    return {arb::morphology(tree), decor, {}, arb::cv_policy_every_segment()};
 }

--- a/example/diffusion/diffusion.cpp
+++ b/example/diffusion/diffusion.cpp
@@ -26,7 +26,7 @@ namespace U = arb::units;
 struct linear: public recipe {
      linear(double ext, double dx, double Xi, double beta): l{ext}, d{dx}, i{Xi}, b{beta} {
         gprop.default_parameters = neuron_parameter_defaults;
-        gprop.default_parameters.discretization = cv_policy_max_extent{d};
+        gprop.default_parameters.discretization = cv_policy_max_extent(d);
         gprop.add_ion("bla", 1, 23*U::mM, 42*U::mM, 0*U::mV, b*U::m2/U::s);
     }
 

--- a/example/dryrun/branch_cell.hpp
+++ b/example/dryrun/branch_cell.hpp
@@ -118,12 +118,11 @@ inline arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters
         .place(arb::mlocation{0,0},
                arb::threshold_detector{10*U::mV},
                "detector")                                                 // Add spike threshold detector at the soma.
-        .place(arb::mlocation{0, 0.5}, arb::synapse("expsyn"), "synapse")  // Add a synapse to the mid point of the first dendrite.
-        .set_default(arb::cv_policy_every_segment());                      // Make a CV between every sample in the sample tree.
+        .place(arb::mlocation{0, 0.5}, arb::synapse("expsyn"), "synapse"); // Add a synapse to the mid point of the first dendrite.
 
     // Add additional synapses that will not be connected to anything.
     for (unsigned i=1u; i<params.synapses; ++i) {
         decor.place(arb::mlocation{1, 0.5}, arb::synapse("expsyn"), "dummy_synapses");
     }
-    return arb::cable_cell{arb::morphology(tree), decor, labels};
+    return arb::cable_cell{arb::morphology(tree), decor, labels, arb::cv_policy_every_segment()};
 }

--- a/example/lfp/lfp.cpp
+++ b/example/lfp/lfp.cpp
@@ -86,14 +86,13 @@ private:
             // Use NEURON defaults for reversal potentials, ion concentrations etc., but override ra, cm.
             .set_default(axial_resistivity{100*U::Ohm*U::cm})     // [Ω·cm]
             .set_default(membrane_capacitance{0.01*U::F/U::m2}) // [F/m²]
-            // Twenty CVs per branch on the dendrites (tag 4).
-            .set_default(cv_policy_fixed_per_branch(20, arb::reg::tagged(4)))
             // Add pas and hh mechanisms:
             .paint("(tag 1)"_reg, density("hh")) // (default parameters)
             .paint("(tag 4)"_reg, density("pas/e=-70.0"))
             // Add exponential synapse at centre of soma.
             .place(synapse_location_, synapse("expsyn", {{"e", 0}, {"tau", 2}}), "syn");
-        cell_ = cable_cell(tree, dec);
+        // Twenty CVs per branch on the dendrites (tag 4).
+        cell_ = cable_cell(tree, dec, {}, cv_policy_fixed_per_branch(20, arb::reg::tagged(4)));
     }
 };
 

--- a/example/network_description/branch_cell.hpp
+++ b/example/network_description/branch_cell.hpp
@@ -124,9 +124,5 @@ inline arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters
     }
 
     // Make a CV between every sample in the sample tree.
-    decor.set_default(arb::cv_policy_every_segment());
-
-    arb::cable_cell cell(arb::morphology(tree), decor, labels);
-
-    return cell;
+    return arb::cable_cell(arb::morphology(tree), decor, labels, arb::cv_policy_every_segment());
 }

--- a/example/ornstein_uhlenbeck/ou.cpp
+++ b/example/ornstein_uhlenbeck/ou.cpp
@@ -27,14 +27,13 @@ public:
         // paint the process on the whole cell
         decor dec;
         double const cv_size = 1.0;
-        dec.set_default(cv_policy_max_extent(cv_size));
         dec.paint("(all)"_reg , density("hh"));
         dec.paint("(all)"_reg , density("ornstein_uhlenbeck"));
 
         // single-cell tree with ncvs control volumes
         segment_tree tree;
         tree.append(mnpos, {0, 0, 0.0, 4.0}, {0, 0, ncvs*cv_size, 4.0}, 1);
-        cell_ = cable_cell(morphology(tree), dec);
+        cell_ = cable_cell(morphology(tree), dec, {}, cv_policy_max_extent(cv_size));
     }
 
     arb::cell_size_type num_cells() const override { return 1; }

--- a/example/plasticity/branch_cell.hpp
+++ b/example/plasticity/branch_cell.hpp
@@ -130,7 +130,5 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     }
 
     // Make a CV between every sample in the sample tree.
-    decor.set_default(arb::cv_policy_every_segment());
-
-    return {arb::morphology(tree), labels, decor};
+    return {arb::morphology(tree), decor, labels, arb::cv_policy_every_segment()};
 }

--- a/example/plasticity/plasticity.cpp
+++ b/example/plasticity/plasticity.cpp
@@ -68,9 +68,8 @@ struct recipe: public arb::recipe {
         auto decor = arb::decor{}
             .paint(all, arb::density("hh", {{"gl", 5}}))
             .place(center, arb::synapse("expsyn"), syn)
-            .place(center, arb::threshold_detector{-10.0*arb::units::mV}, det)
-            .set_default(arb::cv_policy_every_segment());
-        return arb::cable_cell({tree}, decor);
+            .place(center, arb::threshold_detector{-10.0*arb::units::mV}, det);
+        return arb::cable_cell({tree}, decor, {}, arb::cv_policy_every_segment());
     }
 };
 

--- a/example/ring/branch_cell.hpp
+++ b/example/ring/branch_cell.hpp
@@ -124,9 +124,5 @@ inline arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters
     }
 
     // Make a CV between every sample in the sample tree.
-    decor.set_default(arb::cv_policy_every_segment());
-
-    arb::cable_cell cell(arb::morphology(tree), decor, labels);
-
-    return cell;
+    return arb::cable_cell(arb::morphology(tree), decor, labels, arb::cv_policy_every_segment());
 }

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -358,30 +358,30 @@ void register_cells(py::module& m) {
 
     // arb::cell_cv_data
     cell_cv_data
-    .def_property_readonly("num_cv", [](const arb::cell_cv_data& data){return data.size();},
-                 "Return the number of CVs in the cell.")
-            .def("cables",
-                 [](const arb::cell_cv_data& d, unsigned index) {
-                    if (index >= d.size()) throw py::index_error("index out of range");
-                    return d.cables(index);
-                 },
-                 "index"_a, "Return a list of cables representing the CV at the given index.")
-            .def("children",
-                 [](const arb::cell_cv_data& d, unsigned index) {
-                     if (index >= d.size()) throw py::index_error("index out of range");
-                     return d.children(index);
-                 },
-                 "index"_a,
-                 "Return a list of indices of the CVs representing the children of the CV at the given index.")
-            .def("parent",
-                 [](const arb::cell_cv_data& d, unsigned index) {
-                     if (index >= d.size()) throw py::index_error("index out of range");
-                     return d.parent(index);
-                 },
-                 "index"_a,
-                 "Return the index of the CV representing the parent of the CV at the given index.")
-            .def("__str__",  [](const arb::cell_cv_data& p){return "<arbor.cell_cv_data>";})
-            .def("__repr__", [](const arb::cell_cv_data& p){return "<arbor.cell_cv_data>";});
+        .def_property_readonly("num_cv", [](const arb::cell_cv_data& data){return data.size();},
+                               "Return the number of CVs in the cell.")
+        .def("cables",
+             [](const arb::cell_cv_data& d, unsigned index) {
+                 if (index >= d.size()) throw py::index_error("index out of range");
+                 return d.cables(index);
+             },
+             "index"_a, "Return a list of cables representing the CV at the given index.")
+        .def("children",
+             [](const arb::cell_cv_data& d, unsigned index) {
+                 if (index >= d.size()) throw py::index_error("index out of range");
+                 return d.children(index);
+             },
+             "index"_a,
+             "Return a list of indices of the CVs representing the children of the CV at the given index.")
+        .def("parent",
+             [](const arb::cell_cv_data& d, unsigned index) {
+                 if (index >= d.size()) throw py::index_error("index out of range");
+                 return d.parent(index);
+             },
+             "index"_a,
+             "Return the index of the CV representing the parent of the CV at the given index.")
+        .def("__str__",  [](const arb::cell_cv_data& p){return "<arbor.cell_cv_data>";})
+        .def("__repr__", [](const arb::cell_cv_data& p){return "<arbor.cell_cv_data>";});
 
     m.def("cv_data", [](const arb::cable_cell& cell) { return arb::cv_data(cell);},
           "cell"_a, "the cable cell",
@@ -913,34 +913,22 @@ void register_cells(py::module& m) {
             },
             "locations"_a, "detector"_a, "label"_a,
             "Add a voltage spike detector at each location in locations."
-            "The group of spike detectors has the label 'label', used for forming connections between cells.")
-        .def("discretization",
-            [](arb::decor& dec, const arb::cv_policy& p) { return dec.set_default(p); },
-            py::arg("policy"),
-             "A cv_policy used to discretise the cell into compartments for simulation")
-        .def("discretization",
-            [](arb::decor& dec, const std::string& p) {
-                return dec.set_default(arborio::parse_cv_policy_expression(p).unwrap());
-            },
-            py::arg("policy"),
-            "An s-expression string representing a cv_policy used to discretise the "
-            "cell into compartments for simulation");
-
+            "The group of spike detectors has the label 'label', used for forming connections between cells.");
     cable_cell
         .def(py::init(
-            [](const arb::morphology& m, const arb::decor& d, const std::optional<label_dict_proxy>& l) {
-                if (l) return arb::cable_cell(m, d, l->dict);
-                return arb::cable_cell(m, d);
+            [](const arb::morphology& m, const arb::decor& d, const std::optional<label_dict_proxy>& l, const std::optional<arb::cv_policy>& p) {
+                if (l) return arb::cable_cell(m, d, l->dict, p);
+                return arb::cable_cell(m, d, {}, p);
             }),
-            "morphology"_a, "decor"_a, "labels"_a=py::none(),
-            "Construct with a morphology, decor, and label dictionary.")
+            "morphology"_a, "decor"_a, "labels"_a=py::none(), "discretization"_a=py::none(),
+            "Construct with a morphology, decor, label dictionary, and cv policy.")
         .def(py::init(
-            [](const arb::segment_tree& t, const arb::decor& d, const std::optional<label_dict_proxy>& l) {
-                if (l) return arb::cable_cell({t}, d, l->dict);
-                return arb::cable_cell({t}, d);
+            [](const arb::segment_tree& t, const arb::decor& d, const std::optional<label_dict_proxy>& l, const std::optional<arb::cv_policy>& p) {
+                if (l) return arb::cable_cell({t}, d, l->dict, p);
+                return arb::cable_cell({t}, d, {}, p);
             }),
-            "segment_tree"_a, "decor"_a, "labels"_a=py::none(),
-            "Construct with a morphology derived from a segment tree, decor, and label dictionary.")
+            "segment_tree"_a, "decor"_a, "labels"_a=py::none(), "discretization"_a=py::none(),
+            "Construct with a morphology derived from a segment tree, decor, label dictionary, and cv policy.")
         .def_property_readonly("num_branches",
             [](const arb::cable_cell& c) {return c.morphology().num_branches();},
             "The number of unbranched cable sections in the morphology.")
@@ -952,6 +940,21 @@ void register_cells(py::module& m) {
         .def("cables",
             [](arb::cable_cell& c, const char* label) {return c.concrete_region(arborio::parse_region_expression(label).unwrap()).cables();},
             "label"_a, "The cable segments of the cell morphology for a region label.")
+        // Discretization
+        .def("discretization",
+            [](const arb::cable_cell& c) { return c.discretization(); },
+             "The cv_policy used to discretise the cell into compartments for simulation")
+        .def("discretization",
+            [](arb::cable_cell& c, const arb::cv_policy& p) { return c.discretization(p); },
+            py::arg("policy"),
+             "A cv_policy used to discretise the cell into compartments for simulation")
+        .def("discretization",
+            [](arb::cable_cell& c, const std::string& p) {
+                return c.discretization(arborio::parse_cv_policy_expression(p).unwrap());
+            },
+            py::arg("policy"),
+            "An s-expression string representing a cv_policy used to discretise the "
+            "cell into compartments for simulation")
         // Stringification
         .def("__repr__", [](const arb::cable_cell&){return "<arbor.cable_cell>";})
         .def("__str__",  [](const arb::cable_cell&){return "<arbor.cable_cell>";});

--- a/python/example/diffusion.py
+++ b/python/example/diffusion.py
@@ -42,7 +42,6 @@ dec = (
     .set_ion("na", int_con=0.0 * U.mM, diff=0.005 * U.m2 / U.s)
     .place("(location 0 0.5)", A.synapse("inject/x=na", {"alpha": 200.0}), "Zap")
     .paint("(all)", A.density("decay/x=na"))
-    .discretization(A.cv_policy("(max-extent 5)"))
     # Set up ion diffusion
     .set_ion(
         "na",
@@ -57,7 +56,7 @@ dec = (
 prb = [
     A.cable_probe_ion_diff_concentration_cell("na", "nad"),
 ]
-cel = A.cable_cell(tree, dec)
+cel = A.cable_cell(tree, dec, discretization=A.cv_policy("(max-extent 5)"))
 rec = recipe(cel, prb)
 sim = A.simulation(rec)
 hdl = (sim.sample((0, "nad"), A.regular_schedule(0.1 * U.ms)),)

--- a/python/example/network_two_cells_gap_junctions.py
+++ b/python/example/network_two_cells_gap_junctions.py
@@ -60,11 +60,11 @@ class TwoCellsWithGapJunction(A.recipe):
         )
 
         if self.max_extent is not None:
-            decor.discretization(A.cv_policy_max_extent(self.max_extent))
+            cvp = A.cv_policy_max_extent(self.max_extent)
         else:
-            decor.discretization(A.cv_policy_single())
+            cvp = A.cv_policy_single()
 
-        return A.cable_cell(tree, decor, labels)
+        return A.cable_cell(tree, decor, labels, cvp)
 
     def gap_junctions_on(self, gid):
         return [A.gap_junction_connection(((gid + 1) % 2, "gj"), "gj", 1)]

--- a/python/example/probe_lfpykit.py
+++ b/python/example/probe_lfpykit.py
@@ -88,15 +88,16 @@ decor = (
     .paint("(all)", A.density("pas/e=-65", g=0.0001))
     # attach the stimulus
     .place(str(clamp_location), iclamp, "iclamp")
-    # use a fixed 3 CVs per branch
-    .discretization(A.cv_policy_fixed_per_branch(3))
 )
+
+# use a fixed 3 CVs per branch
+cvp = A.cv_policy(A.cv_policy_fixed_per_branch(3))
 
 # place_pwlin can be queried with region/locset expressions to obtain
 # geometrical objects, like points and segments, essentially recovering
 # geometry from morphology.
 ppwl = A.place_pwlin(morphology)
-cell = A.cable_cell(morphology, decor)
+cell = A.cable_cell(morphology, decor, discretization=cvp)
 
 # instantiate recipe with cell
 rec = Recipe(cell)

--- a/python/example/probe_lfpykit.py
+++ b/python/example/probe_lfpykit.py
@@ -91,7 +91,7 @@ decor = (
 )
 
 # use a fixed 3 CVs per branch
-cvp = A.cv_policy(A.cv_policy_fixed_per_branch(3))
+cvp = A.cv_policy_fixed_per_branch(3)
 
 # place_pwlin can be queried with region/locset expressions to obtain
 # geometrical objects, like points and segments, essentially recovering

--- a/python/example/single_cell_allen.py
+++ b/python/example/single_cell_allen.py
@@ -131,10 +131,10 @@ def make_cell(base, swc, fit):
     decor.place('"midpoint"', A.threshold_detector(-40 * U.mV), "sd")
 
     # (10) discretisation strategy: max compartment length
-    decor.discretization(A.cv_policy_max_extent(20))
+    cvp = A.cv_policy_max_extent(20)
 
     # (11) Create cell
-    return A.cable_cell(morphology, decor, labels), offset
+    return A.cable_cell(morphology, decor, labels, cvp), offset
 
 
 # (12) Create cell, model

--- a/python/example/single_cell_bluepyopt/l5pc/C060114A7_axon_replacement.acc
+++ b/python/example/single_cell_bluepyopt/l5pc/C060114A7_axon_replacement.acc
@@ -1,6 +1,6 @@
 (arbor-component 
   (meta-data 
-    (version "0.9-dev"))
+    (version "0.10-dev"))
   (morphology 
     (branch 0 -1 
       (segment 0 

--- a/python/example/single_cell_bluepyopt/l5pc/C060114A7_modified.acc
+++ b/python/example/single_cell_bluepyopt/l5pc/C060114A7_modified.acc
@@ -1,6 +1,6 @@
 (arbor-component 
   (meta-data 
-    (version "0.9-dev"))
+    (version "0.10-dev"))
   (morphology 
     (branch 0 -1 
       (segment 0 

--- a/python/example/single_cell_bluepyopt/l5pc/l5pc_decor.acc
+++ b/python/example/single_cell_bluepyopt/l5pc/l5pc_decor.acc
@@ -1,5 +1,5 @@
 (arbor-component
-  (meta-data (version "0.9-dev"))
+  (meta-data (version "0.10-dev"))
   (decor
     (default (membrane-potential -65 (scalar 1.0)))
     (default (temperature-kelvin 307.14999999999998 (scalar 1.0)))

--- a/python/example/single_cell_bluepyopt/l5pc/l5pc_label_dict.acc
+++ b/python/example/single_cell_bluepyopt/l5pc/l5pc_label_dict.acc
@@ -1,5 +1,5 @@
 (arbor-component
-  (meta-data (version "0.9-dev"))
+  (meta-data (version "0.10-dev"))
   (label-dict 
     (region-def "all" (all)) 
     (region-def "apic" (tag 4)) 

--- a/python/example/single_cell_bluepyopt/simplecell/simple_cell_decor.acc
+++ b/python/example/single_cell_bluepyopt/simplecell/simple_cell_decor.acc
@@ -1,5 +1,5 @@
 (arbor-component
-  (meta-data (version "0.9-dev"))
+  (meta-data (version "0.10-dev"))
   (decor
     (paint (region "soma") (membrane-capacitance 0.01 (scalar 1)))
     (paint (region "soma") (density (mechanism "default::hh" ("gnabar" 0.10299326453483033) ("gkbar" 0.027124836082684685))))))

--- a/python/example/single_cell_bluepyopt/simplecell/simple_cell_label_dict.acc
+++ b/python/example/single_cell_bluepyopt/simplecell/simple_cell_label_dict.acc
@@ -1,5 +1,5 @@
 (arbor-component
-  (meta-data (version "0.9-dev"))
+  (meta-data (version "0.10-dev"))
   (label-dict 
     (region-def "all" (all)) 
     (region-def "apic" (tag 4)) 

--- a/python/example/single_cell_bluepyopt_l5pc.py
+++ b/python/example/single_cell_bluepyopt_l5pc.py
@@ -50,7 +50,7 @@ class single_recipe(A.recipe):
     def __init__(self, cell, probes):
         # The base C++ class constructor must be called first, to ensure that
         # all memory in the C++ class is initialized correctly.
-        A.recipe.__init__(self)
+        super().__init__()
         self.the_cell = cell
         self.the_probes = probes
 

--- a/python/example/single_cell_bluepyopt_l5pc.py
+++ b/python/example/single_cell_bluepyopt_l5pc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import arbor
+import arbor as A
 import pandas
 import seaborn
 import sys
@@ -12,7 +12,6 @@ except ImportError:
     exit(-42)
 
 # (1) Read the cell JSON description referencing morphology, label dictionary and decor.
-
 if len(sys.argv) < 2:
     print("No JSON file passed to the program")
     sys.exit(0)
@@ -21,7 +20,6 @@ cell_json_filename = sys.argv[1]
 cell_json, morpho, decor, labels = ephys.create_acc.read_acc(cell_json_filename)
 
 # (2) Define labels for stimuli and voltage recordings.
-
 labels["soma_center"] = "(location 0 0.5)"
 labels["dend1"] = (
     '(restrict-to (distal-translate (proximal (region "apic")) 660)'
@@ -29,42 +27,39 @@ labels["dend1"] = (
 )
 
 # (3) Define stimulus and spike detector, adjust discretization
-
 decor.place(
-    '"soma_center"', arbor.iclamp(tstart=295, duration=5, current=1.9), "soma_iclamp"
+    '"soma_center"', A.iclamp(tstart=295, duration=5, current=1.9), "soma_iclamp"
 )
 
 # Add spike detector
-decor.place('"soma_center"', arbor.threshold_detector(-10), "detector")
+decor.place('"soma_center"', A.threshold_detector(-10), "detector")
 
 # Adjust discretization (single CV on soma, default everywhere else)
-decor.discretization(arbor.cv_policy_max_extent(1.0) | arbor.cv_policy_single('"soma"'))
+cvp = A.cv_policy_max_extent(1.0) | A.cv_policy_single('"soma"')
 
 # (4) Create the cell.
-
-cell = arbor.cable_cell(morpho, decor, labels)
+cell = A.cable_cell(morpho, decor, labels, cvp)
 
 # (5) Declare a probe.
+probe = A.cable_probe_membrane_voltage('"dend1"')
 
-probe = arbor.cable_probe_membrane_voltage('"dend1"')
 
-
-# (6) Create a class that inherits from arbor.recipe
-class single_recipe(arbor.recipe):
+# (6) Create a class that inherits from A.recipe
+class single_recipe(A.recipe):
     # (6.1) Define the class constructor
     def __init__(self, cell, probes):
         # The base C++ class constructor must be called first, to ensure that
         # all memory in the C++ class is initialized correctly.
-        arbor.recipe.__init__(self)
+        A.recipe.__init__(self)
         self.the_cell = cell
         self.the_probes = probes
 
-        self.the_props = arbor.neuron_cable_properties()
+        self.the_props = A.neuron_cable_properties()
 
         # Add catalogues with explicit qualifiers
-        self.the_props.catalogue = arbor.catalogue()
-        self.the_props.catalogue.extend(arbor.default_catalogue(), "default::")
-        self.the_props.catalogue.extend(arbor.bbp_catalogue(), "BBP::")
+        self.the_props.catalogue = A.catalogue()
+        self.the_props.catalogue.extend(A.default_catalogue(), "default::")
+        self.the_props.catalogue.extend(A.bbp_catalogue(), "BBP::")
 
     # (6.2) Override the num_cells method
     def num_cells(self):
@@ -72,7 +67,7 @@ class single_recipe(arbor.recipe):
 
     # (6.3) Override the cell_kind method
     def cell_kind(self, gid):
-        return arbor.cell_kind.cable
+        return A.cell_kind.cable
 
     # (6.4) Override the cell_description method
     def cell_description(self, gid):
@@ -92,13 +87,13 @@ class single_recipe(arbor.recipe):
 recipe = single_recipe(cell, [probe])
 
 # (7) Create a simulation (using defaults for context and partition_load_balance)
-sim = arbor.simulation(recipe)
+sim = A.simulation(recipe)
 
 # Instruct the simulation to record the spikes and sample the probe
-sim.record(arbor.spike_recording.all)
+sim.record(A.spike_recording.all)
 
-probe_id = arbor.cell_member(0, 0)
-handle = sim.sample(probe_id, arbor.regular_schedule(0.02))
+probe_id = A.cell_member(0, 0)
+handle = sim.sample(probe_id, A.regular_schedule(0.02))
 
 # (8) Run the simulation
 sim.run(tfinal=600, dt=0.025)

--- a/python/example/single_cell_bluepyopt_simplecell.py
+++ b/python/example/single_cell_bluepyopt_simplecell.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import arbor
+import arbor as A
 import pandas
 import seaborn
 import sys
@@ -12,7 +12,6 @@ except ImportError:
     exit(-42)
 
 # (1) Read the cell JSON description referencing morphology, label dictionary and decor.
-
 if len(sys.argv) < 2:
     print("No JSON file passed to the program")
     sys.exit(0)
@@ -21,33 +20,29 @@ cell_json_filename = sys.argv[1]
 cell_json, morpho, decor, labels = ephys.create_acc.read_acc(cell_json_filename)
 
 # (2) Define labels for stimuli and voltage recordings.
-
 labels["soma_center"] = "(location 0 0.5)"
 
 # (3) Define stimulus and spike detector, adjust discretization
-
 decor.place(
-    '"soma_center"', arbor.iclamp(tstart=100, duration=50, current=0.05), "soma_iclamp"
+    '"soma_center"', A.iclamp(tstart=100, duration=50, current=0.05), "soma_iclamp"
 )
 
 # Add spike detector
-decor.place('"soma_center"', arbor.threshold_detector(-10), "detector")
+decor.place('"soma_center"', A.threshold_detector(-10), "detector")
 
 # Adjust discretization (single CV on soma, default everywhere else)
-decor.discretization(arbor.cv_policy_max_extent(1.0) | arbor.cv_policy_single('"soma"'))
+cvp = A.cv_policy_max_extent(1.0) | A.cv_policy_single('"soma"')
 
 # (4) Create the cell.
-
-cell = arbor.cable_cell(morpho, decor, labels)
+cell = A.cable_cell(morpho, decor, labels, cvp)
 
 # (5) Make the single cell model.
-
-m = arbor.single_cell_model(cell)
+m = A.single_cell_model(cell)
 
 # Add catalogues with qualifiers
-m.properties.catalogue = arbor.catalogue()
-m.properties.catalogue.extend(arbor.default_catalogue(), "default::")
-m.properties.catalogue.extend(arbor.bbp_catalogue(), "BBP::")
+m.properties.catalogue = A.catalogue()
+m.properties.catalogue.extend(A.default_catalogue(), "default::")
+m.properties.catalogue.extend(A.bbp_catalogue(), "BBP::")
 
 # (6) Attach voltage probe that samples at 50 kHz.
 m.probe("voltage", where='"soma_center"', frequency=50)

--- a/python/example/single_cell_cable.py
+++ b/python/example/single_cell_cable.py
@@ -10,7 +10,8 @@ import seaborn as sns  # You may have to pip install these.
 
 
 class Cable(A.recipe):
-    def __init__(self,
+    def __init__(
+        self,
         probes,
         Vm,
         length,
@@ -21,7 +22,8 @@ class Cable(A.recipe):
         stimulus_start,
         stimulus_duration,
         stimulus_amplitude,
-        cv_policy_max_extent):
+        cv_policy_max_extent,
+    ):
         """
         probes -- list of probes
 

--- a/python/example/single_cell_cable.py
+++ b/python/example/single_cell_cable.py
@@ -10,8 +10,7 @@ import seaborn as sns  # You may have to pip install these.
 
 
 class Cable(A.recipe):
-    def __init__(
-        self,
+    def __init__(self,
         probes,
         Vm,
         length,
@@ -22,8 +21,7 @@ class Cable(A.recipe):
         stimulus_start,
         stimulus_duration,
         stimulus_amplitude,
-        cv_policy_max_extent,
-    ):
+        cv_policy_max_extent):
         """
         probes -- list of probes
 
@@ -103,9 +101,8 @@ class Cable(A.recipe):
         )
 
         policy = A.cv_policy_max_extent(self.cv_policy_max_extent)
-        decor.discretization(policy)
 
-        return A.cable_cell(tree, decor, labels)
+        return A.cable_cell(tree, decor, labels, policy)
 
     def probes(self, _):
         return self.the_probes

--- a/python/example/single_cell_detailed.py
+++ b/python/example/single_cell_detailed.py
@@ -71,12 +71,13 @@ decor = (
     .place('"root"', A.iclamp(30 * U.ms, 1 * U.ms, current=2 * U.nA), "iclamp1")
     .place('"root"', A.iclamp(50 * U.ms, 1 * U.ms, current=2 * U.nA), "iclamp2")
     .place('"axon_terminal"', A.threshold_detector(-10 * U.mV), "detector")
-    # Set discretisation: Soma as one CV, 1um everywhere else
-    .discretization('(replace (single (region "soma")) (max-extent 1.0))')
 )
 
+# Set discretisation: Soma as one CV, 1um everywhere else
+cvp = A.cv_policy('(replace (single (region "soma")) (max-extent 1.0))')
+
 # (4) Create the cell.
-cell = A.cable_cell(morph, decor, labels)
+cell = A.cable_cell(morph, decor, labels, cvp)
 
 # (5) Construct the model
 model = A.single_cell_model(cell)

--- a/python/example/single_cell_detailed_recipe.py
+++ b/python/example/single_cell_detailed_recipe.py
@@ -67,14 +67,13 @@ decor = (
     .place('"root"', A.iclamp(30 * U.ms, 1 * U.ms, current=2 * U.nA), "iclamp1")
     .place('"root"', A.iclamp(50 * U.ms, 1 * U.ms, current=2 * U.nA), "iclamp2")
     .place('"axon_terminal"', A.threshold_detector(-10 * U.mV), "detector")
-    # Set discretisation: Soma as one CV, 1um everywhere else
-    .discretization('(replace (single (region "soma")) (max-extent 1.0))')
 )
 
+# Set discretisation: Soma as one CV, 1um everywhere else
+cvp = A.cv_policy('(replace (single (region "soma")) (max-extent 1.0))')
 
-# (4) Create the cell.
-cell = A.cable_cell(lmrf.morphology, decor, labels)
-
+# (4) Create the cell
+cell = A.cable_cell(lmrf.morphology, decor, labels, cvp)
 
 # (5) Create a class that inherits from A.recipe
 class single_recipe(A.recipe):

--- a/python/example/single_cell_detailed_recipe.py
+++ b/python/example/single_cell_detailed_recipe.py
@@ -75,6 +75,7 @@ cvp = A.cv_policy('(replace (single (region "soma")) (max-extent 1.0))')
 # (4) Create the cell
 cell = A.cable_cell(lmrf.morphology, decor, labels, cvp)
 
+
 # (5) Create a class that inherits from A.recipe
 class single_recipe(A.recipe):
     # (5.1) Define the class constructor

--- a/python/example/single_cell_nml.py
+++ b/python/example/single_cell_nml.py
@@ -63,7 +63,7 @@ decor = (
 )
 
 # Set discretisation: Soma as one CV, 1um everywhere else
-cvp = A.cv_data('(replace (single (region "soma")) (max-extent 1.0))')
+cvp = A.cv_policy('(replace (single (region "soma")) (max-extent 1.0))')
 
 # Combine morphology with region and locset definitions to make a cable cell.
 cell = A.cable_cell(morpho, decor, labels, cvp)

--- a/python/example/single_cell_nml.py
+++ b/python/example/single_cell_nml.py
@@ -60,12 +60,13 @@ decor = (
     .place('"stim_site"', A.iclamp(8 * U.ms, 1 * U.ms, current=4 * U.nA), "iclamp3")
     # Detect spikes at the soma with a voltage threshold of -10 mV.
     .place('"axon_end"', A.threshold_detector(-10 * U.mV), "detector")
-    # Set discretisation: Soma as one CV, 1um everywhere else
-    .discretization('(replace (single (region "soma")) (max-extent 1.0))')
 )
 
+# Set discretisation: Soma as one CV, 1um everywhere else
+cvp = A.cv_data('(replace (single (region "soma")) (max-extent 1.0))')
+
 # Combine morphology with region and locset definitions to make a cable cell.
-cell = A.cable_cell(morpho, decor, labels)
+cell = A.cable_cell(morpho, decor, labels, cvp)
 
 print(cell.locations('"axon_end"'))
 

--- a/python/example/single_cell_swc.py
+++ b/python/example/single_cell_swc.py
@@ -60,13 +60,14 @@ decor = (
     .place('"stim_site"', A.iclamp(8 * U.ms, 1 * U.ms, current=4 * U.nA), "iclamp3")
     # Detect spikes at the soma with a voltage threshold of -10 mV.
     .place('"axon_end"', A.threshold_detector(-10 * U.mV), "detector")
-    # Create the policy used to discretise the cell into CVs.
-    # Use a single CV for the soma, and CVs of maximum length 1 μm elsewhere.
-    .discretization('(replace (single (region "soma")) (max-extent 1.0))')
 )
 
+# Create the policy used to discretise the cell into CVs.
+# Use a single CV for the soma, and CVs of maximum length 1 μm elsewhere.
+cvp = A.cv_policy('(replace (single (region "soma")) (max-extent 1.0))')
+
 # Combine morphology with region and locset definitions to make a cable cell.
-cell = A.cable_cell(morpho, decor, labels)
+cell = A.cable_cell(morpho, decor, labels, cvp)
 
 # Make single cell model.
 m = A.single_cell_model(cell)

--- a/python/strprintf.hpp
+++ b/python/strprintf.hpp
@@ -168,7 +168,7 @@ namespace impl {
             for (auto& x: s.seq_) {
                 if (!first) o << s.sep_;
                 first = false;
-                o << s.f(x);
+                o << s.f_(x);
             }
             return o;
         }

--- a/python/test/unit/test_io.py
+++ b/python/test/unit/test_io.py
@@ -231,9 +231,7 @@ class serdes_recipe(A.recipe):
 
         dec = A.decor()
         dec.paint("(all)", A.density("pas"))
-        dec.discretization(A.cv_policy("(max-extent 1)"))
-
-        return A.cable_cell(tree, dec)
+        return A.cable_cell(tree, dec, discretization=A.cv_policy("(max-extent 1)"))
 
     def global_properties(self, _):
         return self.the_props

--- a/python/test/unit/test_io.py
+++ b/python/test/unit/test_io.py
@@ -9,7 +9,7 @@ from io import StringIO
 
 acc = """(arbor-component
   (meta-data
-    (version "0.9-dev"))
+    (version "0.10-dev"))
   (cable-cell
     (morphology
       (branch 0 -1

--- a/test/common_cells.cpp
+++ b/test/common_cells.cpp
@@ -97,11 +97,9 @@ mcable soma_cell_builder::cable(mcable cab) const {
 
 // Add a new branch that is attached to parent_branch.
 // Returns the id of the new branch.
-msize_t soma_cell_builder::add_branch(
-        msize_t parent_branch,
-        double len, double r1, double r2, int ncomp,
-        const std::string& region)
-{
+msize_t soma_cell_builder::add_branch(msize_t parent_branch,
+                                      double len, double r1, double r2, int ncomp,
+                                      const std::string& region) {
     // Get tag id of region (add a new tag if region does not already exist).
     int tag = get_tag(region);
 
@@ -147,18 +145,13 @@ cable_cell_description soma_cell_builder::make_cell() const {
 
     // Make label dictionary with one entry for each tag.
     label_dict dict;
-    for (auto& tag: tag_map) {
-        dict.set(tag.first, reg::tagged(tag.second));
+    for (auto& [k, v]: tag_map) {
+        dict.set(k, reg::tagged(v));
     }
 
     auto boundaries = cv_boundaries;
-    for (auto& b: boundaries) {
-        b = location(b);
-    }
-    decor decorations;
-    decorations.set_default(cv_policy_explicit(boundaries));
-    // Construct cable_cell from sample tree, dictionary and decorations.
-    return {std::move(tree), std::move(dict), std::move(decorations)};
+    for (auto& b: boundaries) b = location(b);
+    return {std::move(tree), std::move(dict), {}, cv_policy_explicit(boundaries)};
 }
 
 /*
@@ -185,7 +178,7 @@ cable_cell_description make_cell_soma_only(bool with_stim) {
                             "cc");
     }
 
-    return {c.morph, c.labels, c.decorations};
+    return c;
 }
 
 /*
@@ -222,7 +215,7 @@ cable_cell_description make_cell_ball_and_stick(bool with_stim) {
                             "cc");
     }
 
-    return {c.morph, c.labels, c.decorations};
+    return c;
 }
 
 /*
@@ -265,7 +258,7 @@ cable_cell_description make_cell_ball_and_3stick(bool with_stim) {
                             "cc1");
     }
 
-    return {c.morph, c.labels, c.decorations};
+    return c;
 }
 
 } // namespace arb

--- a/test/common_cells.hpp
+++ b/test/common_cells.hpp
@@ -14,10 +14,9 @@ struct cable_cell_description {
     morphology morph;
     label_dict labels;
     decor decorations;
+    std::optional<cv_policy> discretization;
 
-    operator cable_cell() const {
-        return cable_cell(morph, decorations, labels);
-    }
+    operator cable_cell() const { return cable_cell(morph, decorations, labels, discretization); }
 };
 
 class soma_cell_builder {
@@ -38,7 +37,7 @@ public:
     // Add a new branch that is attached to parent_branch.
     // Returns the id of the new branch.
     msize_t add_branch(msize_t parent_branch, double len, double r1, double r2, int ncomp,
-                    const std::string& region);
+                       const std::string& region);
 
     mlocation location(mlocation) const;
     mcable cable(mcable) const;

--- a/test/ubench/CMakeLists.txt
+++ b/test/ubench/CMakeLists.txt
@@ -26,7 +26,7 @@ foreach(bench_src ${bench_sources})
     string(REGEX REPLACE "\\.[^.]*$" "" bench_exe ${bench_src})
     add_executable(${bench_exe} EXCLUDE_FROM_ALL "${bench_src}")
 
-    target_link_libraries(${bench_exe} arbor arborio arbor-private-headers benchmark)
+    target_link_libraries(${bench_exe} arbor arborio arbor-private-headers ext-bench)
     target_compile_options(${bench_exe} PRIVATE ${ARB_CXX_FLAGS_TARGET_FULL})
     target_compile_definitions(${bench_exe} PRIVATE "-DDATADIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../swc\"")
     list(APPEND bench_exe_list ${bench_exe})

--- a/test/ubench/fvm_discretize.cpp
+++ b/test/ubench/fvm_discretize.cpp
@@ -60,7 +60,6 @@ void run_cv_geom_explicit(benchmark::State& state) {
     while (state.KeepRunning()) {
         auto ends = cv_policy_every_segment().cv_boundary_points(c);
         auto ends2 = cv_policy_explicit(std::move(ends)).cv_boundary_points(c);
-
         benchmark::DoNotOptimize(cv_geometry(c, ends2));
     }
 }
@@ -68,38 +67,28 @@ void run_cv_geom_explicit(benchmark::State& state) {
 void run_discretize(benchmark::State& state) {
     auto gdflt = neuron_parameter_defaults;
     const std::size_t ncv_per_branch = state.range(0);
-
-    decor dec;
     auto morpho = from_swc(SWCFILE);
-    dec.set_default(cv_policy_fixed_per_branch(ncv_per_branch));
-
     while (state.KeepRunning()) {
-        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, dec}, gdflt));
+        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, {}, {}, cv_policy_fixed_per_branch(ncv_per_branch)}, gdflt));
     }
 }
 
 void run_discretize_every_segment(benchmark::State& state) {
     auto gdflt = neuron_parameter_defaults;
-
-    decor dec;
     auto morpho = from_swc(SWCFILE);
-    dec.set_default(cv_policy_every_segment());
-
     while (state.KeepRunning()) {
-        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, dec}, gdflt));
+        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, {}, {}, cv_policy_every_segment()}, gdflt));
     }
 }
 
 void run_discretize_explicit(benchmark::State& state) {
     auto gdflt = neuron_parameter_defaults;
 
-    decor dec;
     auto morpho = from_swc(SWCFILE);
-    auto ends = cv_policy_every_segment().cv_boundary_points(cable_cell{morpho, {}});
-    dec.set_default(cv_policy_explicit(std::move(ends)));
+    auto ends = cv_policy_every_segment().cv_boundary_points(cable_cell{morpho, {}, {}, {}});
 
     while (state.KeepRunning()) {
-        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, dec}, gdflt));
+        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, {}, {}, cv_policy_explicit(std::move(ends))}, gdflt));
     }
 }
 

--- a/test/ubench/fvm_discretize.cpp
+++ b/test/ubench/fvm_discretize.cpp
@@ -88,7 +88,7 @@ void run_discretize_explicit(benchmark::State& state) {
     auto ends = cv_policy_every_segment().cv_boundary_points(cable_cell{morpho, {}, {}, {}});
 
     while (state.KeepRunning()) {
-        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, {}, {}, cv_policy_explicit(std::move(ends))}, gdflt));
+        benchmark::DoNotOptimize(fvm_cv_discretize(cable_cell{morpho, {}, {}, cv_policy_explicit(ends)}, gdflt));
     }
 }
 

--- a/test/ubench/mech_vec.cpp
+++ b/test/ubench/mech_vec.cpp
@@ -63,7 +63,6 @@ public:
 
         arb::decor decor;
         decor.paint(arb::reg::tagged(1), arb::density("pas"));
-        decor.set_default(arb::cv_policy_max_extent((dend_length+soma_radius*2)/num_comp_));
 
         auto distribution = std::uniform_real_distribution<float>(0.f, 1.0f);
         for(unsigned i = 0; i < num_synapse_; i++) {
@@ -71,7 +70,7 @@ public:
             decor.place(arb::mlocation{0, distribution(gen)}, arb::synapse("expsyn"), "syn");
         }
 
-        return arb::cable_cell{arb::morphology(tree), decor};
+        return arb::cable_cell{arb::morphology(tree), decor, {}, arb::cv_policy_max_extent((dend_length+soma_radius*2)/num_comp_)};
     }
 
     virtual cell_kind get_cell_kind(cell_gid_type) const override {
@@ -110,9 +109,7 @@ public:
 
         arb::decor decor;
         decor.paint(arb::reg::all(), arb::density("pas"));
-        decor.set_default(arb::cv_policy_max_extent((dend_length+soma_radius*2)/num_comp_));
-
-        return arb::cable_cell {arb::morphology(tree), decor};
+        return arb::cable_cell {arb::morphology(tree), decor, {}, arb::cv_policy_max_extent((dend_length+soma_radius*2)/num_comp_)};
     }
 
     virtual cell_kind get_cell_kind(cell_gid_type) const override {
@@ -153,9 +150,8 @@ public:
 
         arb::decor decor;
         decor.paint(arb::reg::all(), arb::density("pas"));
-        decor.set_default(arb::cv_policy_max_extent((dend_length*3+soma_radius*2)/num_comp_));
 
-        return arb::cable_cell{arb::morphology(tree), decor};
+        return arb::cable_cell{arb::morphology(tree), decor, {}, arb::cv_policy_max_extent((dend_length*3+soma_radius*2)/num_comp_)};
     }
 
     virtual cell_kind get_cell_kind(cell_gid_type) const override {
@@ -194,9 +190,8 @@ public:
 
         arb::decor decor;
         decor.paint(arb::reg::all(), arb::density("hh"));
-        decor.set_default(arb::cv_policy_max_extent((dend_length+soma_radius*2)/num_comp_));
 
-        return arb::cable_cell{arb::morphology(tree), decor};
+        return arb::cable_cell{arb::morphology(tree), decor, {}, arb::cv_policy_max_extent((dend_length+soma_radius*2)/num_comp_)};
     }
 
     virtual cell_kind get_cell_kind(cell_gid_type) const override {
@@ -237,9 +232,8 @@ public:
 
         arb::decor decor;
         decor.paint(arb::reg::all(), arb::density("hh"));
-        decor.set_default(arb::cv_policy_max_extent((dend_length*3+soma_radius*2)/num_comp_));
 
-        return arb::cable_cell{arb::morphology(tree), decor};
+        return arb::cable_cell{arb::morphology(tree), decor, {}, arb::cv_policy_max_extent((dend_length*3+soma_radius*2)/num_comp_)};
     }
 
     virtual cell_kind get_cell_kind(cell_gid_type) const override {

--- a/test/unit-distributed/test_communicator.cpp
+++ b/test/unit-distributed/test_communicator.cpp
@@ -202,10 +202,9 @@ namespace {
                 arb::segment_tree tree;
                 tree.append(arb::mnpos, {0, 0, 0.0, 1.0}, {0, 0, 200, 1.0}, 1);
                 arb::decor decor;
-                decor.set_default(arb::cv_policy_fixed_per_branch(10));
                 decor.place(arb::mlocation{0, 0.5}, arb::threshold_detector{10*arb::units::mV}, "src");
                 decor.place(arb::mlocation{0, 0.5}, arb::synapse("expsyn"), "tgt");
-                return arb::cable_cell(arb::morphology(tree), decor);
+                return arb::cable_cell(arb::morphology(tree), decor, {}, arb::cv_policy_fixed_per_branch(10));
             }
             return arb::lif_cell("src", "tgt");
         }
@@ -274,10 +273,9 @@ namespace {
             arb::segment_tree tree;
             tree.append(arb::mnpos, {0, 0, 0.0, 1.0}, {0, 0, 200, 1.0}, 1);
             arb::decor decor;
-            decor.set_default(arb::cv_policy_fixed_per_branch(10));
             decor.place(arb::mlocation{0, 0.5}, arb::threshold_detector{10*arb::units::mV}, "src");
             decor.place(arb::ls::uniform(arb::reg::all(), 0, size_, gid), arb::synapse("expsyn"), "tgt");
-            return arb::cable_cell(arb::morphology(tree), decor);
+            return arb::cable_cell(arb::morphology(tree), decor, {}, arb::cv_policy_fixed_per_branch(10));
         }
         cell_kind get_cell_kind(cell_gid_type gid) const override {
             return cell_kind::cable;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -193,7 +193,7 @@ make_catalogue_standalone(
 target_link_libraries(dummy-catalogue PRIVATE arbor-private-deps)
 add_dependencies(unit dummy-catalogue)
 
-target_link_libraries(unit PRIVATE arbor-private-deps)
+target_link_libraries(unit PRIVATE arbor-private-deps ext-gtest)
 target_compile_definitions(unit PRIVATE "-DDATADIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../swc\"")
 target_compile_definitions(unit PRIVATE "-DLIBDIR=\"${PROJECT_BINARY_DIR}/lib\"")
 target_include_directories(unit PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/test/unit/test_cv_geom.cpp
+++ b/test/unit/test_cv_geom.cpp
@@ -584,8 +584,7 @@ TEST(region_cv, custom_geometry) {
     {
         decor d;
         // Discretize by segment
-        d.set_default(cv_policy_every_segment());
-        auto cell = cable_cell(m, d, l);
+        auto cell = cable_cell(m, d, l, cv_policy_every_segment());
         auto geom = cv_data(cell);
         EXPECT_TRUE(geom);
 
@@ -642,8 +641,7 @@ TEST(region_cv, custom_geometry) {
           {2, 0.2},
           {2, 1}
         });
-        d.set_default(cv_policy_explicit(ls));
-        auto cell = cable_cell(m, d, l);
+        auto cell = cable_cell(m, d, l, cv_policy_explicit(ls));
         auto geom = cv_data(cell);
         EXPECT_TRUE(geom);
 

--- a/test/unit/test_cv_policy.cpp
+++ b/test/unit/test_cv_policy.cpp
@@ -1,6 +1,3 @@
-#include <iterator>
-#include <numeric>
-#include <utility>
 #include <vector>
 
 #include <arbor/cable_cell.hpp>
@@ -43,8 +40,7 @@ TEST(cv_policy, single) {
     for (region reg:
             {reg::all(), reg::branch(2), reg::cable(3, 0.25, 1.),
              join(reg::cable(1, 0.75, 1), reg::branch(3), reg::cable(2, 0, 0.5)),
-             join(reg::cable(2, 0, 0.5), reg::branch(3), reg::cable(4, 0, 0.5))})
-    {
+             join(reg::cable(2, 0, 0.5), reg::branch(3), reg::cable(4, 0, 0.5))}) {
         locset expected = ls::cboundary(reg);
         EXPECT_TRUE(locset_eq(cell.provider(), ls::cboundary(reg), cv_policy_single(reg).cv_boundary_points(cell)));
     }
@@ -94,9 +90,7 @@ TEST(cv_policy, explicit_policy) {
 
 TEST(cv_policy, empty_morphology) {
     // Any policy applied to an empty morphology should give an empty locset.
-
-    using namespace cv_policy_flag;
-
+    using enum cv_policy_flag;
     cv_policy policies[] = {
         cv_policy_fixed_per_branch(3),
         cv_policy_fixed_per_branch(3, interior_forks),
@@ -116,7 +110,7 @@ TEST(cv_policy, empty_morphology) {
 }
 
 TEST(cv_policy, fixed_per_branch) {
-    using namespace cv_policy_flag;
+    using enum cv_policy_flag;
     using L = mlocation;
 
     // Root branch only:
@@ -200,7 +194,7 @@ TEST(cv_policy, fixed_per_branch) {
 }
 
 TEST(cv_policy, max_extent) {
-    using namespace cv_policy_flag;
+    using enum cv_policy_flag;
     using L = mlocation;
 
     // Root branch only:
@@ -268,7 +262,7 @@ TEST(cv_policy, max_extent) {
 }
 
 TEST(cv_policy, every_segment) {
-    using namespace cv_policy_flag;
+    using enum cv_policy_flag;
 
     // Cell with root branch and two child branches, with multiple samples per branch.
     // Fork is at (0., 0., 4.0).
@@ -317,7 +311,7 @@ TEST(cv_policy, every_segment) {
 }
 
 TEST(cv_policy, domain) {
-    using namespace cv_policy_flag;
+    using enum cv_policy_flag;
 
     region reg1 = join(reg::branch(1), reg::cable(2, 0, 0.5));
     region reg2 = join(reg::branch(1), reg::cable(2, 0.5, 1), reg::cable(4, 0, 1));

--- a/test/unit/test_diffusion.cpp
+++ b/test/unit/test_diffusion.cpp
@@ -37,7 +37,7 @@ constexpr int    with_gpu = -1;
 struct linear: public recipe {
     linear(double x, double d, double c): extent{x}, diameter{d}, cv_length{c} {
         gprop.default_parameters = arb::neuron_parameter_defaults;
-        gprop.default_parameters.discretization = arb::cv_policy_max_extent{cv_length};
+        gprop.default_parameters.discretization = arb::cv_policy_max_extent(cv_length);
         // Stick morphology
         // -----x-----
         segment_tree tree;

--- a/test/unit/test_fvm_layout.cpp
+++ b/test/unit/test_fvm_layout.cpp
@@ -1402,7 +1402,7 @@ TEST(fvm_layout, density_norm_area_partial) {
     hh_end["gkbar"] = end_gkbar;
 
     auto desc = builder.make_cell();
-    desc.decorations.set_default(cv_policy_fixed_per_branch(1));
+    desc.discretization = cv_policy_fixed_per_branch(1);
 
     desc.decorations.paint(builder.cable({1, 0., 0.3}), density(hh_begin));
     desc.decorations.paint(builder.cable({1, 0.4, 1.}), density(hh_end));
@@ -1693,8 +1693,7 @@ TEST(fvm_layout, vinterp_cable) {
 
     // CV midpoints at branch pos 0.1, 0.3, 0.5, 0.7, 0.9.
     // Expect voltage reference locations to be CV modpoints.
-    d.set_default(cv_policy_fixed_per_branch(5));
-    cable_cell cell{m, d};
+    cable_cell cell{m, d, {}, cv_policy_fixed_per_branch(5)};
     fvm_cv_discretization D = fvm_cv_discretize(cell, neuron_parameter_defaults);
 
     // Test locations, either side of CV midpoints plus extrema, CV boundaries.
@@ -1753,8 +1752,7 @@ TEST(fvm_layout, vinterp_forked) {
     // CV 0 contains branch 0 and the fork point; CV 1 and CV 2 have CV 0 as parent,
     // and contain branches 1 and 2 respectively, excluding the fork point.
     mlocation_list cv_ends{{1, 0.}, {2, 0.}};
-    d.set_default(cv_policy_explicit(cv_ends));
-    cable_cell cell{m, d};
+    cable_cell cell{m, d, {}, cv_policy_explicit(cv_ends)};
     fvm_cv_discretization D = fvm_cv_discretize(cell, neuron_parameter_defaults);
 
     // Points in branch 0 should only get CV 0 for interpolation.
@@ -1806,12 +1804,10 @@ TEST(fvm_layout, iinterp) {
         if (p.second.empty()) continue;
         decor d;
 
-        d.set_default(cv_policy_fixed_per_branch(3));
-        cells.emplace_back(cable_cell{p.second, d});
+        cells.emplace_back(cable_cell{p.second, d, {}, cv_policy_fixed_per_branch(3)});
         label.push_back(p.first+": forks-at-end"s);
 
-        d.set_default(cv_policy_fixed_per_branch(3, cv_policy_flag::interior_forks));
-        cells.emplace_back(cable_cell{p.second, d});
+        cells.emplace_back(cable_cell{p.second, d, {}, cv_policy_fixed_per_branch(3, cv_policy_flag::interior_forks)});
         label.push_back(p.first+": interior-forks"s);
     }
 
@@ -1859,8 +1855,7 @@ TEST(fvm_layout, iinterp) {
     // CV 0 contains branch 0 and the fork point; CV 1 and CV 2 have CV 0 as parent,
     // and contain branches 1 and 2 respectively, excluding the fork point.
     mlocation_list cv_ends{{1, 0.}, {2, 0.}};
-    d.set_default(cv_policy_explicit(cv_ends));
-    cable_cell cell{m, d};
+    cable_cell cell{m, d, {}, cv_policy_explicit(cv_ends)};
     D = fvm_cv_discretize(cell, neuron_parameter_defaults);
 
     // Expect axial current interpolations on branches 1 and 2 to match CV 1 and 2
@@ -1925,7 +1920,7 @@ TEST(fvm_layout, inhomogeneous_parameters) {
 
     auto param = neuron_parameter_defaults;
     param.membrane_capacitance = 42.0;
-    param.discretization = cv_policy_fixed_per_branch{30};
+    param.discretization = cv_policy_fixed_per_branch(30);
 
     auto expected = std::vector<param_at>{{8.37758,385.369,2},       // constant
                                           {8.37758,385.369,2},

--- a/test/unit/test_fvm_lowered.cpp
+++ b/test/unit/test_fvm_lowered.cpp
@@ -227,9 +227,9 @@ TEST(fvm_lowered, target_handles) {
     // (in increasing target order)
     descriptions[0].decorations.place(mlocation{0, 0.7}, synapse("expsyn"), "syn0");
     descriptions[0].decorations.place(mlocation{0, 0.3}, synapse("expsyn"), "syn1");
+
     descriptions[1].decorations.place(mlocation{2, 0.2}, synapse("exp2syn"), "syn2");
     descriptions[1].decorations.place(mlocation{2, 0.8}, synapse("expsyn"), "syn3");
-
     descriptions[1].decorations.place(mlocation{0, 0}, threshold_detector{3.3*arb::units::mV}, "detector");
 
     cable_cell cells[] = {descriptions[0], descriptions[1]};
@@ -268,7 +268,6 @@ TEST(fvm_lowered, target_handles) {
     fvm_cell fvcell1(*context);
     auto fvm_info1 = fvcell1.initialize({0, 1}, cable1d_recipe(cells, false));
     test_target_handles(fvcell1);
-
 }
 
 TEST(fvm_lowered, stimulus) {
@@ -825,7 +824,6 @@ TEST(fvm_lowered, post_events_shared_state) {
             tree.append(arb::mnpos, {0, 0, 0.0, 1.0}, {0, 0, 200, 1.0}, 1);
 
             arb::decor decor;
-            decor.set_default(arb::cv_policy_fixed_per_branch(ncv_));
 
             auto ndetectors = detectors_per_cell_[gid];
             auto offset = 1.0 / ndetectors;
@@ -834,7 +832,7 @@ TEST(fvm_lowered, post_events_shared_state) {
             }
             decor.place(arb::mlocation{0, 0.5}, synapse_, "syanpse");
 
-            return arb::cable_cell(arb::morphology(tree), decor);
+            return arb::cable_cell(arb::morphology(tree), decor, {}, arb::cv_policy_fixed_per_branch(ncv_));
         }
 
         cell_kind get_cell_kind(cell_gid_type gid) const override {
@@ -921,22 +919,20 @@ TEST(fvm_lowered, label_data) {
             tree.append(arb::mnpos, {0, 0, 0.0, 1.0}, {0, 0, 200, 1.0}, 1);
             {
                 arb::decor decor;
-                decor.set_default(arb::cv_policy_fixed_per_branch(10));
                 decor.place(uniform(all(), 0, 3, 42), arb::synapse("expsyn"), "4_synapses");
                 decor.place(uniform(all(), 4, 4, 42), arb::synapse("expsyn"), "1_synapse");
                 decor.place(uniform(all(), 5, 5, 42), arb::threshold_detector{10*arb::units::mV}, "1_detector");
 
-                cells_.push_back(arb::cable_cell(arb::morphology(tree), decor));
+                cells_.push_back(arb::cable_cell(arb::morphology(tree), decor, {}, arb::cv_policy_fixed_per_branch(10)));
             }
             {
                 arb::decor decor;
-                decor.set_default(arb::cv_policy_fixed_per_branch(10));
                 decor.place(uniform(all(), 0, 2, 24), arb::threshold_detector{10*arb::units::mV}, "3_detectors");
                 decor.place(uniform(all(), 3, 4, 24), arb::threshold_detector{10*arb::units::mV}, "2_detectors");
                 decor.place(uniform(all(), 5, 6, 24), arb::junction("gj"), "2_gap_junctions");
                 decor.place(uniform(all(), 7, 7, 24), arb::junction("gj"), "1_gap_junction");
 
-                cells_.push_back(arb::cable_cell(arb::morphology(tree), decor));
+                cells_.push_back(arb::cable_cell(arb::morphology(tree), decor, {}, arb::cv_policy_fixed_per_branch(10)));
             }
         }
 

--- a/test/unit/test_s_expr.cpp
+++ b/test/unit/test_s_expr.cpp
@@ -235,11 +235,10 @@ std::string round_trip_network_value(const char* in) {
     }
 }
 
-
 TEST(cv_policies, round_tripping) {
     auto literals = {"(every-segment (tag 42))",
-                     "(fixed-per-branch 23 (segment 0) 1)",
-                     "(max-extent 23.1 (segment 0) 1)",
+                     "(fixed-per-branch 23 (segment 0) (flag-interior-forks))",
+                     "(max-extent 23.1 (segment 0) (flag-interior-forks))",
                      "(single (segment 0))",
                      "(explicit (terminal) (segment 0))",
                      "(join (every-segment (tag 42)) (single (segment 0)))",
@@ -252,8 +251,8 @@ TEST(cv_policies, round_tripping) {
 
 TEST(cv_policies, literals) {
     EXPECT_NO_THROW("(every-segment (tag 42))"_cvp);
-    EXPECT_NO_THROW("(fixed-per-branch 23 (segment 0) 1)"_cvp);
-    EXPECT_NO_THROW("(max-extent 23.1 (segment 0) 1)"_cvp);
+    EXPECT_NO_THROW("(fixed-per-branch 23 (segment 0) (flag-interior-forks))"_cvp);
+    EXPECT_NO_THROW("(max-extent 23.1 (segment 0) (flag-interior-forks))"_cvp);
     EXPECT_NO_THROW("(single (segment 0))"_cvp);
     EXPECT_NO_THROW("(explicit (terminal) (segment 0))"_cvp);
     EXPECT_NO_THROW("(join (every-segment (tag 42)) (single (segment 0)))"_cvp);
@@ -860,8 +859,7 @@ TEST(decor_literals, round_tripping) {
         "(scaled-mechanism (density (mechanism \"pas\" (\"g\" 0.02))) (\"g\" (exp (add (radius 2.1) (scalar 3.2)))))",
     };
     auto default_literals = {
-        "(ion-reversal-potential-method \"ca\" (mechanism \"nernst/ca\"))",
-        "(cv-policy (single (segment 0)))"
+        "(ion-reversal-potential-method \"ca\" (mechanism \"nernst/ca\"))"
     };
     auto place_literals = {
         "(current-clamp (envelope (10 0.5) (110 0.5) (110 0)) 10 0.25)",
@@ -923,8 +921,7 @@ TEST(decor_expressions, round_tripping) {
         "(default (ion-internal-concentration \"ca\" 5 (scalar 75.1)))",
         "(default (ion-external-concentration \"h\" 6 (scalar -50.1)))",
         "(default (ion-reversal-potential \"na\" 7 (scalar 30)))",
-        "(default (ion-reversal-potential-method \"ca\" (mechanism \"nernst/ca\")))",
-        "(default (cv-policy (max-extent 2 (region \"soma\") 2)))"
+        "(default (ion-reversal-potential-method \"ca\" (mechanism \"nernst/ca\")))"
     };
     auto decorate_place_literals = {
         "(place (location 3 0.2) (current-clamp (envelope (10 0.5) (110 0.5) (110 0)) 0.5 0.25) \"clamp\")",
@@ -1004,11 +1001,6 @@ TEST(decor, round_tripping) {
                                 "    (default \n"
                                 "      (ion-reversal-potential-method \"na\" \n"
                                 "        (mechanism \"nernst\")))\n"
-                                "    (default \n"
-                                "      (cv-policy \n"
-                                "        (fixed-per-branch 10 \n"
-                                "          (all)\n"
-                                "          1)))\n"
                                 "    (paint \n"
                                 "      (region \"dend\")\n"
                                 "      (density \n"
@@ -1274,7 +1266,11 @@ TEST(cable_cell, round_tripping) {
                                 "            (110.000000 0.500000)\n"
                                 "            (110.000000 0.000000))\n"
                                 "          0.000000 0.000000)\n"
-                                "        \"iclamp\"))))";
+                                "        \"iclamp\"))\n"
+                                "    (cv-policy \n"
+                                "      (fixed-per-branch 10 \n"
+                                "        (all)\n"
+                                "        (flag-interior-forks)))))";
 
     EXPECT_EQ(component_str, round_trip_component(component_str.c_str()));
 

--- a/test/unit/test_sde.cpp
+++ b/test/unit/test_sde.cpp
@@ -254,15 +254,13 @@ public:
 
         // set cvs explicitly
         double const cv_size = 1.0;
-        dec.set_default(cv_policy_max_extent(cv_size));
-
         // generate cells
         unsigned const n1 = ncvs/2;
         for (unsigned int i=0; i<ncell_; ++i) {
             segment_tree tree;
             tree.append(mnpos, {i*20., 0, 0.0, 4.0}, {i*20., 0, n1*cv_size, 4.0}, 1);
             tree.append(0, {i*20., 0, ncvs*cv_size, 4.0}, 2);
-            cells_.push_back(cable_cell(morphology(tree), dec));
+            cells_.push_back(cable_cell(morphology(tree), dec, {}, cv_policy_max_extent(cv_size)));
         }
     }
 
@@ -335,7 +333,6 @@ public:
 
         // set cvs explicitly
         double const cv_size = 1.0;
-        dec.set_default(cv_policy_max_extent(cv_size));
 
         // generate cells
         unsigned const n1 = ncvs/2;
@@ -343,7 +340,7 @@ public:
             segment_tree tree;
             tree.append(mnpos, {i*20., 0, 0.0, 4.0}, {i*20., 0, n1*cv_size, 4.0}, 1);
             tree.append(0, {i*20., 0, ncvs*cv_size, 4.0}, 2);
-            cells_.push_back(cable_cell(morphology(tree), dec, labels));
+            cells_.push_back(cable_cell(morphology(tree), dec, labels, cv_policy_max_extent(cv_size)));
         }
     }
 
@@ -969,7 +966,6 @@ public:
 
         // set cvs explicitly
         double const cv_size = 1.0;
-        dec.set_default(cv_policy_max_extent(cv_size));
 
         // generate cells
         unsigned const n1 = ncvs/2;
@@ -977,7 +973,7 @@ public:
             segment_tree tree;
             tree.append(mnpos, {i*20., 0, 0.0, 4.0}, {i*20., 0, n1*cv_size, 4.0}, 1);
             tree.append(0, {i*20., 0, ncvs*cv_size, 4.0}, 2);
-            cells_.push_back(cable_cell(morphology(tree), dec, labels));
+            cells_.push_back(cable_cell(morphology(tree), dec, labels, cv_policy_max_extent(cv_size)));
         }
     }
 

--- a/test/unit/test_spikes.cpp
+++ b/test/unit/test_spikes.cpp
@@ -222,12 +222,11 @@ TEST(SPIKES_TEST_CLASS, threshold_watcher_interpolation) {
 
     for (unsigned i = 0; i < 8; i++) {
         arb::decor decor;
-        decor.set_default(arb::cv_policy_every_segment());
         decor.place("mid"_lab, arb::threshold_detector{10*arb::units::mV}, "detector");
         decor.place("mid"_lab, arb::i_clamp::box(0.01*arb::units::ms + i*dt, duration, 0.5*arb::units::nA), "clamp");
         decor.place("mid"_lab, arb::synapse("expsyn"), "synapse");
 
-        arb::cable_cell cell(morpho, decor, dict);
+        arb::cable_cell cell(morpho, decor, dict, arb::cv_policy_every_segment());
         cable1d_recipe rec({cell});
 
         auto decomp = arb::partition_load_balance(rec, context);


### PR DESCRIPTION
This PR rectifies a long-standing issue since the introduction of `decor`: 
CV discretization was treated as a defaultable value instead of a cell property, along with bio-physical properties.

This lead to some awkward facts:
- Intermingling of bio-physics and numerical settings
- Discretization is treated like a default without override.
- Discretization cannot be changed once set, e.g. if read from `.acc`, requiring the copy+update of a decor instead

Thus:
- Discretization can now be set during `cable_cell` construction
- It can be read and updated later
- Refactor `cv_policy` to use type erasure like other, similar constructions, e.g. schedules.
- Hide internal `cv_policy` constructors.

⚠️ Breaks `.acc` by upgrading from 0.9 to 0.10 ⚠️ 

Closes #1408 
