### PR TITLE
Clean up K_T and K_P.

### DIFF
--- a/mechanisms/allen/K_P.mod
+++ b/mechanisms/allen/K_P.mod
@@ -1,6 +1,7 @@
-: Comment: The persistent component of the K current
-: Reference:        Voltage-gated K+ channels in layer 5 neocortical pyramidal neurones from young rats:subtypes and gradients,Korngreen and Sakmann, J. Physiology, 2000
-
+: Comment:   The persistent component of the K current
+: Reference: Voltage-gated K+ channels in layer 5 neocortical pyramidal neurones from young rats:subtypes and gradients
+:            Korngreen and Sakmann
+:            J. Physiology, 2000
 
 NEURON {
     SUFFIX K_P
@@ -9,17 +10,17 @@ NEURON {
 }
 
 UNITS {
-    (S) = (siemens)
+    (S)  = (siemens)
     (mV) = (millivolt)
     (mA) = (milliamp)
 }
 
 PARAMETER {
-    v    (mV)
-    celsius (degC)
-    gbar = 0.00001 (S/cm2)
-    vshift = 0 (mV)
-    tauF = 1
+    v                 (mV)
+    celsius           (degC)
+    gbar    = 0.00001 (S/cm2)
+    vshift  = 0       (mV)
+    tauF    = 1
 }
 
 STATE { m h }
@@ -30,29 +31,32 @@ BREAKPOINT {
     SOLVE states METHOD cnexp
     LOCAL g
     g = gbar*m*m*h
-    ik = g*(v-ek)
+    ik = g*(v - ek)
 }
 
 DERIVATIVE states {
-    LOCAL m_rho, h_rho
+    LOCAL m_rho, h_rho, vs, m_z
 
-    if (v < -50 + vshift){
-        m_rho = qt/(tauF * (1.25 + 175.03*exp(-(v - vshift) * -0.026)))
-       } else {
-        m_rho = qt/(tauF * (1.25 +  13.00*exp(-(v - vshift) * 0.026)))
+    vs = v - vshift
+
+    if (vs < -50) {
+        m_z = 175.03*exp( 0.026*vs)
+    } else {
+        m_z =  13.00*exp(-0.026*vs)
     }
 
-    h_rho =  qt/(360 + (1010 + 24*(v + 55 - vshift))*exp(-((v + 75 - vshift)/48)^2))
+    m_rho = qt/(tauF*(1.25 + m_z))
+    h_rho = qt/((24*vs + 2690)*exp(-((vs + 75)/48)^2))
 
-    m' = qt*(m_inf(v) - m)*m_rho
-    h' = qt*(h_inf(v) - h)*h_rho
+    m' = (m_inf(vs) - m)*m_rho
+    h' = (h_inf(vs) - h)*h_rho
 }
 
 INITIAL{
     qt = 2.3^(0.1*(celsius - 21))
-    m = m_inf(v)
-    h = h_inf(v)
+    m = m_inf(v - vshift)
+    h = h_inf(v - vshift)
 }
 
-FUNCTION m_inf(v) { m_inf = 1/(1 + exp(-(v + 14.3 - vshift)/14.6)) }
-FUNCTION h_inf(v) { h_inf = 1/(1 + exp( (v + 54.0 - vshift)/11)) }
+FUNCTION m_inf(vs) { m_inf = 1/(1 + exp(-(vs + 14.3)/14.6)) }
+FUNCTION h_inf(vs) { h_inf = 1/(1 + exp( (vs + 54.0)/11)) }

--- a/mechanisms/allen/K_T.mod
+++ b/mechanisms/allen/K_T.mod
@@ -1,11 +1,12 @@
 : Comment:   The transient component of the K current
 : Reference: Voltage-gated K+ channels in layer 5 neocortical pyramidal neurones from young rats:subtypes and gradients
-:            Korngreen and Sakmann, J. Physiology, 2000
+:            Korngreen and Sakmann,
+:            J. Physiology, 2000
 
 NEURON {
     SUFFIX K_T
     USEION k READ ek WRITE ik
-    RANGE gbar
+    RANGE gbar, qt, vshift, mTauF, hTauF
 }
 
 UNITS {
@@ -22,31 +23,34 @@ PARAMETER {
     celsius          (degC)
 }
 
-STATE {
-    m
-    h
-}
+STATE { m h }
+
+ASSIGNED { qt }
 
 BREAKPOINT {
     SOLVE states METHOD cnexp
-    ik = gbar*m*m*m*m*h*(v-ek)
+    LOCAL g
+    g = gbar*m*m*m*m*h
+    ik = g*(v - ek)
 }
 
 DERIVATIVE states {
-    LOCAL qt, mRat, hRat, hInf, mInf
+    LOCAL m_rho, h_rho, vs
 
-    qt = 2.3^((celsius-21)/10)
+    vs = v - vshift
 
-    mInf =  1/(1 + exp(-(v + 47 - vshift)/29))
-    hInf =  1/(1 + exp( (v + 66 - vshift)/10))
-    mRat =  qt/(0.34 + mTauF*0.92*exp(-((v + 71 - vshift)/59)^2))
-    hRat =  qt/(8    + hTauF*49  *exp(-((v + 73 - vshift)/23)^2))
+    m_rho =  qt/(0.34 + mTauF* 0.92*exp(-((vs + 71)/59)^2))
+    h_rho =  qt/(8    + hTauF*49.  *exp(-((vs + 73)/23)^2))
 
-    m' = (mInf - m)*mRat
-    h' = (hInf - h)*hRat
+    m' = (m_inf(vs) - m)*m_rho
+    h' = (h_inf(vs) - h)*h_rho
 }
 
-INITIAL{
-    m =  1/(1 + exp(-(v + 47 - vshift)/29))
-    h =  1/(1 + exp( (v + 66 - vshift)/10))
+INITIAL {
+    qt = 2.3^(0.1*(celsius - 21))
+    m = m_inf(v - vshift)
+    h = h_inf(v - vshift)
 }
+
+FUNCTION m_inf(vs) { m_inf = 1/(1 + exp(-(vs + 47)/29))
+FUNCTION h_inf(vs) { h_inf = 1/(1 + exp( (vs + 66)/10))


### PR DESCRIPTION
- Simplify logic and maths
- Remove double application of `qt`
- Align style and usage of both files.
