### PR TITLE
Add cable cell option to Brunel example

### DIFF
--- a/arbor/include/arbor/lif_cell.hpp
+++ b/arbor/include/arbor/lif_cell.hpp
@@ -12,8 +12,8 @@ using namespace U::literals;
 
 // Model parameters of leaky integrate and fire neuron model.
 struct ARB_SYMBOL_VISIBLE lif_cell {
-    cell_tag_type source; // Label of source.
-    cell_tag_type target; // Label of target.
+    cell_tag_type source = ""; // Label of source.
+    cell_tag_type target = ""; // Label of target.
 
     // Neuronal parameters.
     U::quantity tau_m = 10_ms;    // Membrane potential decaying constant [ms].
@@ -23,10 +23,6 @@ struct ARB_SYMBOL_VISIBLE lif_cell {
     U::quantity E_R   =  0_mV;    // Reset potential [mV].
     U::quantity V_m   =  0_mV;    // Initial value of the Membrane potential [mV].
     U::quantity t_ref =  2_ms;    // Refractory period [ms].
-
-    lif_cell() = default;
-    lif_cell(cell_tag_type source, cell_tag_type target): source(std::move(source)), target(std::move(target)) {}
-
 };
 
 // LIF probe metadata, to be passed to sampler callbacks. Intentionally left blank.

--- a/arbor/include/arbor/units.hpp
+++ b/arbor/include/arbor/units.hpp
@@ -59,6 +59,7 @@ constexpr inline auto pA = pico  * A;
 
 constexpr inline auto V = ::units::precise::volt;
 constexpr inline auto mV = milli * V;
+constexpr inline auto uV = micro * V;
 
 constexpr inline auto  Hz = ::units::precise::second.pow(-1);
 constexpr inline auto kHz = kilo * Hz;

--- a/example/remote/remote.cpp
+++ b/example/remote/remote.cpp
@@ -21,15 +21,16 @@ struct remote_recipe: public arb::recipe {
 
         arb::cell_size_type num_cells() const override { return size; }
         arb::util::unique_any get_cell_description(arb::cell_gid_type) const override {
-            auto lif = arb::lif_cell("src", "tgt");
-            lif.tau_m =   2.0*U::ms;
-            lif.V_th  = -10.0*U::mV;
-            lif.C_m   =  20.0*U::pF;
-            lif.E_L   = -23.0*U::mV;
-            lif.V_m   = -23.0*U::mV;
-            lif.E_R   = -23.0*U::mV;
-            lif.t_ref =   0.2*U::ms;
-            return lif;
+            return arb::lif_cell{.source = "src",
+                                 .target = "tgt",
+                                 .tau_m  =   2.0*U::ms,
+                                 .V_th   = -10.0*U::mV,
+                                 .C_m    =  20.0*U::pF,
+                                 .E_L    = -23.0*U::mV,
+                                 .E_R    = -23.0*U::mV,
+                                 .V_m    = -23.0*U::mV,
+                                 .t_ref  =   0.2*U::ms,
+            };
         }
         std::vector<arb::ext_cell_connection> external_connections_on(arb::cell_gid_type) const override {
             std::vector<arb::ext_cell_connection> res;

--- a/python/cells.cpp
+++ b/python/cells.cpp
@@ -266,7 +266,9 @@ void register_cells(py::module& m) {
                std::optional<U::quantity> E_R,
                std::optional<U::quantity> V_m,
                std::optional<U::quantity> t_ref) {
-                auto cell = arb::lif_cell{std::move(source_label), std::move(target_label)};
+                auto cell = arb::lif_cell{};
+                cell.source = std::move(source_label);
+                cell.target = std::move(target_label);
                 if (tau_m) cell.tau_m = *tau_m;
                 if (V_th) cell.V_th = *V_th;
                 if (C_m) cell.C_m = *C_m;

--- a/scripts/run_cpp_examples.sh
+++ b/scripts/run_cpp_examples.sh
@@ -25,7 +25,15 @@ ok=0
 # List of all examples
 all_examples=(
     "bench"
-    "brunel"
+    "brunel -G 1"
+    "brunel -G 10"
+    "brunel -G 100"
+    "brunel -G 100000"
+    "brunel --n-excitatory 10000 --n-inhibitory 2500 --tfinal 10 --in-degree-prop 0.1 --dt 0.01 --lambda 1.5 -g 0.8 --delay 1.0 --weight 0.00010 -G 1 --use-cable-cells"
+    "brunel --n-excitatory 10000 --n-inhibitory 2500 --tfinal 10 --in-degree-prop 0.1 --dt 0.01 --lambda 1.5 -g 0.8 --delay 1.0 --weight 0.00010 -G 10 --use-cable-cells"
+    # TODO These need to be enabled when the group size issue is fixed.
+    # "brunel --n-excitatory 10000 --n-inhibitory 2500 --tfinal 10 --in-degree-prop 0.1 --dt 0.01 --lambda 1.5 -g 0.8 --delay 1.0 --weight 0.00010 -G 100 --use-cable-cells"
+    # "brunel --n-excitatory 10000 --n-inhibitory 2500 --tfinal 10 --in-degree-prop 0.1 --dt 0.01 --lambda 1.5 -g 0.8 --delay 1.0 --weight 0.00010 -G 100000 --use-cable-cells"
     "gap_junctions"
     "generators"
     "lfp"
@@ -49,6 +57,13 @@ skip_local=(
 expected_outputs=(
     972
     6998
+    6998
+    6998
+    6998
+    38956
+    38956
+    # 38956
+    # 38956
     "30"
     ""
     ""

--- a/test/unit-distributed/test_communicator.cpp
+++ b/test/unit-distributed/test_communicator.cpp
@@ -206,7 +206,7 @@ namespace {
                 decor.place(arb::mlocation{0, 0.5}, arb::synapse("expsyn"), "tgt");
                 return arb::cable_cell(arb::morphology(tree), decor, {}, arb::cv_policy_fixed_per_branch(10));
             }
-            return arb::lif_cell("src", "tgt");
+            return arb::lif_cell{.source="src", .target="tgt"};
         }
 
         cell_kind get_cell_kind(cell_gid_type gid) const override {

--- a/test/unit-distributed/test_network_generation.cpp
+++ b/test/unit-distributed/test_network_generation.cpp
@@ -38,7 +38,7 @@ public:
     cell_size_type num_cells() const override { return num_cells_; }
 
     arb::util::unique_any get_cell_description(cell_gid_type gid) const override {
-        if (gid % 3 == 1) { return lif_cell("source", "target"); }
+        if (gid % 3 == 1) { return lif_cell{.source="source", .target="target"}; }
         if (gid % 3 == 2) { return spike_source_cell("spike_source"); }
 
         // cable cell

--- a/test/unit/test_lif_cell_group.cpp
+++ b/test/unit/test_lif_cell_group.cpp
@@ -67,8 +67,7 @@ public:
             return spike_source_cell("src", explicit_schedule_from_milliseconds({0.}));
         }
         // LIF cell.
-        auto cell = lif_cell("src", "tgt");
-        return cell;
+        return lif_cell{.source="src", .target="tgt"};
     }
 
 private:
@@ -97,8 +96,7 @@ public:
     }
 
     util::unique_any get_cell_description(cell_gid_type gid) const override {
-        auto cell = lif_cell("src", "tgt");
-        return cell;
+        return lif_cell{.source="src", .target="tgt"};
     }
 
     std::vector<arb::event_generator> event_generators(arb::cell_gid_type gid) const override {
@@ -137,7 +135,7 @@ public:
         return res;
     }
     util::unique_any get_cell_description(cell_gid_type gid) const override {
-        auto cell = lif_cell("src", "tgt");
+        auto cell = lif_cell{.source="src", .target="tgt"};
         if (gid == 0) {
             cell.E_R = -23.0*U::mV;
             cell.V_m = -18.0*U::mV;

--- a/test/unit/test_simulation.cpp
+++ b/test/unit/test_simulation.cpp
@@ -124,11 +124,15 @@ struct lif_chain: public recipe {
     cell_kind get_cell_kind(cell_gid_type) const override { return cell_kind::lif; }
     util::unique_any get_cell_description(cell_gid_type) const override {
         // A hair-trigger LIF cell with tiny time constant and no refractory period.
-        lif_cell lif("src", "tgt");
-        lif.tau_m = 0.01*U::ms;           // time constant (ms)
-        lif.t_ref = 0*U::ms;              // refactory period (ms)
-        lif.V_th = lif.E_L + 0.001*U::mV; // threshold voltage 1 µV higher than resting
-        return lif;
+        auto E_L = 0_mV;
+        return lif_cell {
+            .source = "src",
+            .target = "tgt",
+            .tau_m  = 0.01*U::ms,      // time constant
+            .V_th   = E_L + 1.0*U::uV, // threshold voltage 1 µV higher than resting
+            .E_L    = E_L,
+            .t_ref  = 0*U::ms,         // refactory period (ms)
+        };
     }
 
     std::vector<cell_connection> connections_on(cell_gid_type target) const override {


### PR DESCRIPTION
1. Add the option to use a simple HH cell to the Brunel example. 
2. Add correct group size controls to Brunel
3. Add more integration tests
4. Make `lif_cell` an aggregate, which enables C++20 designated initializers i.e. `lif_cell {.Vm=42_mV}`.

This enables us to
- test/benchmark the event delivery in the cable cell path (Brunel is quite event heavy)
- add a few integration tests checking the invariance across CPU/GPU and group size with both paths
- add optimizations of said code paths later.