### PR TITLE
No more locks in sampler add/del

### DIFF
--- a/arbor/cable_cell_group.hpp
+++ b/arbor/cable_cell_group.hpp
@@ -74,9 +74,6 @@ private:
 
     // Collection of samplers to be run against probes in this group.
     sampler_association_map sampler_map_;
-
-    // Mutex for thread-safe access to sampler associations.
-    std::mutex sampler_mex_;
 };
 
 } // namespace arb


### PR DESCRIPTION
Recognize that sampler handling is a simulation-level method, which is not callable by multiple threads.