### PR TITLE
Remove obsolete show() from morphology and segment_tree classes

### DIFF
--- a/doc/python/morphology.rst
+++ b/doc/python/morphology.rst
@@ -299,12 +299,6 @@ Cable cell morphology
 
         A list of the segments.
 
-    .. method:: show
-
-        Return a string containing an ASCII rendering of the tree.
-
-        :return: string
-
 .. py:class:: morphology
 
     A *morphology* describes the geometry of a cell as unbranched cables
@@ -357,12 +351,6 @@ Cable cell morphology
 
             :param int i: branch index
             :rtype: list[msegment]
-
-    .. method:: show
-
-        Return a string containing an ASCII rendering of the morphology.
-
-        :return: string
 
 .. py:class:: place_pwlin
 


### PR DESCRIPTION
<!-- Please make sure your PR follows our [contribution guidelines](https://github.com/arbor-sim/arbor/tree/master/doc/contrib) and agree to the terms outlined in the [PR procedure](https://github.com/arbor-sim/arbor/tree/master/doc/contrib/pr.rst). -->

When developing a cell in version 0.10.0, I found that the show() method does not exist for both the segement_tree and morphology classes. I removed them from the documentation.

