### PR TITLE
Re-factor connection setup and event dispatch.

### DIFF
--- a/arbor/backends/event.hpp
+++ b/arbor/backends/event.hpp
@@ -51,6 +51,9 @@ struct deliverable_event {
 struct deliverable_event_data {
     cell_local_size_type mech_index = 0; // same as target_handle::mech_index
     float weight = 0;
+
+    auto operator<=>(deliverable_event_data const&) const noexcept = default;
+
     deliverable_event_data(cell_local_size_type idx, float w) noexcept:
         mech_index(idx),
         weight(w) {}

--- a/arbor/backends/event_stream_base.hpp
+++ b/arbor/backends/event_stream_base.hpp
@@ -8,6 +8,7 @@
 #include "backends/event_stream_state.hpp"
 #include "event_lane.hpp"
 #include "timestep_range.hpp"
+#include "util/span.hpp"
 
 ARB_SERDES_ENABLE_EXT(arb_deliverable_event_data, mech_index, weight);
 
@@ -91,66 +92,49 @@ struct spike_event_stream_base: event_stream_base<deliverable_event> {
                            const timestep_range& steps,
                            std::unordered_map<unsigned, EventStream>& streams) {
         arb_assert(lanes.size() < divs.size());
-
         // reset streams and allocate sufficient space for temporaries
-        auto n_steps = steps.size();
         for (auto& [id, stream]: streams) {
             stream.clear();
             stream.ev_spans_.resize(steps.size() + 1, 0);
-            stream.spikes_.clear();
-            // ev_data_ has been cleared during v.clear(), so we use its capacity
-            stream.spikes_.reserve(stream.ev_data_.capacity());
         }
-
-        // loop over lanes: group events by mechanism and sort them by time
-        arb_size_type cell = 0;
-        for (const auto& lane: lanes) {
-            auto div = divs[cell];
-            arb_size_type step = 0;
-            for (const auto& evt: lane) {
-                step = steps.find(evt.time) - steps.begin();
-                // Events coinciding with epoch's upper boundary belong to next epoch
-                if (step >= n_steps) break;
-                arb_assert(div + evt.target < handles.size());
-                const auto& handle = handles[div + evt.target];
-                auto& stream = streams[handle.mech_id];
-                stream.spikes_.emplace_back(spike_data{step, handle.mech_index, evt.time, evt.weight});
-                stream.ev_spans_[step + 1]++;
+        // Traverse incoming data first by time step then by cell, keeping track
+        // of the next event to process in the time range [t(step), t(step+1)).
+        // That allows for sorting event spans individually.
+        auto cell_evnt_idx = std::vector(lanes.size(), cell_size_type(0));
+        for (auto step: util::count_along(steps)) {
+            const auto& [t_lo, t_hi] = steps[step];
+            for (auto cell_idx: util::count_along(lanes)) {
+                auto div = divs[cell_idx];
+                auto evnt_idx = cell_evnt_idx[cell_idx];
+                const auto& lane = lanes[cell_idx];
+                // find lower edge and skip events
+                for (; evnt_idx < lane.size() && lane[evnt_idx].time < t_lo; ++evnt_idx) {}
+                // traverse lower edge -> upper edge and store events
+                for (; evnt_idx < lane.size() && lane[evnt_idx].time < t_hi; ++evnt_idx) {
+                    const auto& evnt = lane[evnt_idx];
+                    const auto& handle = handles[div + evnt.target];
+                    auto& stream = streams[handle.mech_id];
+                    stream.ev_data_.emplace_back(event_data_type{handle.mech_index, evnt.weight});
+                    stream.ev_spans_[step + 1]++;
+                }
+                // remember the next event to process for cell `idx`
+                cell_evnt_idx[cell_idx] = evnt_idx;
             }
-            ++cell;
+            // sort step bucket and update right partition
+            for (auto& [id, stream]: streams) {
+                // fix the partition property
+                stream.ev_spans_[step + 1] += stream.ev_spans_[step];
+                // sort events in partition
+                std::sort(stream.ev_data_.begin() + stream.ev_spans_[step],
+                          stream.ev_data_.begin() + stream.ev_spans_[step + 1],
+                          [](const auto& a, const auto& b) {
+                              return std::tie(a.mech_index, a.weight) < std::tie(b.mech_index, b.weight);
+                          });
+            }
         }
 
-        // TODO parallelise over streams, however, need a proper testcase/benchmark.
-        // auto tg = threading::task_group(ts.get());
-        for (auto& [id, stream]: streams) {
-            // tg.run([&stream=stream]() {
-                // scan to partition stream (aliasing is explicitly allowed)
-                std::inclusive_scan(stream.ev_spans_.begin(), stream.ev_spans_.end(),
-                                    stream.ev_spans_.begin());
-                // This is made slightly faster by using pdqsort.
-                // Despite events being sorted by time in the partitions defined
-                // by the lane index here, they are not _totally_ sorted, thus
-                // sort is needed, merge not being strong enough :/
-                std::sort(stream.spikes_.begin(), stream.spikes_.end());
-                // copy temporary deliverable_events into stream's ev_data_
-                stream.ev_data_.reserve(stream.spikes_.size());
-                for (const auto& spike: stream.spikes_) stream.ev_data_.emplace_back(event_data_type{spike.mech_index, spike.weight});
-                // delegate to derived class init: static cast necessary to access protected init()
-                static_cast<spike_event_stream_base&>(stream).init();
-            // });
-        }
-        // tg.wait();
+        for (auto& [id, stream]: streams) static_cast<spike_event_stream_base&>(stream).init();
     }
-
-  protected: // members
-    struct spike_data {
-        arb_size_type step = 0;
-        cell_local_size_type mech_index = 0;
-        time_type time = 0;
-        float weight = 0;
-        auto operator<=>(spike_data const&) const noexcept = default;
-    };
-    std::vector<spike_data> spikes_;
 };
 
 struct sample_event_stream_base : event_stream_base<sample_event> {

--- a/arbor/backends/event_stream_base.hpp
+++ b/arbor/backends/event_stream_base.hpp
@@ -108,11 +108,7 @@ struct spike_event_stream_base: event_stream_base<deliverable_event> {
             auto div = divs[cell];
             arb_size_type step = 0;
             for (const auto& evt: lane) {
-                step = std::lower_bound(steps.begin() + step,
-                                        steps.end(),
-                                        evt.time,
-                                        [](const auto& bucket, time_type time) { return bucket.t_end() <= time; })
-                     - steps.begin();
+                step = steps.find(evt.time) - steps.begin();
                 // Events coinciding with epoch's upper boundary belong to next epoch
                 if (step >= n_steps) break;
                 arb_assert(div + evt.target < handles.size());

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -141,10 +141,11 @@ void communicator::update_connections(const recipe& rec,
     std::size_t ext = 0;
     auto src_domain = src_domains.begin();
     auto target_resolver = resolver(&target_resolution_map);
+    auto source_resolver = resolver(&source_resolution_map);
     for (const auto index: util::make_span(num_local_cells_)) {
         const auto tgt_gid = gids[index];
         const auto iod = dom_dec.index_on_domain(tgt_gid);
-        auto source_resolver = resolver(&source_resolution_map);
+        source_resolver.clear();
         for (const auto cidx: util::make_span(part_connections[index], part_connections[index+1])) {
             const auto& conn = gid_connections[cidx];
             auto src_gid = conn.source.gid;

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -156,7 +156,8 @@ void communicator::update_connections(const recipe& rec,
             auto src_dom = dom_dec.gid_domain(src_gid);
             auto src_lid = source_resolver.resolve(conn.source);
             auto tgt_lid = target_resolver.resolve(tgt_gid, conn.target);
-            connections_by_src_domain[src_dom].emplace_back(cell_member_type(src_gid, src_lid), tgt_lid, conn.weight, conn.delay, iod);
+            // NOTE old compilers
+            connections_by_src_domain[src_dom].emplace_back(connection{cell_member_type(src_gid, src_lid), tgt_lid, conn.weight, conn.delay, iod});
             ++n_con;
         }
     }

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -23,6 +23,8 @@
 
 #include "communication/communicator.hpp"
 
+#include "../ska-sort.hpp"
+
 namespace arb {
 
 communicator::communicator(const recipe& rec, const domain_decomposition& dom_dec, context ctx):
@@ -142,7 +144,7 @@ void communicator::update_connections(const recipe& rec,
     //       - generate one resultant vector each
     //       - merge those serially
     //       The word coarsegrained is load-bearing, as many small task will result
-    //       in many, many allocations.
+    //       in many, many allocations and we don't have the proper primitives.
     PE(init:communicator:update:connections:local);
     std::size_t n_con = 0;
     std::vector<std::vector<connection>> connections_by_src_domain(num_domains_);

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -23,8 +23,6 @@
 
 #include "communication/communicator.hpp"
 
-#include "../ska-sort.hpp"
-
 namespace arb {
 
 communicator::communicator(const recipe& rec, const domain_decomposition& dom_dec, context ctx):

--- a/arbor/communication/communicator.cpp
+++ b/arbor/communication/communicator.cpp
@@ -156,8 +156,15 @@ void communicator::update_connections(const recipe& rec,
             auto src_dom = dom_dec.gid_domain(src_gid);
             auto src_lid = source_resolver.resolve(conn.source);
             auto tgt_lid = target_resolver.resolve(tgt_gid, conn.target);
-            // NOTE old compilers
-            connections_by_src_domain[src_dom].emplace_back(connection{cell_member_type(src_gid, src_lid), tgt_lid, conn.weight, conn.delay, iod});
+            // NOTE old compilers stumble over emplace_back here
+            connections_by_src_domain[src_dom].emplace_back(
+                connection{
+                .source={.gid=src_gid, .index=src_lid},
+                .target=tgt_lid,
+                .weight=conn.weight,
+                .delay=conn.delay,
+                .index_on_domain=iod
+            });
             ++n_con;
         }
     }

--- a/arbor/communication/communicator.hpp
+++ b/arbor/communication/communicator.hpp
@@ -93,8 +93,7 @@ public:
         std::vector<float> weights;
         std::vector<float> delays;
 
-        void make(const std::vector<connection>& cons) {
-            clear();
+        void make(std::vector<connection>& cons) {
             for (const auto& con: cons) {
                 idx_on_domain.push_back(con.index_on_domain);
                 srcs.push_back(con.source);
@@ -104,16 +103,12 @@ public:
             }
         }
 
-        void make(const std::vector<std::vector<connection>>& conss) {
-            clear();
-            for (const auto& cons: conss) {
-                for (const auto& con: cons) {
-                    idx_on_domain.push_back(con.index_on_domain);
-                    srcs.push_back(con.source);
-                    dests.push_back(con.target);
-                    weights.push_back(con.weight);
-                    delays.push_back(con.delay);
-                }
+        void make(std::vector<std::vector<connection>>& conss) {
+            for (auto& cons: conss) {
+                make(cons);
+                // NOTE: For memory capacity reasons, we might want to try to
+                //       destroy the sub-vectors here, once we are done.
+                // cons = {};
             }
         }
 
@@ -139,11 +134,6 @@ public:
     const connection_list& connections() const;
 
 private:
-
-    // helper for setting up the connection table
-    void reset_index(const domain_decomposition&);
-    void reset_partition(const std::vector<std::vector<connection>>&);
-
     cell_size_type num_total_cells_ = 0;
     cell_size_type num_local_cells_ = 0;
     cell_size_type num_local_groups_ = 0;

--- a/arbor/communication/communicator.hpp
+++ b/arbor/communication/communicator.hpp
@@ -104,6 +104,27 @@ public:
             }
         }
 
+        void make(const std::vector<std::vector<connection>>& conss) {
+            clear();
+            for (const auto& cons: conss) {
+                for (const auto& con: cons) {
+                    idx_on_domain.push_back(con.index_on_domain);
+                    srcs.push_back(con.source);
+                    dests.push_back(con.target);
+                    weights.push_back(con.weight);
+                    delays.push_back(con.delay);
+                }
+            }
+        }
+
+        void reserve(std::size_t n) {
+            idx_on_domain.reserve(n);
+            srcs.reserve(n);
+            dests.reserve(n);
+            weights.reserve(n);
+            delays.reserve(n);
+        }
+
         void clear() {
             idx_on_domain.clear();
             srcs.clear();
@@ -118,6 +139,10 @@ public:
     const connection_list& connections() const;
 
 private:
+
+    // helper for setting up the connection table
+    void reset_index(const domain_decomposition&);
+    void reset_partition(const std::vector<std::vector<connection>>&);
 
     cell_size_type num_total_cells_ = 0;
     cell_size_type num_local_cells_ = 0;

--- a/arbor/include/arbor/event_generator.hpp
+++ b/arbor/include/arbor/event_generator.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include <arbor/assert.hpp>
 #include <arbor/common_types.hpp>
 #include <arbor/spike_event.hpp>
@@ -10,9 +8,10 @@
 
 namespace arb {
 
-// An `event_generator` generates a sequence of events to be delivered to a cell.
-// The sequence of events is always in ascending order, i.e. each event will be
-// greater than the event that proceeded it, where events are ordered by:
+// An `event_generator` generates a sequence of events to be delivered to a
+// cell. The sequence of events is always in ascending order, i.e. each event
+// will be greater than the event that proceeded it, where events are ordered
+// by:
 //  - delivery time;
 //  - then target id for events with the same delivery time;
 //  - then weight for events with the same delivery time and target.
@@ -25,83 +24,68 @@ namespace arb {
 //
 // `event_seq event_generator::events(time_type to, time_type from)`
 //
-//     Provide a non-owning view on to the events in the time interval
-//     [to, from).
+//     Provide a non-owning view on to the events in the time interval [to,
+//     from).
 //
-// `void resolve_label(resolution_function)`
+// `void set_target_lid(lid)`
 //
-//     event_generators are constructed on cable_local_label_types comprising
-//     a label and a selection policy. These labels need to be resolved to a
-//     specific cell_lid_type. This is done using a resolution_function.
+//     event_generators are constructed on cable_local_label_types comprising a
+//     label and a selection policy. These labels need to be resolved to a
+//     specific cell_lid_type. This is done externally.
 //
-// The `event_seq` type is a pair of `spike_event` pointers that
-// provide a view onto an internally-maintained contiguous sequence
-// of generated spike event objects. This view is valid only for
-// the lifetime of the generator, and is invalidated upon a call
-// to `reset` or another call to `events`.
+// The `event_seq` type is a pair of `spike_event` pointers that provide a view
+// onto an internally-maintained contiguous sequence of generated spike event
+// objects. This view is valid only for the lifetime of the generator, and is
+// invalidated upon a call to `reset` or another call to `events`.
 //
 // Calls to the `events` method must be monotonic in time: without an
-// intervening call to `reset`, two successive calls `events(t0, t1)`
-// and `events(t2, t3)` to the same event generator must satisfy
-// 0 ≤ t0 ≤ t1 ≤ t2 ≤ t3.
+// intervening call to `reset`, two successive calls `events(t0, t1)` and
+// `events(t2, t3)` to the same event generator must satisfy
+//
+//         0 ≤ t0 ≤ t1 ≤ t2 ≤ t3.
 //
 // `event_generator` objects have value semantics.
 
 using event_seq = std::pair<const spike_event*, const spike_event*>;
-using resolution_function = std::function<cell_lid_type(const cell_local_label_type&)>;
-
 
 // Generate events with a fixed target and weight according to
 // a provided time schedule.
-
 struct event_generator {
     event_generator(cell_local_label_type target, float weight, schedule sched):
-        target_(std::move(target)), weight_(weight), sched_(std::move(sched))
+        weight_(weight), target_(std::move(target)), sched_(std::move(sched))
     {}
 
-    void resolve_label(resolution_function label_resolver) {
-        resolved_ = label_resolver(target_);
-    }
+    void set_target_lid(cell_lid_type lid) { target_lid_ = lid; }
+    const cell_local_label_type& target() const { return target_; }
 
-    void reset() {
-        sched_.reset();
-    }
+    void reset() { sched_.reset(); }
 
     event_seq events(time_type t0, time_type t1) {
-        if (!resolved_) throw arbor_internal_error("Unresolved label in event generator.");
-        auto tgt = *resolved_;
-        auto ts = sched_.events(t0, t1);
+        arb_assert(target_lid_ != cell_lid_type(-1));
+        const auto& [t_lo, t_hi] = sched_.events(t0, t1);
 
         events_.clear();
-        events_.reserve(ts.second-ts.first);
-
-        for (auto i = ts.first; i!=ts.second; ++i) {
-            events_.push_back(spike_event{tgt, *i, weight_});
-        }
+        events_.reserve(t_hi - t_lo);
+        for (auto it = t_lo; it != t_hi; ++it) events_.emplace_back(target_lid_, *it, weight_);
 
         return {events_.data(), events_.data()+events_.size()};
     }
 
 private:
-    pse_vector events_;
+    cell_lid_type target_lid_ = cell_lid_type(-1);
+    float weight_ = 0;
     cell_local_label_type target_;
-    resolution_function label_resolver_;
-    std::optional<cell_lid_type> resolved_;
-    float weight_;
+    pse_vector events_;
     schedule sched_;
 };
 
 // Simplest generator: just do nothing
-inline
-event_generator empty_generator(
-    cell_local_label_type target,
-    float weight) {
+inline event_generator empty_generator(cell_local_label_type target, float weight) {
     return event_generator(std::move(target), weight, schedule());
 }
 
 
 // Generate events at integer multiples of dt that lie between tstart and tstop.
-
 inline event_generator regular_generator(cell_local_label_type target,
                                          float weight,
                                          const units::quantity& tstart,
@@ -116,13 +100,11 @@ inline event_generator poisson_generator(cell_local_label_type target,
                                          const units::quantity& rate_kHz,
                                          seed_type seed = default_seed,
                                          const units::quantity& tstop=terminal_time*units::ms) {
-    // TODO(TH) handle seed
     return event_generator(std::move(target), weight, poisson_schedule(tstart, rate_kHz, seed, tstop));
 }
 
 
 // Generate events from a predefined sorted event sequence.
-
 template<typename S> inline
 event_generator explicit_generator(cell_local_label_type target,
                                    float weight,

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -154,8 +154,7 @@ cell_lid_type resolver::resolve(cell_gid_type gid, const cell_local_label_type& 
     }
     else if (pol == lid_selection_policy::round_robin_halt) {
         // Policy round_robin_halt: use previous state of round_robin policy, if existent
-        rrh_state_map_[gid][hash] = rr_state_map_[gid][hash];
-        auto idx = rrh_state_map_[gid][hash];
+        auto idx = rr_state_map_[gid][hash];
         return range_set.at(idx);
     }
     throw std::runtime_error("impossible");

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -97,6 +97,15 @@ std::size_t label_resolution_map::count(cell_gid_type gid, hash_type hash) const
     return map.count(std::make_pair(gid, hash));
 }
 
+const label_resolution_map::range_set& label_resolution_map::at(cell_gid_type gid, const cell_tag_type& tag) const {
+    return at(gid, hash_value(tag));
+}
+
+std::size_t label_resolution_map::count(cell_gid_type gid, const cell_tag_type& tag) const {
+    return count(gid, hash_value(tag));
+}
+
+
 label_resolution_map::label_resolution_map(const cell_labels_and_gids& clg) {
     arb_assert(clg.label_range.check_invariant());
     const auto& gids = clg.gids;

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -97,15 +97,6 @@ std::size_t label_resolution_map::count(cell_gid_type gid, hash_type hash) const
     return map.count(std::make_pair(gid, hash));
 }
 
-const label_resolution_map::range_set& label_resolution_map::at(cell_gid_type gid, const cell_tag_type& tag) const {
-    return at(gid, hash_value(tag));
-}
-
-std::size_t label_resolution_map::count(cell_gid_type gid, const cell_tag_type& tag) const {
-    return count(gid, hash_value(tag));
-}
-
-
 label_resolution_map::label_resolution_map(const cell_labels_and_gids& clg) {
     arb_assert(clg.label_range.check_invariant());
     const auto& gids = clg.gids;

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -83,41 +83,35 @@ private:
 
 struct ARB_ARBOR_API round_robin_state {
     cell_lid_type state = 0;
-    round_robin_state() : state(0) {};
-    round_robin_state(cell_lid_type state) : state(state) {};
-    cell_lid_type get();
     lid_hopefully update(const label_resolution_map::range_set& range);
 };
 
 struct ARB_ARBOR_API round_robin_halt_state {
     cell_lid_type state = 0;
-    round_robin_halt_state() : state(0) {};
-    round_robin_halt_state(cell_lid_type state) : state(state) {};
-    cell_lid_type get();
     lid_hopefully update(const label_resolution_map::range_set& range);
 };
 
-struct ARB_ARBOR_API assert_univalent_state {
-    cell_lid_type get();
-    lid_hopefully update(const label_resolution_map::range_set& range);
-};
+struct ARB_ARBOR_API assert_univalent_state {};
 
 // Struct used for resolving the lid of a (gid, label, lid_selection_policy) input.
 // Requires a `label_resolution_map` which stores the constant mapping of (gid, label) pairs to lid sets.
 struct ARB_ARBOR_API resolver {
+    resolver() = default;
     resolver(const label_resolution_map* label_map): label_map_(label_map) {}
     cell_lid_type resolve(const cell_global_label_type& iden);
     cell_lid_type resolve(cell_gid_type gid, const cell_local_label_type& lid);
 
-    using state_variant = std::variant<round_robin_state, round_robin_halt_state, assert_univalent_state>;
+    void clear() {
+        rr_state_map_.clear();
+        rrh_state_map_.clear();
+    }
 
 private:
     template<typename K, typename V>
     using map = std::unordered_map<K, V>;
-    state_variant construct_state(lid_selection_policy pol);
-    state_variant construct_state(lid_selection_policy pol, cell_lid_type state);
 
-    const label_resolution_map* label_map_;
-    map<cell_gid_type, map<hash_type, map<lid_selection_policy, state_variant>>> state_map_;
+    const label_resolution_map* label_map_ = nullptr;
+    map<cell_gid_type, map<hash_type, round_robin_state>> rr_state_map_;
+    map<cell_gid_type, map<hash_type, round_robin_halt_state>> rrh_state_map_;
 };
 } // namespace arb

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -64,8 +64,7 @@ class ARB_ARBOR_API label_resolution_map {
 public:
     struct range_set {
         std::vector<lid_range> ranges;
-        std::vector<unsigned> ranges_partition = {0};
-        cell_size_type size() const;
+        std::size_t size = 0;
         cell_lid_type at(unsigned idx) const;
     };
 
@@ -75,9 +74,15 @@ public:
     const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const;
     const range_set& at(cell_gid_type gid, hash_type hash) const;
     std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const;
+    std::size_t count(cell_gid_type gid, hash_type hash) const;
 
 private:
-    std::unordered_map<cell_gid_type, std::unordered_map<hash_type, range_set>> map;
+    using Key = std::pair<cell_gid_type, hash_type>;
+
+    struct Hasher {
+        std::size_t operator()(const Key& key) const { return hash_value(key.first, key.second); }
+    };
+    std::unordered_map<Key, range_set, Hasher> map;
 };
 
 // Struct used for resolving the lid of a (gid, label, lid_selection_policy) input.
@@ -88,9 +93,7 @@ struct ARB_ARBOR_API resolver {
     cell_lid_type resolve(const cell_global_label_type& iden);
     cell_lid_type resolve(cell_gid_type gid, const cell_local_label_type& lid);
 
-    void clear() {
-        rr_state_map_.clear();
-    }
+    void clear() { rr_state_map_.clear(); }
 
 private:
     template<typename K, typename V>

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -74,6 +74,8 @@ struct ARB_ARBOR_API label_resolution_map {
 
     const range_set& at(cell_gid_type gid, hash_type hash) const;
     std::size_t count(cell_gid_type gid, hash_type hash) const;
+    const range_set& at(cell_gid_type gid, const cell_tag_type&) const;
+    std::size_t count(cell_gid_type gid, const cell_tag_type&) const;
 
     const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const { return at(gid, hash_value(tag)); }
     std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const { return count(gid, hash_value(tag)); }

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -90,7 +90,6 @@ struct ARB_ARBOR_API resolver {
 
     void clear() {
         rr_state_map_.clear();
-        rrh_state_map_.clear();
     }
 
 private:
@@ -98,7 +97,7 @@ private:
     using map = std::unordered_map<K, V>;
 
     const label_resolution_map* label_map_ = nullptr;
+    // save index for round-robin and round-robin-halt policies
     map<cell_gid_type, map<hash_type, cell_lid_type>> rr_state_map_;
-    map<cell_gid_type, map<hash_type, cell_lid_type>> rrh_state_map_;
 };
 } // namespace arb

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -75,6 +75,9 @@ struct ARB_ARBOR_API label_resolution_map {
     const range_set& at(cell_gid_type gid, hash_type hash) const;
     std::size_t count(cell_gid_type gid, hash_type hash) const;
 
+    const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const { return at(gid, hash_value(tag)); }
+    std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const { return count(gid, hash_value(tag)); }
+
 private:
     using Key = std::pair<cell_gid_type, hash_type>;
 

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -23,8 +23,12 @@ struct ARB_ARBOR_API cell_label_range {
     cell_label_range& operator=(const cell_label_range&) = default;
     cell_label_range& operator=(cell_label_range&&) = default;
 
-    cell_label_range(std::vector<cell_size_type> size_vec, std::vector<cell_tag_type> label_vec, std::vector<lid_range> rapfnge_vec);
-    cell_label_range(std::vector<cell_size_type> size_vec, std::vector<hash_type> label_vec, std::vector<lid_range> range_vec);
+    cell_label_range(std::vector<cell_size_type> size_vec,
+                     const std::vector<cell_tag_type>& label_vec,
+                     std::vector<lid_range> range_vec);
+    cell_label_range(std::vector<cell_size_type> size_vec,
+                     std::vector<hash_type> label_vec,
+                     std::vector<lid_range> range_vec);
 
     void add_cell();
 
@@ -36,10 +40,8 @@ struct ARB_ARBOR_API cell_label_range {
 
     // The number of labels associated with each cell.
     std::vector<cell_size_type> sizes;
-
     // The labels corresponding to each cell, partitioned according to sizes_.
     std::vector<hash_type> labels;
-
     // The lid_range corresponding to each label.
     std::vector<lid_range> ranges;
 };
@@ -60,20 +62,17 @@ struct ARB_ARBOR_API cell_labels_and_gids {
 // Class constructed from `cell_labels_and_ranges`:
 // Represents the information in the object in a more
 // structured manner for lid resolution in `resolver`
-class ARB_ARBOR_API label_resolution_map {
-public:
+struct ARB_ARBOR_API label_resolution_map {
     struct range_set {
-        std::vector<lid_range> ranges;
         std::size_t size = 0;
+        std::vector<lid_range> ranges;
         cell_lid_type at(unsigned idx) const;
     };
 
     label_resolution_map() = default;
     explicit label_resolution_map(const cell_labels_and_gids&);
 
-    const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const;
     const range_set& at(cell_gid_type gid, hash_type hash) const;
-    std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const;
     std::size_t count(cell_gid_type gid, hash_type hash) const;
 
 private:

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -74,9 +74,6 @@ struct ARB_ARBOR_API label_resolution_map {
 
     const range_set& at(cell_gid_type gid, hash_type hash) const;
     std::size_t count(cell_gid_type gid, hash_type hash) const;
-    const range_set& at(cell_gid_type gid, const cell_tag_type&) const;
-    std::size_t count(cell_gid_type gid, const cell_tag_type&) const;
-
     const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const { return at(gid, hash_value(tag)); }
     std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const { return count(gid, hash_value(tag)); }
 

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -12,8 +12,6 @@
 
 namespace arb {
 
-using lid_hopefully = arb::util::expected<cell_lid_type, std::string>;
-
 // class containing the data required for {cell, label} to lid resolution.
 // `sizes` is a partitioning vector for associating a cell with a set of
 // (label, range) pairs in `labels`, `ranges`.
@@ -68,35 +66,24 @@ public:
         std::vector<lid_range> ranges;
         std::vector<unsigned> ranges_partition = {0};
         cell_size_type size() const;
-        lid_hopefully at(unsigned idx) const;
+        cell_lid_type at(unsigned idx) const;
     };
 
     label_resolution_map() = default;
     explicit label_resolution_map(const cell_labels_and_gids&);
 
     const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const;
+    const range_set& at(cell_gid_type gid, hash_type hash) const;
     std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const;
 
 private:
     std::unordered_map<cell_gid_type, std::unordered_map<hash_type, range_set>> map;
 };
 
-struct ARB_ARBOR_API round_robin_state {
-    cell_lid_type state = 0;
-    lid_hopefully update(const label_resolution_map::range_set& range);
-};
-
-struct ARB_ARBOR_API round_robin_halt_state {
-    cell_lid_type state = 0;
-    lid_hopefully update(const label_resolution_map::range_set& range);
-};
-
-struct ARB_ARBOR_API assert_univalent_state {};
-
 // Struct used for resolving the lid of a (gid, label, lid_selection_policy) input.
 // Requires a `label_resolution_map` which stores the constant mapping of (gid, label) pairs to lid sets.
 struct ARB_ARBOR_API resolver {
-    resolver() = default;
+    resolver() = delete;
     resolver(const label_resolution_map* label_map): label_map_(label_map) {}
     cell_lid_type resolve(const cell_global_label_type& iden);
     cell_lid_type resolve(cell_gid_type gid, const cell_local_label_type& lid);
@@ -111,7 +98,7 @@ private:
     using map = std::unordered_map<K, V>;
 
     const label_resolution_map* label_map_ = nullptr;
-    map<cell_gid_type, map<hash_type, round_robin_state>> rr_state_map_;
-    map<cell_gid_type, map<hash_type, round_robin_halt_state>> rrh_state_map_;
+    map<cell_gid_type, map<hash_type, cell_lid_type>> rr_state_map_;
+    map<cell_gid_type, map<hash_type, cell_lid_type>> rrh_state_map_;
 };
 } // namespace arb

--- a/arbor/simulation.cpp
+++ b/arbor/simulation.cpp
@@ -265,19 +265,15 @@ simulation_state::simulation_state(
         });
 
     PE(init:simulation:sources);
-    cell_labels_and_gids local_sources, local_targets;
-    for(const auto& i: util::make_span(num_groups)) {
-        local_sources.append(cg_sources.at(i));
-        local_targets.append(cg_targets.at(i));
-    }
-    PL();
-
-    PE(init:simulation:source:MPI);
+    cell_labels_and_gids local_sources;
+    for(auto gidx: util::make_span(num_groups)) local_sources.append(std::move(cg_sources[gidx]));
     auto global_sources = ctx->distributed->gather_cell_labels_and_gids(local_sources);
+    source_resolution_map_ = label_resolution_map(std::move(global_sources));
     PL();
 
-    PE(init:simulation:resolvers);
-    source_resolution_map_ = label_resolution_map(std::move(global_sources));
+    PE(init:simulation:targets);
+    cell_labels_and_gids local_targets;
+    for(auto gidx: util::make_span(num_groups)) local_targets.append(std::move(cg_targets[gidx]));
     target_resolution_map_ = label_resolution_map(std::move(local_targets));
     PL();
 
@@ -302,22 +298,19 @@ void simulation_state::update(const recipe& rec) {
     cell_size_type lidx = 0;
     cell_size_type grpidx = 0;
     PE(init:simulation:update:generators);
-    auto target_resolution_map_ptr = std::make_shared<label_resolution_map>(target_resolution_map_);
+    auto target_resolver = resolver(&target_resolution_map_);
     for (const auto& group_info: ddc_.groups()) {
         for (auto gid: group_info.gids) {
             // Store mapping of gid to local cell index.
             gid_to_local_[gid] = {lidx, grpidx};
-            // Resolve event_generator targets; each event generator gets their own resolver state.
-            auto event_gens = rec.event_generators(gid);
-            for (auto& g: event_gens) {
-                g.resolve_label([target_resolution_map_ptr,
-                                 event_resolver=resolver(target_resolution_map_ptr.get()),
-                                 gid] (const cell_local_label_type& label) mutable {
-                        return event_resolver.resolve({gid, label});
-                    });
-            }
             // Set up the event generators for cell gid.
-            event_generators_[lidx] = event_gens;
+            event_generators_[lidx] = rec.event_generators(gid);
+            // Resolve event_generator targets; each event generator gets their own resolver state.
+            for (auto& gen: event_generators_[lidx]) {
+                target_resolver.clear();
+                auto lid = target_resolver.resolve(gid, gen.target());
+                gen.set_target_lid(lid);
+            }
             ++lidx;
         }
         ++grpidx;

--- a/arbor/util/partition.hpp
+++ b/arbor/util/partition.hpp
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <stdexcept>
 #include <type_traits>
+#include <string>
 
 #include <arbor/util/expected.hpp>
 

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -354,7 +354,7 @@ void add_subset(cell_gid_type gid,
     if (m + start + gid_in_range >= end) throw std::runtime_error("Requested too many connections from the given range of gids.");
     // Exclude ourself
     std::vector<bool> seen(end - start, false);
-    
+    if (gid >= start && gid < end) seen[gid - start] = true;
     std::mt19937 gen(gid + 42);
     while(m > 0) {
         cell_gid_type val = rand_range(gen, start, end);

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -213,7 +213,7 @@ int main(int argc, char** argv) {
         unsigned num_threads = arbenv::default_concurrency();
         int gpu_id = arbenv::find_private_gpu(MPI_COMM_WORLD);
         auto context = arb::make_context(arb::proc_allocation{num_threads, gpu_id}, MPI_COMM_WORLD);
-        root = arb::rank(context)==0;
+        root = arb::rank(context) == 0;
 #else
         auto context = arb::make_context(arbenv::default_allocation());
 #endif
@@ -230,7 +230,10 @@ int main(int argc, char** argv) {
 
         // read parameters
         auto o = read_options(argc, argv);
-        if (!o) {return 0; }
+        if (!o) {
+            std::cerr << "Couldm't read options.\n";
+            return -1;
+        }
         cl_options options = o.value();
 
         std::fstream spike_out;
@@ -279,9 +282,7 @@ int main(int argc, char** argv) {
         hints[cell_kind::cable].gpu_group_size = group_size;
         auto dec = partition_load_balance(recipe, context, hints);
 
-        simulation sim(recipe,
-                       context,
-                       dec);
+        simulation sim(recipe, context, dec);
 
         // Set up spike recording.
         std::vector<arb::spike> recorded_spikes;
@@ -356,10 +357,12 @@ void add_subset(cell_gid_type gid,
     std::vector<bool> seen(end - start, false);
     if (gid >= start && gid < end) seen[gid - start] = true;
     std::mt19937 gen(gid + 42);
+    auto conn = arb::cell_connection{{0, src}, {tgt}, weight, delay*U::ms};
     while(m > 0) {
         cell_gid_type val = rand_range(gen, start, end);
         if (seen[val - start]) continue;
-        conns.push_back({{val, src}, {tgt}, weight, delay*U::ms});
+        conn.source.gid = val;
+        conns.push_back(conn);
         seen[val - start] = true;
         m--;
     }

--- a/example/brunel/brunel.cpp
+++ b/example/brunel/brunel.cpp
@@ -353,15 +353,15 @@ void add_subset(cell_gid_type gid,
     auto gid_in_range = int(gid >= start && gid < end);
     if (m + start + gid_in_range >= end) throw std::runtime_error("Requested too many connections from the given range of gids.");
     // Exclude ourself
-    std::set<cell_gid_type> seen{gid};
+    std::vector<bool> seen(end - start, false);
+    
     std::mt19937 gen(gid + 42);
     while(m > 0) {
         cell_gid_type val = rand_range(gen, start, end);
-        if (!seen.count(val)) {
-            conns.push_back({{val, src}, {tgt}, weight, delay*U::ms});
-            seen.insert(val);
-            m--;
-        }
+        if (seen[val - start]) continue;
+        conns.push_back({{val, src}, {tgt}, weight, delay*U::ms});
+        seen[val - start] = true;
+        m--;
     }
 }
 

--- a/test/unit/test_event_generators.cpp
+++ b/test/unit/test_event_generators.cpp
@@ -15,7 +15,7 @@ namespace{
 
 TEST(event_generators, assign_and_copy) {
     event_generator gen = regular_generator({"l2"}, 5., 0.5*arb::units::ms, 0.75*arb::units::ms);
-    gen.resolve_label([](const cell_local_label_type&) {return 2;});
+    gen.set_target_lid(2);
     spike_event expected{2, 0.75, 5.};
 
     auto first = [](const event_seq& seq) {
@@ -54,7 +54,7 @@ TEST(event_generators, regular) {
     float weight = 3.14;
 
     event_generator gen = regular_generator(label, weight, t0*arb::units::ms, dt*arb::units::ms);
-    gen.resolve_label([lid](const cell_local_label_type&) {return lid;});
+    gen.set_target_lid(lid);
 
     // Helper for building a set of expected events.
     auto expected = [&] (std::vector<time_type> times) {
@@ -90,7 +90,7 @@ TEST(event_generators, seq) {
     }
 
     event_generator gen = explicit_generator_from_milliseconds(l0, weight, times);
-    gen.resolve_label([](const cell_local_label_type&) {return 0;});
+    gen.set_target_lid(0);
 
     EXPECT_EQ(expected, as_vector(gen.events(0, 100.))); gen.reset();
     EXPECT_EQ(expected, as_vector(gen.events(0, 100.))); gen.reset();
@@ -130,7 +130,7 @@ TEST(event_generators, poisson) {
     float weight = 42;
 
     event_generator gen = poisson_generator(label, weight, t0*arb::units::ms, lambda*arb::units::kHz);
-    gen.resolve_label([lid](const cell_local_label_type&) {return lid;});
+    gen.set_target_lid(lid);
 
     pse_vector int1 = as_vector(gen.events(0, t1));
     // Test that the output is sorted

--- a/test/unit/test_label_resolution.cpp
+++ b/test/unit/test_label_resolution.cpp
@@ -140,7 +140,6 @@ TEST(test_label_resolution, policies) {
         auto rset = res_map.at(0, "l0_0");
         EXPECT_EQ(1u, rset.ranges.size());
         EXPECT_EQ(lid_range(0, 1), rset.ranges.front());
-        EXPECT_EQ((vec{0u, 1u}), rset.ranges_partition);
 
         // gid 1
         EXPECT_EQ(0u, res_map.count(1, "l0_0"));
@@ -150,34 +149,29 @@ TEST(test_label_resolution, policies) {
         rset = res_map.at(2, "l2_0");
         EXPECT_EQ(1u, rset.ranges.size());
         EXPECT_EQ(lid_range(0, 3), rset.ranges.front());
-        EXPECT_EQ((vec{0u, 3u}), rset.ranges_partition);
 
         // gid 3
         EXPECT_EQ(1u, res_map.count(3, "l3_0"));
         rset = res_map.at(3, "l3_0");
         EXPECT_EQ(1u, rset.ranges.size());
         EXPECT_EQ(lid_range(1, 2), rset.ranges.front());
-        EXPECT_EQ((vec{0u, 1u}), rset.ranges_partition);
 
         EXPECT_EQ(1u, res_map.count(3, "l3_1"));
         rset = res_map.at(3, "l3_1");
         EXPECT_EQ(1u, rset.ranges.size());
         EXPECT_EQ(lid_range(4, 10), rset.ranges.front());
-        EXPECT_EQ((vec{0u, 6u}), rset.ranges_partition);
 
         // gid 4
         EXPECT_EQ(1u, res_map.count(4, "l4_0"));
         rset = res_map.at(4, "l4_0");
         EXPECT_EQ(1u, rset.ranges.size());
         EXPECT_EQ(lid_range(5, 6), rset.ranges.front());
-        EXPECT_EQ((vec{0u, 1u}), rset.ranges_partition);
 
         EXPECT_EQ(1u, res_map.count(4, "l4_1"));
         rset = res_map.at(4, "l4_1");
         EXPECT_EQ(2u, rset.ranges.size());
         EXPECT_EQ(lid_range(8, 11), rset.ranges.at(0));
         EXPECT_EQ(lid_range(12, 14), rset.ranges.at(1));
-        EXPECT_EQ((vec{0u, 3u, 5u}), rset.ranges_partition);
 
         // Check lid resolution
         auto lid_resolver = arb::resolver(&res_map);
@@ -254,14 +248,12 @@ TEST(test_label_resolution, policies) {
         auto rset = res_map.at(0, "l0_1");
         EXPECT_EQ(1u, rset.ranges.size());
         EXPECT_EQ(lid_range(0, 3), rset.ranges.front());
-        EXPECT_EQ((vec{0u, 3u}), rset.ranges_partition);
 
         EXPECT_EQ(1u, res_map.count(0, "l0_0"));
         rset = res_map.at(0, "l0_0");
         EXPECT_EQ(2u, rset.ranges.size());
         EXPECT_EQ(lid_range(0, 1), rset.ranges.at(0));
         EXPECT_EQ(lid_range(1, 3), rset.ranges.at(1));
-        EXPECT_EQ((vec{0u, 1u, 3u}), rset.ranges_partition);
 
         // gid 1
         EXPECT_EQ(0u, res_map.count(1, "l0_1"));
@@ -272,21 +264,18 @@ TEST(test_label_resolution, policies) {
         EXPECT_EQ(2u, rset.ranges.size());
         EXPECT_EQ(lid_range(4, 6), rset.ranges.at(0));
         EXPECT_EQ(lid_range(9, 12), rset.ranges.at(1));
-        EXPECT_EQ((vec{0u, 2u, 5u}), rset.ranges_partition);
 
         EXPECT_EQ(1u, res_map.count(2, "l2_1"));
         rset = res_map.at(2, "l2_1");
         EXPECT_EQ(2u, rset.ranges.size());
         EXPECT_EQ(lid_range(1, 2), rset.ranges.at(0));
         EXPECT_EQ(lid_range(0, 1), rset.ranges.at(1));
-        EXPECT_EQ((vec{0u, 1u, 2u}), rset.ranges_partition);
 
         EXPECT_EQ(1u, res_map.count(2, "l2_2"));
         rset = res_map.at(2, "l2_2");
         EXPECT_EQ(2u, rset.ranges.size());
         EXPECT_EQ(lid_range(5, 5), rset.ranges.at(0));
         EXPECT_EQ(lid_range(22, 23), rset.ranges.at(1));
-        EXPECT_EQ((vec{0u, 0u, 1u}), rset.ranges_partition);
 
         // Check lid resolution
         auto lid_resolver = arb::resolver(&res_map);

--- a/test/unit/test_label_resolution.cpp
+++ b/test/unit/test_label_resolution.cpp
@@ -125,7 +125,6 @@ TEST(test_cell_labels_and_gids, build) {
 }
 
 TEST(test_label_resolution, policies) {
-    using vec = std::vector<cell_lid_type>;
     {
         std::vector<cell_gid_type> gids = {0, 1, 2, 3, 4};
         std::vector<cell_size_type> sizes = {1, 0, 1, 2, 3};

--- a/test/unit/test_merge_events.cpp
+++ b/test/unit/test_merge_events.cpp
@@ -159,10 +159,8 @@ TEST(merge_events, X)
         {0, 26, 4},
     };
 
-    auto gen = regular_generator({"l0"}, 42.f, t0*arb::units::ms, 5*arb::units::ms);
-    gen.resolve_label([](const cell_local_label_type&) {return 2;});
-    std::vector<event_generator> generators = {gen};
-
+    std::vector<event_generator> generators = {regular_generator({"l0"}, 42.f, t0*arb::units::ms, 5*arb::units::ms)};
+    generators[0].set_target_lid(2);
     merge_events(t0, t1, lc, events, generators, lf);
 
     pse_vector expected = {
@@ -182,9 +180,7 @@ TEST(merge_events, X)
     EXPECT_EQ(expected, lf);
 }
 
-    struct labeled_synapse_event {
-
-    };
+struct labeled_synapse_event {};
 
 using lse_vector = std::vector<std::tuple<cell_local_label_type, time_type, float>>;
 
@@ -204,11 +200,10 @@ TEST(merge_events, tourney_seq)
     }
     util::sort(expected);
 
-    auto
-        g1 = explicit_generator_from_milliseconds(l0, w1, times),
-        g2 = explicit_generator_from_milliseconds(l0, w2, times);
-    g1.resolve_label([](const cell_local_label_type&) {return 0;});
-    g2.resolve_label([](const cell_local_label_type&) {return 0;});
+    auto g1 = explicit_generator_from_milliseconds(l0, w1, times);
+    g1.set_target_lid(0);
+    auto g2 = explicit_generator_from_milliseconds(l0, w2, times);
+    g2.set_target_lid(0);
 
     std::vector<event_span> spans = {g1.events(0, terminal_time),
                                      g2.events(0, terminal_time)};
@@ -243,7 +238,7 @@ TEST(merge_events, tourney_poisson) {
         // of events with the same time but different weights works properly.
         auto G = i%(ngen-1);
         auto gen = poisson_generator(label, weight, t0*arb::units::ms, lambda*arb::units::kHz, G);
-        gen.resolve_label([lid](const cell_local_label_type&) {return lid;});
+        gen.set_target_lid(lid);
         generators.push_back(std::move(gen));
     }
 


### PR DESCRIPTION
Builds on #2447. 

Further clean-up of infrastructure in `communicator` and `event_stream`. Reduce intermediate datastructures
on the CPU side. Host memory is a critical resource during large (GPU) benchmarks.

### connection update

Eliminates intermediate host-side array of `cell_connections` and builds `connections` directly.
Outlined a few ideas wrt to parallelisation.

### spike delivery

Eliminate intermediate list of spikes in event delivery and push events directly into streams. 
Traverse streams in time-order.