### PR TITLE
Add accessors to msegment and record SWC ids in loader.

### DIFF
--- a/arborio/include/arborio/loaded_morphology.hpp
+++ b/arborio/include/arborio/loaded_morphology.hpp
@@ -10,7 +10,10 @@
 
 namespace arborio {
 
-struct ARB_ARBORIO_API swc_metadata {};
+struct ARB_ARBORIO_API swc_metadata {
+    std::vector<int> segment_prox_id;
+    std::vector<int> segment_dist_id;
+};
 
 struct ARB_ARBORIO_API asc_color {
     uint8_t r = 0;

--- a/arborio/include/arborio/swcio.hpp
+++ b/arborio/include/arborio/swcio.hpp
@@ -52,48 +52,35 @@ struct ARB_SYMBOL_VISIBLE swc_unsupported_tag: swc_error {
 };
 
 struct ARB_ARBORIO_API swc_record {
-    int id = 0;          // sample number
-    int tag = 0;         // structure identifier (tag)
-    double x = 0;        // sample coordinates
-    double y = 0;
-    double z = 0;
-    double r = 0;        // sample adius
-    int parent_id= -1;   // record parent's sample number
+    int id = 0;                 // sample number
+    int tag = 0;                // structure identifier (tag)
+    double x = 0, y = 0, z = 0; // sample coordinates
+    double r = 0;               // sample radius
+    int parent_id= -1;          // record parent's sample number
 
     swc_record() = default;
     swc_record(int id, int tag, double x, double y, double z, double r, int parent_id):
         id(id), tag(tag), x(x), y(y), z(z), r(r), parent_id(parent_id)
     {}
 
-    bool operator==(const swc_record& other) const {
-        return id == other.id &&
-            x == other.x &&
-            y == other.y &&
-            z == other.z &&
-            r == other.r &&
-            parent_id == other.parent_id;
-    }
-
-    bool operator!=(const swc_record& other) const {
-        return !(*this == other);
-    }
+    bool operator==(const swc_record& other) const = default;
+    bool operator!=(const swc_record& other) const = default;
 
     friend std::ostream& operator<<(std::ostream&, const swc_record&);
     friend std::istream& operator>>(std::istream&, swc_record&);
 };
 
 struct ARB_ARBORIO_API swc_data {
-private:
-    std::string metadata_;
-    std::vector<swc_record> records_;
-
-public:
     swc_data() = delete;
     swc_data(std::vector<arborio::swc_record>);
     swc_data(std::string, std::vector<arborio::swc_record>);
 
     const std::vector<swc_record>& records() const {return records_;};
     std::string metadata() const {return metadata_;};
+
+private:
+    std::string metadata_;
+    std::vector<swc_record> records_;
 };
 
 // Read SWC records from stream, collecting any initial metadata represented

--- a/python/morphology.cpp
+++ b/python/morphology.cpp
@@ -117,9 +117,12 @@ void register_morphology(py::module& m) {
 
     // arb::msegment
     msegment
-        .def_readonly("prox", &arb::msegment::prox, "the location and radius of the proximal end.")
-        .def_readonly("dist", &arb::msegment::dist, "the location and radius of the distal end.")
-        .def_readonly("tag", &arb::msegment::tag, "tag meta-data.");
+        .def_readonly("prox", &arb::msegment::id, "segment id.")
+        .def_readonly("prox", &arb::msegment::prox, "location and radius of the proximal end.")
+        .def_readonly("dist", &arb::msegment::dist, "location and radius of the distal end.")
+        .def_readonly("tag", &arb::msegment::tag, "tag meta-data.")
+        .def("__str__", [](const arb::msegment& c) { return util::pprintf("(segment {} {} {} {} {})", c.id, c.prox, c.dist, c.tag); })
+        .def("__repr__", [](const arb::msegment& c) { return util::pprintf("(segment {} {} {} {} {})", c.id, c.prox, c.dist, c.tag); });
 
     // arb::mcable
     cable
@@ -463,6 +466,11 @@ void register_morphology(py::module& m) {
         .def_readonly("group_segments",
             &arborio::nml_metadata::group_segments,
             "Map from segmentGroup ids to their corresponding segment ids.");
+
+    swc_meta
+        .def_readonly("segment_prox_id", &arborio::swc_metadata::segment_prox_id, "Map segment to SWC id of the distal sample as recorded in the data file. Can be mnpos if sample was synthesized.")
+        .def_readonly("segment_dist_id", &arborio::swc_metadata::segment_dist_id, "Map segment to SWC id of the proximal sample as recorded in the data file. Can be mnpos if sample was synthesized.")
+        ;
 
     // arborio::neuroml
     neuroml


### PR DESCRIPTION
This aims to help working with SWC files by adding the sample ids as written in the
original .swc on disk. `swc_metadata` now contains lists with these ids for each
segment, one list for proximal and one for distal ids. Ids may be `arb::mnpos` where
Arbor synthesized a sample, which happens on single-sample somata.

Most segments are spanned by the samples with prox and dist id in the _file_.
