### PR TITLE
Refactor domain decomposition

### DIFF
--- a/arbor/include/arbor/domain_decomposition.hpp
+++ b/arbor/include/arbor/domain_decomposition.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <algorithm>
-#include <functional>
 #include <utility>
 #include <vector>
 
@@ -37,16 +35,15 @@ struct group_description {
 /// distribution of cells across cell_groups and domains.
 /// A load balancing algorithm is responsible for generating the
 /// domain_decomposition, e.g. arb::partitioned_load_balancer().
-class ARB_ARBOR_API domain_decomposition {
-public:
+struct ARB_ARBOR_API domain_decomposition {
     domain_decomposition() = delete;
     domain_decomposition(const recipe& rec, context ctx, const std::vector<group_description>& groups);
 
     domain_decomposition(const domain_decomposition&) = default;
     domain_decomposition& operator=(const domain_decomposition&) = default;
 
-    int gid_domain(cell_gid_type gid) const;
-    cell_size_type index_on_domain(cell_gid_type gid) const;
+    int gid_domain(cell_gid_type gid) const { return gid_domain_[gid]; }
+    cell_size_type index_on_domain(cell_gid_type gid) const { return gid_index_[gid]; }
     int num_domains() const;
     int domain_id() const;
     cell_size_type num_local_cells() const;
@@ -57,9 +54,8 @@ public:
 
 private:
     /// Return the domain id and index on domain of cell with gid.
-    /// Supplied by the load balancing algorithm that generates the domain
-    /// decomposition.
-    std::function<std::pair<int,cell_size_type>(cell_gid_type)> gid_domain_;
+    std::vector<int> gid_domain_;
+    std::vector<cell_size_type> gid_index_;
 
     /// Number of distributed domains
     int num_domains_;


### PR DESCRIPTION
Splat gid -> (rank, index) into two vectors
```
  {
    "name": "run_n=128_d=10-complex=true",
    "num-cells": 8192,
    "num-tiles": 4096,
    "synapses": 1000,
    "min-delay": 5,
    "duration": 250,
    "ring-size": 4,
    "event-weight": 0.2,
    "record": false,
    "spikes": false,
    "dt": 0.1,
    "depth": 2,
    "complex": false,
    "cpu-group-size": 1024,
    "branch-probs": [
        1,
        0.1
    ],
    "compartments": [
        2,
        1
    ],
    "lengths": [
        2,
        1
    ]
  }
```
  Before:
```
  394264576 spikes generated at rate of 6.34092e-07 ms between spikes

  ---- meters -------------------------------------------------------------------------------
  meter                         time(s)
  -------------------------------------------------------------------------------------------
  model-init                     59.365
  model-run                      16.184
  meter-total                    75.549
```
  After
```
  394264576 spikes generated at rate of 6.34092e-07 ms between spikes

  ---- meters -------------------------------------------------------------------------------
  meter                         time(s)
  -------------------------------------------------------------------------------------------
  model-init                     47.805
  model-run                      16.080
  meter-total                    63.885
```