### PR TITLE
Major Optimisations in Label Resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,6 @@ list(APPEND arbor_export_dependencies units)
 CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
                VERSION 4.5.0)
-target_include_directories(arbor-private-deps SYSTEM INTERFACE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
 
 CPMFindPackage(NAME tinyopt
               GITHUB_REPOSITORY halfflat/tinyopt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,12 +393,14 @@ list(APPEND arbor_export_dependencies units)
 
 CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
-               VERSION 4.5.0)
+               VERSION 4.5.0
+               SYSTEM YES
+               EXCLUDE_FROM_ALL YES)
 
 CPMFindPackage(NAME tinyopt
-              GITHUB_REPOSITORY halfflat/tinyopt
-              GIT_TAG 7e6d707d49c6cb4be27ebd253856be65293288df
-              DOWNLOAD_ONLY YES)
+               GITHUB_REPOSITORY halfflat/tinyopt
+               GIT_TAG 7e6d707d49c6cb4be27ebd253856be65293288df
+               DOWNLOAD_ONLY YES)
 
 add_library(ext-tinyopt INTERFACE)
 if(tinyopt_ADDED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,9 +394,11 @@ list(APPEND arbor_export_dependencies units)
 CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
                VERSION 4.5.0)
-target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
 if(unordered_dense_ADDED)
     install(TARGETS unordered_dense EXPORT arbor-targets)
+    target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
+else()
+    target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ list(APPEND arbor_export_dependencies units)
 CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
                VERSION 4.5.0)
-target_include_directories(arbor-private-deps INTERFACE ${unordered_dense_SOURCE_DIR}/include)
+target_include_directories(arbor-private-deps INTERFACE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
 
 CPMFindPackage(NAME tinyopt
               GITHUB_REPOSITORY halfflat/tinyopt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,17 +394,7 @@ list(APPEND arbor_export_dependencies units)
 CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
                VERSION 4.5.0)
-
-if(unordered_dense_ADDED)
-    message("ADDED uod")
-    install(TARGETS unordered_dense EXPORT arbor-targets)
-    target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
-else()
-    message("FOUND uod")
-    target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
-endif()
-message("uod ${unordered_dense_SOURCE_DIR}")
-
+target_include_directories(arbor-private-deps INTERFACE ${unordered_dense_SOURCE_DIR}/include)
 
 CPMFindPackage(NAME tinyopt
               GITHUB_REPOSITORY halfflat/tinyopt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,11 @@ if(units_ADDED)
 endif()
 list(APPEND arbor_export_dependencies units)
 
+CPMFindPackage(NAME unordered_dense
+               GITHUB_REPOSITORY martinus/unordered_dense
+               VERSION 4.5.0)
+target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
+
 CPMFindPackage(NAME tinyopt
               GITHUB_REPOSITORY halfflat/tinyopt
               GIT_TAG 7e6d707d49c6cb4be27ebd253856be65293288df

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ list(APPEND arbor_export_dependencies units)
 CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
                VERSION 4.5.0)
-target_include_directories(arbor-private-deps INTERFACE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
+target_include_directories(arbor-private-deps SYSTEM INTERFACE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
 
 CPMFindPackage(NAME tinyopt
               GITHUB_REPOSITORY halfflat/tinyopt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,10 @@ CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
                VERSION 4.5.0)
 target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
+if(unordered_dense_ADDED)
+    install(TARGETS unordered_dense EXPORT arbor-targets)
+endif()
+
 
 CPMFindPackage(NAME tinyopt
               GITHUB_REPOSITORY halfflat/tinyopt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,12 +394,16 @@ list(APPEND arbor_export_dependencies units)
 CPMFindPackage(NAME unordered_dense
                GITHUB_REPOSITORY martinus/unordered_dense
                VERSION 4.5.0)
+
 if(unordered_dense_ADDED)
+    message("ADDED uod")
     install(TARGETS unordered_dense EXPORT arbor-targets)
     target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
 else()
+    message("FOUND uod")
     target_link_libraries(arbor-private-deps INTERFACE unordered_dense::unordered_dense)
 endif()
+message("uod ${unordered_dense_SOURCE_DIR}")
 
 
 CPMFindPackage(NAME tinyopt

--- a/arbor/CMakeLists.txt
+++ b/arbor/CMakeLists.txt
@@ -133,6 +133,7 @@ endif()
 # Library target:
 add_library(arbor ${arbor_sources} ${arbor-builtin-mechanisms})
 target_link_libraries(arbor PRIVATE arbor-private-deps arbor-private-headers)
+target_include_directories(arbor PRIVATE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
 target_link_libraries(arbor PUBLIC arbor-public-deps arbor-public-headers)
 
 if(ARB_WITH_CUDA_CLANG)

--- a/arbor/include/arbor/common_types.hpp
+++ b/arbor/include/arbor/common_types.hpp
@@ -19,15 +19,12 @@
 namespace arb {
 
 // Internal hashes use this 64bit id
-
 using hash_type = std::size_t;
 
 // For identifying cells globally.
-
 using cell_gid_type = std::uint32_t;
 
 // For sizes of collections of cells.
-
 using cell_size_type = std::make_unsigned_t<cell_gid_type>;
 
 // For indexes into cell-local data.

--- a/arbor/include/arbor/util/visibility.hpp
+++ b/arbor/include/arbor/util/visibility.hpp
@@ -49,3 +49,4 @@
 #   define ARB_SYMBOL_VISIBLE
 #endif
 
+#define ARB_UNREACHABLE __builtin_unreachable();

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <numeric>
+#include <algorithm>
 
 #include <arbor/assert.hpp>
 #include <arbor/arbexcept.hpp>

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -95,16 +95,14 @@ label_resolution_map::label_resolution_map(const cell_labels_and_gids& clg) {
 
     map.reserve(labels.size());
     auto div = 0;
-    auto key = gid_label_pair{};
     for (auto gidx: util::count_along(gids)) {
-        key.gid = gids[gidx];
         auto len = sizes[gidx];
+        auto gid = gids[gidx];
         for (auto lidx: util::make_span(div, div + len)) {
             const auto& range = ranges[lidx];
             if (range.end  < range.begin) throw arb::arbor_internal_error("label_resolution_map: invalid lid_range");
             if (range.end == range.begin) continue;
-            key.label = labels[lidx];
-            auto& range_set = map[key];
+            auto& range_set = map[gid_label_pair{.gid=gid, .label=labels[lidx]}];
             range_set.ranges.push_back(range);
             range_set.size += range.end - range.begin;
         }
@@ -116,7 +114,7 @@ cell_lid_type resolver::resolve(const cell_global_label_type& iden) { return res
 
 cell_lid_type resolver::resolve(cell_gid_type gid, const cell_local_label_type& label) {
     const auto& [tag, pol] = label;
-    auto key = gid_label_pair(gid, hash_value(tag));
+    auto key = gid_label_pair{.gid=gid, .label=hash_value(tag)};
     const auto& it = label_map_->map.find(key);
     if (it == label_map_->map.end()) throw arb::bad_connection_label(gid, tag, "label does not exist");
     const auto& range_set = it->second;

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -10,6 +10,7 @@
 
 #include "util/span.hpp"
 #include "label_resolution.hpp"
+#include "util/strprintf.hpp"
 
 namespace arb {
 
@@ -93,47 +94,93 @@ label_resolution_map::label_resolution_map(const cell_labels_and_gids& clg) {
     const auto& ranges = clg.label_range.ranges;
     const auto& sizes = clg.label_range.sizes;
 
-    map.reserve(labels.size());
+    singletons.reserve(labels.size());
     auto div = 0;
     for (auto gidx: util::count_along(gids)) {
         auto len = sizes[gidx];
         auto gid = gids[gidx];
         for (auto lidx: util::make_span(div, div + len)) {
             const auto& range = ranges[lidx];
+            auto key = gid_label_pair{.gid=gid, .label=labels[lidx]};
             if (range.end  < range.begin) throw arb::arbor_internal_error("label_resolution_map: invalid lid_range");
             if (range.end == range.begin) continue;
-            auto& range_set = map[gid_label_pair{.gid=gid, .label=labels[lidx]}];
-            range_set.ranges.push_back(range);
-            range_set.size += range.end - range.begin;
+            auto size = range.end - range.begin;
+            // is a 'proper' range
+            if (size > 1) {
+                auto& rset = rangesets[key];
+                rset.ranges.push_back(range);
+                rset.size += size;
+            }
+            // already in rangesets
+            else if (rangesets.contains(key)) {
+                auto& rset = rangesets[key];
+                rset.ranges.push_back(range);
+                rset.size += size;
+            }
+            // key was already in singletons, so move to 'normal' rangesets and append
+            else if (singletons.contains(key)) {
+                auto& rset = rangesets[key];
+                auto off = singletons[key];
+                rset.ranges.push_back({off, off + 1});
+                rset.ranges.push_back(range);
+                rset.size = 1 + size; // remember to add the singleton's length
+                singletons.erase(key);
+            }
+            // must be a pristine singleton
+            else {
+                singletons[key] = range.begin;
+            }
         }
         div += len;
     }
 }
 
-cell_lid_type resolver::resolve(const cell_global_label_type& iden) { return resolve(iden.gid, iden.label); }
+std::size_t label_resolution_map::count(const cell_global_label_type& iden) { return count(iden.gid, iden.label.tag); }
 
+std::size_t label_resolution_map::count(cell_gid_type gid, const cell_tag_type& label) {
+    auto key = gid_label_pair{.gid=gid, .label=hash_value(label)};
+    return singletons.count(key) + rangesets.count(key);
+}
+
+range_set label_resolution_map::at(const cell_global_label_type& iden) { return at(iden.gid, iden.label.tag); }
+
+range_set label_resolution_map::at(cell_gid_type gid, const cell_tag_type& label) {
+    auto key = gid_label_pair{.gid=gid, .label=hash_value(label)};
+    if (auto it = singletons.find(key); it != singletons.end()) {
+        return range_set{.size=1, .ranges={{it->second, it->second + 1}}};
+    }
+    if (auto it = rangesets.find(key); it != rangesets.end()) {
+        return it->second;
+    }
+    throw std::range_error{util::pprintf("Key ({}, {}) not found.", gid, label)};
+}
+
+cell_lid_type resolver::resolve(const cell_global_label_type& iden) { return resolve(iden.gid, iden.label); }
 cell_lid_type resolver::resolve(cell_gid_type gid, const cell_local_label_type& label) {
+    // policy
+    // 1) univalent        :: assert there's one target and return it
+    // 2) round robin      :: return targets cyclically
+    // 3) round robin halt :: return last target from 2), do not update counter
     const auto& [tag, pol] = label;
+    // set up the key
     auto key = gid_label_pair{.gid=gid, .label=hash_value(tag)};
-    const auto& it = label_map_->map.find(key);
-    if (it == label_map_->map.end()) throw arb::bad_connection_label(gid, tag, "label does not exist");
+    // check whether our key points to a singleton (=range of length 1)
+    // if so, the answer is always that one lid regardless of policy
+    {
+        const auto& it = label_map_->singletons.find(key);
+        if (it != label_map_->singletons.end()) return it->second;
+    }
+    // was not a singleton, so look in the 'proper' ranges
+    const auto& it = label_map_->rangesets.find(key);
+    // fail, was neither in singletons nor here
+    if (it == label_map_->rangesets.end()) throw arb::bad_connection_label(gid, tag, "label does not exist");
+    // if it's not a singleton, univalent is invalid!
+    if (pol == lid_selection_policy::assert_univalent) throw arb::bad_connection_label(gid, tag, "range is not univalent");
+    // now policy must be rr or rr halt
     const auto& range_set = it->second;
-    if (pol == lid_selection_policy::assert_univalent) {
-        // must have single-entry range_set
-        if (range_set.size != 1) throw arb::bad_connection_label(gid, tag, "range is not univalent");
-        return range_set.at(0);
-    }
-    else if (pol == lid_selection_policy::round_robin) {
-        // cycle through range_set
-        auto idx = rr_state_map_[key];
-        rr_state_map_[key] = (idx + 1) % range_set.size;
-        return range_set.at(idx);
-    }
-    else if (pol == lid_selection_policy::round_robin_halt) {
-        // use previous state of round_robin policy
-        auto idx = rr_state_map_[key];
-        return range_set.at(idx);
-    }
-    ARB_UNREACHABLE
+    auto idx = rr_state_map_[key];
+    // if rr, update counter, if rr halt don't.
+    if (pol == lid_selection_policy::round_robin) rr_state_map_[key] = (idx + 1) % range_set.size;
+    return range_set.at(idx);
 }
 } // namespace arb

--- a/arbor/label_resolution.cpp
+++ b/arbor/label_resolution.cpp
@@ -75,9 +75,10 @@ bool cell_labels_and_gids::check_invariant() const {
    | [s0, e0) [s1, e1), ... [sk, ek), ... |
        len0     len1
 */
-cell_lid_type label_resolution_map::range_set::at(unsigned idx) const {
+cell_lid_type label_resolution_map::range_set::at(unsigned idx, const std::vector<lid_range>& ranges) const {
     if (idx >= size) throw arbor_internal_error("invalid lid");
-    for (const auto& [beg, end]: ranges) {
+    for (auto ridx: util::make_span(index, offset)) {
+        const auto& [beg, end] = ranges[ridx];
         auto len = end - beg;
         if (idx < len) return idx + beg;
         idx -= len;
@@ -92,23 +93,36 @@ label_resolution_map::label_resolution_map(const cell_labels_and_gids& clg) {
     const auto& ranges = clg.label_range.ranges;
     const auto& sizes = clg.label_range.sizes;
 
-    map.reserve(labels.size());
+    map_.reserve(labels.size());
     auto div = 0;
     auto key = Key{};
+    std::vector<std::vector<lid_range>> tmp;
     for (auto gidx: util::count_along(gids)) {
         key.gid = gids[gidx];
         auto len = sizes[gidx];
         for (auto lidx = div; lidx < div + len; ++lidx) {
             const auto& range = ranges[lidx];
-            auto size = int(range.end - range.begin);
-            if (size < 0) throw arb::arbor_internal_error("label_resolution_map: invalid lid_range");
-            if (size == 0) continue;
+            if (range.end < range.begin) throw arb::arbor_internal_error("label_resolution_map: invalid lid_range");
+            if (range.begin == range.end) continue;
             key.label = labels[lidx];
-            auto& range_set = map[key];
-            range_set.ranges.push_back(range);
-            range_set.size += size;
+            auto& rset = map_[key];
+            if (rset.size == 0) {
+                rset.index = tmp.size();
+                tmp.emplace_back();
+            }
+            tmp[rset.index].push_back(range);
+            rset.size += range.end - range.begin;
         }
         div += len;
+    }
+    for (auto& [k, rs]: map_) {
+        auto idx = ranges_.size();
+        auto& range = tmp[rs.index];
+        ranges_.insert(ranges_.end(), range.begin(), range.end());
+        range = {};
+        auto off = ranges_.size();
+        rs.index = idx;
+        rs.offset = off;
     }
 }
 
@@ -124,18 +138,18 @@ cell_lid_type resolver::resolve(cell_gid_type gid, const cell_local_label_type& 
     if (pol == lid_selection_policy::assert_univalent) {
         // must have single-entry range_set
         if (range_set.size != 1) throw arb::bad_connection_label(gid, tag, "range is not univalent");
-        return range_set.at(0);
+        return range_set.at(0, label_map_->ranges_);
     }
     else if (pol == lid_selection_policy::round_robin) {
         // cycle through range_set
         auto idx = rr_state_map_[key];
         rr_state_map_[key] = (idx + 1) % range_set.size;
-        return range_set.at(idx);
+        return range_set.at(idx, label_map_->ranges_);
     }
     else if (pol == lid_selection_policy::round_robin_halt) {
         // use previous state of round_robin policy
         auto idx = rr_state_map_[key];
-        return range_set.at(idx);
+        return range_set.at(idx, label_map_->ranges_);
     }
     ARB_UNREACHABLE
 }

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -81,9 +81,9 @@ struct ARB_ARBOR_API label_resolution_map {
 
     struct range_set {
         std::size_t size = 0;
-        std::size_t index = 0;
-        std::size_t offset = 0;
-        cell_lid_type at(unsigned idx, const std::vector<lid_range>& ranges) const;
+        // Most have one element only
+        util::smallvec<lid_range, 1> ranges;
+        cell_lid_type at(unsigned idx) const;
     };
 
     template<typename V>
@@ -92,17 +92,17 @@ struct ARB_ARBOR_API label_resolution_map {
     label_resolution_map() = default;
     explicit label_resolution_map(const cell_labels_and_gids&);
 
-    const auto find(const Key& key) const { return map_.find(key); }
-    const auto end() const { return map_.end(); }
-    const range_set& at(const Key& key) const { return map_.at(key); }
-    std::size_t count(const Key& key) const { return map_.count(key); }
+    const auto find(const Key& key) const { return map.find(key); }
+    const auto end() const { return map.end(); }
+    const range_set& at(const Key& key) const { return map.at(key); }
+    std::size_t count(const Key& key) const { return map.count(key); }
     const range_set& at(cell_gid_type gid, hash_type hash) const { return at(Key(gid, hash)); }
     std::size_t count(cell_gid_type gid, hash_type hash) const { return count(Key(gid, hash)); }
     const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const { return at(gid, hash_value(tag)); }
     std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const { return count(gid, hash_value(tag)); }
 
-    map_type<range_set> map_;
-    std::vector<lid_range> ranges_;
+private:
+    map_type<range_set> map;
 };
 
 // Struct used for resolving the lid of a (gid, label, lid_selection_policy) input.

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -81,9 +81,9 @@ struct ARB_ARBOR_API label_resolution_map {
 
     struct range_set {
         std::size_t size = 0;
-        // Most have one element only
-        util::smallvec<lid_range, 1> ranges;
-        cell_lid_type at(unsigned idx) const;
+        std::size_t index = 0;
+        std::size_t offset = 0;
+        cell_lid_type at(unsigned idx, const std::vector<lid_range>& ranges) const;
     };
 
     template<typename V>
@@ -92,17 +92,17 @@ struct ARB_ARBOR_API label_resolution_map {
     label_resolution_map() = default;
     explicit label_resolution_map(const cell_labels_and_gids&);
 
-    const auto find(const Key& key) const { return map.find(key); }
-    const auto end() const { return map.end(); }
-    const range_set& at(const Key& key) const { return map.at(key); }
-    std::size_t count(const Key& key) const { return map.count(key); }
+    const auto find(const Key& key) const { return map_.find(key); }
+    const auto end() const { return map_.end(); }
+    const range_set& at(const Key& key) const { return map_.at(key); }
+    std::size_t count(const Key& key) const { return map_.count(key); }
     const range_set& at(cell_gid_type gid, hash_type hash) const { return at(Key(gid, hash)); }
     std::size_t count(cell_gid_type gid, hash_type hash) const { return count(Key(gid, hash)); }
     const range_set& at(cell_gid_type gid, const cell_tag_type& tag) const { return at(gid, hash_value(tag)); }
     std::size_t count(cell_gid_type gid, const cell_tag_type& tag) const { return count(gid, hash_value(tag)); }
 
-private:
-    map_type<range_set> map;
+    map_type<range_set> map_;
+    std::vector<lid_range> ranges_;
 };
 
 // Struct used for resolving the lid of a (gid, label, lid_selection_policy) input.

--- a/arbor/label_resolution.hpp
+++ b/arbor/label_resolution.hpp
@@ -90,7 +90,15 @@ using gid_label_map = ankerl::unordered_dense::map<gid_label_pair, V, gid_label_
 struct ARB_ARBOR_API label_resolution_map {
     label_resolution_map() = default;
     explicit label_resolution_map(const cell_labels_and_gids&);
-    gid_label_map<range_set> map;
+    gid_label_map<range_set> rangesets;
+    gid_label_map<cell_lid_type> singletons;
+
+
+    std::size_t count(const cell_global_label_type& iden);
+    std::size_t count(cell_gid_type gid, const cell_tag_type& label);
+
+    range_set at(const cell_global_label_type& iden);
+    range_set at(cell_gid_type gid, const cell_tag_type& label);
 };
 
 // Struct used for resolving the lid of a (gid, label, lid_selection_policy) input.

--- a/arbor/util/smallvec.hpp
+++ b/arbor/util/smallvec.hpp
@@ -1,0 +1,78 @@
+#pragma once
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+// after: https://github.com/KonanM/small_vector (Unlicense)
+namespace arb::util {
+
+template<typename T, size_t N = 8, typename NonReboundT = T>
+struct smallvec_allocator {
+    alignas(alignof(T)) std::byte buffer_[N * sizeof(T)];
+    std::allocator<T> alloc_{};
+    bool buffer_used_ = false;
+
+    using value_type = T;
+    using propagate_on_container_move_assignment = std::false_type;
+    using propagate_on_container_swap = std::false_type;
+    using is_always_equal = std::false_type;
+
+    constexpr smallvec_allocator() noexcept = default;
+    template<class U> constexpr smallvec_allocator(const smallvec_allocator<U, N, NonReboundT>&) noexcept {}
+    template <class U> struct rebind { typedef smallvec_allocator<U, N, NonReboundT> other; };
+
+    constexpr smallvec_allocator(const smallvec_allocator& other) noexcept : buffer_used_(other.buffer_used_) {}
+    constexpr smallvec_allocator& operator=(const smallvec_allocator& other) noexcept { buffer_used_ = other.buffer_used_; return *this; }
+    constexpr smallvec_allocator(smallvec_allocator&&) noexcept {}
+    constexpr smallvec_allocator& operator=(const smallvec_allocator&&) noexcept { return *this; }
+
+    [[nodiscard]] constexpr T* allocate(const size_t n) {
+        // when the allocator was rebound we don't want to use the small buffer
+        if constexpr (std::is_same_v<T, NonReboundT>) {
+            if (n <= N) {
+                buffer_used_ = true;
+                // can use small buffer return a pointer to it
+                return reinterpret_cast<T*>(&buffer_);
+            }
+        }
+        buffer_used_ = false;
+        //otherwise use the default allocator
+        return alloc_.allocate(n);
+    }
+    constexpr void deallocate(void* p, const size_t n) {
+      // don't deallocate if small buffer is in use
+      if (&buffer_ != p) alloc_.deallocate(static_cast<T*>(p), n);
+      buffer_used_ = false;
+    }
+
+    friend constexpr bool operator==(const smallvec_allocator& lhs, const smallvec_allocator& rhs) { return !lhs.buffer_used_ && !rhs.buffer_used_; }
+    friend constexpr bool operator!=(const smallvec_allocator& lhs, const smallvec_allocator& rhs) { return !(lhs == rhs); }
+};
+
+template<typename T, size_t N = 8>
+struct smallvec : public std::vector<T, smallvec_allocator<T, N>>{
+    using vector_type = std::vector<T, smallvec_allocator<T, N>>;
+    constexpr smallvec() noexcept { vector_type::reserve(N); }
+    smallvec(const smallvec&) = default;
+    smallvec& operator=(const smallvec&) = default;
+    smallvec(smallvec&& other) noexcept(std::is_nothrow_move_constructible_v<T>) {
+        if (other.size() <= N) vector_type::reserve(N);
+        vector_type::operator=(std::move(other));
+    }
+    smallvec& operator=(smallvec&& other) noexcept(std::is_nothrow_move_constructible_v<T>) {
+        if (other.size() <= N) vector_type::reserve(N);
+        vector_type::operator=(std::move(other));
+        return *this;
+    }
+    // use the default constructor first to reserve then construct the values
+    explicit smallvec(size_t count): smallvec() { vector_type::resize(count); }
+    smallvec(size_t count, const T& value): smallvec() { vector_type::assign(count, value); }
+    template<typename It> smallvec(It first, It last): smallvec() { vector_type::insert(vector_type::begin(), first, last); }
+    smallvec(std::initializer_list<T> init): smallvec() { vector_type::insert(vector_type::begin(), init); }
+    friend void swap(smallvec& a, smallvec& b) noexcept {
+        using std::swap;
+        swap(static_cast<vector_type&>(a), static_cast<vector_type&>(b));
+    }
+};
+} // arb::util

--- a/example/ornstein_uhlenbeck/CMakeLists.txt
+++ b/example/ornstein_uhlenbeck/CMakeLists.txt
@@ -6,7 +6,5 @@ make_catalogue_lib(
     VERBOSE ${ARB_CAT_VERBOSE})
 
 add_executable(ou EXCLUDE_FROM_ALL ou.cpp)
-target_link_libraries(ou PRIVATE catalogue-ornstein_uhlenbeck)
-target_link_libraries(ou PRIVATE arbor arborio arbor-private-deps)
-target_link_libraries(ou PRIVATE fmt::fmt-header-only)
+target_link_libraries(ou PRIVATE catalogue-ornstein_uhlenbeck arbor arborio fmt::fmt-header-only)
 add_dependencies(examples ou)

--- a/test/ubench/CMakeLists.txt
+++ b/test/ubench/CMakeLists.txt
@@ -27,6 +27,7 @@ foreach(bench_src ${bench_sources})
     add_executable(${bench_exe} EXCLUDE_FROM_ALL "${bench_src}")
 
     target_link_libraries(${bench_exe} arbor arborio arbor-private-headers ext-bench)
+    target_include_directories(${bench_exe} PRIVATE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
     target_compile_options(${bench_exe} PRIVATE ${ARB_CXX_FLAGS_TARGET_FULL})
     target_compile_definitions(${bench_exe} PRIVATE "-DDATADIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../swc\"")
     list(APPEND bench_exe_list ${bench_exe})

--- a/test/unit-distributed/CMakeLists.txt
+++ b/test/unit-distributed/CMakeLists.txt
@@ -15,10 +15,12 @@ add_dependencies(tests unit-local)
 target_compile_options(unit-local PRIVATE ${ARB_CXX_FLAGS_TARGET_FULL})
 target_compile_definitions(unit-local PRIVATE TEST_LOCAL)
 target_link_libraries(unit-local PRIVATE gtest gtest_main arbor arborenv arborio arbor-sup arbor-private-headers ext-tinyopt)
+target_include_directories(unit-local PRIVATE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
 
 if(ARB_WITH_MPI)
     add_executable(unit-mpi EXCLUDE_FROM_ALL ${unit-distributed_sources})
     add_dependencies(tests unit-mpi)
+    target_include_directories(unit-mpi PRIVATE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)
 
     target_compile_options(unit-mpi PRIVATE ${ARB_CXX_FLAGS_TARGET_FULL})
     target_compile_definitions(unit-mpi PRIVATE TEST_MPI)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -196,3 +196,4 @@ target_compile_definitions(unit PRIVATE "-DLIBDIR=\"${PROJECT_BINARY_DIR}/lib\""
 target_include_directories(unit PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_include_directories(unit PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/generated/testing")
 target_link_libraries(unit PRIVATE gtest gtest_main ext-random123 arbor arborenv arborio arborio-private-headers arbor-private-headers arbor-sup)
+target_include_directories(unit PRIVATE $<BUILD_INTERFACE:${unordered_dense_SOURCE_DIR}/include>)

--- a/test/unit/test_label_resolution.cpp
+++ b/test/unit/test_label_resolution.cpp
@@ -272,9 +272,9 @@ TEST(test_label_resolution, policies) {
 
         EXPECT_EQ(1u, res_map.count(2, "l2_2"));
         rset = res_map.at(2, "l2_2");
-        EXPECT_EQ(2u, rset.ranges.size());
-        EXPECT_EQ(lid_range(5, 5), rset.ranges.at(0));
-        EXPECT_EQ(lid_range(22, 23), rset.ranges.at(1));
+        // empty ranges will be dropped! so (5, 5) is gone
+        EXPECT_EQ(1u, rset.ranges.size());
+        EXPECT_EQ(lid_range(22, 23), rset.ranges.at(0));
 
         // Check lid resolution
         auto lid_resolver = arb::resolver(&res_map);

--- a/test/unit/test_label_resolution.cpp
+++ b/test/unit/test_label_resolution.cpp
@@ -234,47 +234,54 @@ TEST(test_label_resolution, policies) {
     }
     // multivalent labels
     {
-        std::vector<cell_gid_type> gids = {0, 1, 2};
+        std::vector<cell_gid_type> gids   = {0, 1, 2};
         std::vector<cell_size_type> sizes = {3, 0, 6};
         std::vector<cell_tag_type> labels = {"l0_0", "l0_1", "l0_0", "l2_0", "l2_0", "l2_2", "l2_1", "l2_1", "l2_2"};
-        std::vector<lid_range> ranges = {{0, 1}, {0, 3}, {1, 3}, {4, 6}, {9, 12}, {5, 5}, {1, 2}, {0, 1}, {22, 23}};
+        std::vector<lid_range> ranges     = {{0, 1}, {0, 3}, {1, 3}, {4, 6}, {9, 12}, {5, 5}, {1, 2}, {0, 1}, {22, 23}};
 
         auto res_map = label_resolution_map(cell_labels_and_gids({sizes, labels, ranges}, gids));
 
         // Check resolver map correctness
         // gid 0
-        EXPECT_EQ(1u, res_map.count(0, "l0_1"));
-        auto rset = res_map.at(0, "l0_1");
-        EXPECT_EQ(1u, rset.ranges.size());
-        EXPECT_EQ(lid_range(0, 3), rset.ranges.front());
-
-        EXPECT_EQ(1u, res_map.count(0, "l0_0"));
-        rset = res_map.at(0, "l0_0");
-        EXPECT_EQ(2u, rset.ranges.size());
-        EXPECT_EQ(lid_range(0, 1), rset.ranges.at(0));
-        EXPECT_EQ(lid_range(1, 3), rset.ranges.at(1));
-
+        {
+            EXPECT_EQ(1u, res_map.count(0, "l0_1"));
+            auto rset = res_map.at(0, "l0_1");
+            EXPECT_EQ(1u, rset.ranges.size());
+            EXPECT_EQ(3u, rset.size);
+            EXPECT_EQ(lid_range(0, 3), rset.ranges.front());
+        }
+        {
+            EXPECT_EQ(1u, res_map.count(0, "l0_0"));
+            auto rset = res_map.at(0, "l0_0");
+            EXPECT_EQ(2u, rset.ranges.size());
+            EXPECT_EQ(lid_range(0, 1), rset.ranges.at(0));
+            EXPECT_EQ(lid_range(1, 3), rset.ranges.at(1));
+        }
         // gid 1
         EXPECT_EQ(0u, res_map.count(1, "l0_1"));
 
         // gid 2
-        EXPECT_EQ(1u, res_map.count(2, "l2_0"));
-        rset = res_map.at(2, "l2_0");
-        EXPECT_EQ(2u, rset.ranges.size());
-        EXPECT_EQ(lid_range(4, 6), rset.ranges.at(0));
-        EXPECT_EQ(lid_range(9, 12), rset.ranges.at(1));
-
-        EXPECT_EQ(1u, res_map.count(2, "l2_1"));
-        rset = res_map.at(2, "l2_1");
-        EXPECT_EQ(2u, rset.ranges.size());
-        EXPECT_EQ(lid_range(1, 2), rset.ranges.at(0));
-        EXPECT_EQ(lid_range(0, 1), rset.ranges.at(1));
-
-        EXPECT_EQ(1u, res_map.count(2, "l2_2"));
-        rset = res_map.at(2, "l2_2");
-        // empty ranges will be dropped! so (5, 5) is gone
-        EXPECT_EQ(1u, rset.ranges.size());
-        EXPECT_EQ(lid_range(22, 23), rset.ranges.at(0));
+        {
+            EXPECT_EQ(1u, res_map.count(2, "l2_0"));
+            auto rset = res_map.at(2, "l2_0");
+            EXPECT_EQ(2u, rset.ranges.size());
+            EXPECT_EQ(lid_range(4, 6), rset.ranges.at(0));
+            EXPECT_EQ(lid_range(9, 12), rset.ranges.at(1));
+        }
+        {
+            EXPECT_EQ(1u, res_map.count(2, "l2_1"));
+            auto rset = res_map.at(2, "l2_1");
+            EXPECT_EQ(2u, rset.ranges.size());
+            EXPECT_EQ(lid_range(1, 2), rset.ranges.at(0));
+            EXPECT_EQ(lid_range(0, 1), rset.ranges.at(1));
+        }
+        {
+            EXPECT_EQ(1u, res_map.count(2, "l2_2"));
+            auto rset = res_map.at(2, "l2_2");
+            // empty ranges will be dropped! so (5, 5) is gone
+            EXPECT_EQ(1u, rset.ranges.size());
+            EXPECT_EQ(lid_range(22, 23), rset.ranges.at(0));
+        }
 
         // Check lid resolution
         auto lid_resolver = arb::resolver(&res_map);


### PR DESCRIPTION
This targets the construction phase in extreme scale scenarios, with quite dramatic effects.

# Benchmark

use ankerl's hashmap
``` json
{
  "name": "run_n=128_d=10-complex=true",
  "num-cells": 8192,
  "num-tiles": 4096,
  "synapses": 1000,
  "min-delay": 5,
  "duration": 250,
  "ring-size": 4,
  "event-weight": 0.2,
  "record": false,
  "spikes": false,
  "dt": 0.1,
  "depth": 2,
  "complex": false,
  "cpu-group-size": 1024,
  "branch-probs": [
      1,
      0.1
  ],
  "compartments": [
      2,
      1b
  ],
  "lengths": [
      2,
      1
  ]
}
```
Before:
```
---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     40.048
model-run                      16.047
meter-total                    56.095
```
Use a struct for Key instead of a pair
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     34.144
model-run                      16.167
meter-total                    50.311
```
Use ankerl oud map
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     20.908
model-run                      16.224
meter-total                    37.132
```
Use proper hasher and tell uod map our hasher is cascading
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     18.611
model-run                      16.251
meter-total                    34.862
```
Construct Key only once
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     17.377
model-run                      16.399
meter-total                    33.775
```
Use find over count/at
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     14.675
model-run                      16.098
meter-total                    30.773
```

# Optimise label_resolution_map ctor
recognise that we can never have duplicate gids due to prior invariant checks
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     12.049
model-run                      16.074
meter-total                    28.122
```
remove partition iterator
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                     11.921
model-run                      16.044
meter-total                    27.965
```
allocate `key` once
add small vector optimisation
add ARB_UNREACHABLE
optimise range_set
```
394264576 spikes generated at rate of 6.34092e-07 ms between spikes

---- meters -------------------------------------------------------------------------------
meter                         time(s)
-------------------------------------------------------------------------------------------
model-init                      4.931
model-run                      15.697
meter-total                    20.628
```
Split maps into those with a single item range and all others.