### PR TITLE
Fix GPU test issues

### DIFF
--- a/test/unit/test_event_stream_gpu.cpp
+++ b/test/unit/test_event_stream_gpu.cpp
@@ -14,7 +14,8 @@ void cpy_d2h(T* dst, const T* src, std::size_t n) {
 template<typename Result>
 void check(Result result) {
     for (std::size_t step=0; step<result.steps.size(); ++step) {
-        for (auto& [mech_id, stream] :  result.streams) {
+        unsigned mech_id = 0;
+        for (auto& stream :  result.streams) {
             stream.mark();
             auto marked = stream.marked_events();
             std::vector<arb_deliverable_event_data> host_data(marked.end - marked.begin);
@@ -23,6 +24,7 @@ void check(Result result) {
                 cpy_d2h(host_data.data(), marked.begin, host_data.size());
                 check_result(host_data.data(), result.expected[mech_id][step]);
             }
+            ++mech_id;
         }
     }
 }

--- a/test/unit/test_serdes.cpp
+++ b/test/unit/test_serdes.cpp
@@ -342,7 +342,7 @@ TEST(serdes, single_cell_gpu) {
 }
 
 TEST(serdes, network_gpu) {
-    auto dt = 0.5*arb::units::ms;
+    auto dt = 0.05*arb::units::ms;
     auto T  = 5*arb::units::ms;
 
     // Result


### PR DESCRIPTION
This pull request fixes issues in the GPU tests introduced in PR #2465 and PR #2264.

Changes include:
- Fixed the event stream GPU test implementation.
- Fixed the handling of the "dt" parameter in the serdes test.

These fixes ensure that the GPU tests run reliably again.