### PR TITLE
Equality for Locset and Region

### DIFF
--- a/arbor/cable_cell.cpp
+++ b/arbor/cable_cell.cpp
@@ -172,9 +172,9 @@ struct cable_cell_impl {
         if constexpr (std::is_same_v<T, membrane_capacitance>)    { return membrane_capacitances_; }
     }
 
-    void paint(const mextent& cables, const std::string& str, const density& prop) { this->paint(cables, str, scaled_mechanism<density>(prop)); }
+    void paint(const mextent& cables, const region& reg, const density& prop) { this->paint(cables, reg, scaled_mechanism<density>(prop)); }
 
-    void paint(const mextent& cables, const std::string& str, const scaled_mechanism<density>& prop) {
+    void paint(const mextent& cables, const region& reg, const scaled_mechanism<density>& prop) {
         std::unordered_map<std::string, iexpr_ptr> im;
         for (const auto& [label, iex]: prop.scale_expr) {
             im.insert_or_assign(label, thingify(iex, provider));
@@ -186,20 +186,20 @@ struct cable_cell_impl {
             if (cable.prox_pos == cable.dist_pos) continue;
             if (!mm.insert(cable, {prop.t_mech, im})) {
                 throw cable_cell_error(util::pprintf("Setting mechanism '{}' on region '{}' overpaints at cable {}",
-                                                     prop.t_mech.mech.name(), str, cable));
+                                                     prop.t_mech.mech.name(), util::to_string(reg), cable));
             }
         }
     }
 
     template <typename TaggedMech>
-    void paint(const mextent& cables, const std::string& str, const TaggedMech& prop) {
+    void paint(const mextent& cables, const region& reg, const TaggedMech& prop) {
         auto& mm = get_region_map(prop);
         for (const auto& cable: cables) {
             // Skip zero-length cables in extent:
             if (cable.prox_pos == cable.dist_pos) continue;
             if (!mm.insert(cable, prop)) {
                 throw cable_cell_error(util::pprintf("Setting property '{}' on region '{}' overpaints at cable {}",
-                                                     show(prop), str, cable));
+                                                     show(prop), util::to_string(reg), cable));
             }
         }
     }
@@ -217,25 +217,34 @@ impl_ptr make_impl(cable_cell_impl* c) { return impl_ptr(c, [](cable_cell_impl* 
 
 void cable_cell_impl::init() {
     // Try to cache with a lookback of one since most models paint/place one
-    // region/locset in direct succession. We also key on the stringy view of
-    // expressions since in general equality is undecidable.
-    std::string last_label = "";
-    mextent last_region;
-    mlocation_list last_locset;
-    for (const auto& [where, what]: decorations.paintings()) {
-        if (auto region = util::to_string(where); last_label != region) {
-            last_label  = std::move(region);
-            last_region = thingify(where, provider);
+    // region/locset in direct succession.
+    {
+        region last;
+        mextent last_region;
+        for (const auto &[where, what] : decorations.paintings()) {
+            if (last != where) {
+                last = where;
+                last_region = thingify(where, provider);
+            }
+            std::visit([this, &last_region, &last](auto &&what) {
+                           this->paint(last_region, last, what);
+                        },
+                        what);
         }
-        std::visit([this, &last_region, &last_label] (auto&& what) { this->paint(last_region, last_label, what); }, what);
     }
-    for (const auto& [where, what, label]: decorations.placements()) {
-        if (auto locset = util::to_string(where); last_label != locset) {
-            last_label  = std::move(locset);
-            last_locset = thingify(where, provider);
+    {
+        locset last;
+        mlocation_list last_locset;
+        for (const auto &[where, what, label] : decorations.placements()) {
+            if (last != where) {
+                last = where;
+                last_locset = thingify(where, provider);
+            }
+            std::visit([this, &last_locset, &label = label](auto &&what) {
+                           return this->place(last_locset, what, label);
+                        },
+                        what);
         }
-        std::visit([this, &last_locset, &label=label] (auto&& what) { return this->place(last_locset, what, label); },
-                   what);
     }
 }
 

--- a/arbor/include/arbor/morph/locset.hpp
+++ b/arbor/include/arbor/morph/locset.hpp
@@ -71,6 +71,7 @@ struct ARB_SYMBOL_VISIBLE locset {
 private:
     struct interface {
         virtual ~interface() {}
+        virtual const void* type()                        const = 0;
         virtual std::unique_ptr<interface> clone()        const = 0;
         virtual std::ostream& print(std::ostream&)        const = 0;
         virtual mlocation_list thingify(const mprovider&) const = 0;
@@ -84,11 +85,17 @@ private:
         explicit wrap(const Impl& impl): wrapped(impl) {}
         explicit wrap(Impl&& impl): wrapped(std::move(impl)) {}
 
-        virtual std::unique_ptr<interface> clone()          const override final { return std::make_unique<wrap<Impl>>(wrapped); }
-        virtual mlocation_list thingify(const mprovider& m) const override final { return thingify_(wrapped, m); }
-        virtual std::ostream& print(std::ostream& o)        const override final { return o << wrapped; }
-        virtual bool eq(const interface& other)      const override final {
-            if (auto ptr = dynamic_cast<const wrap*>(&other)) return wrapped == ptr->wrapped;
+        // we keep this instead of using RTTI
+        static inline const int tag{};
+        const void* type()                          const override final { return &tag; }
+        std::unique_ptr<interface> clone()          const override final { return std::make_unique<wrap<Impl>>(wrapped); }
+        mlocation_list thingify(const mprovider& m) const override final { return thingify_(wrapped, m); }
+        std::ostream& print(std::ostream& o)        const override final { return o << wrapped; }
+        bool eq(const interface& other)             const override final {
+            if (other.type() == type()) {
+                auto ptr = dynamic_cast<const wrap*>(&other);
+                return wrapped == ptr->wrapped;
+            }
             return false;
         }
 

--- a/arbor/include/arbor/morph/locset.hpp
+++ b/arbor/include/arbor/morph/locset.hpp
@@ -52,36 +52,29 @@ struct ARB_SYMBOL_VISIBLE locset {
         return *this;
     }
 
-    friend mlocation_list thingify(const locset& p, const mprovider& m) {
-        return p.impl_->thingify(m);
-    }
-    
-    friend std::ostream& operator<<(std::ostream& o, const locset& p) {
-        return p.impl_->print(o);
-    }
+    friend mlocation_list thingify(const locset& p, const mprovider& m) { return p.impl_->thingify(m); }
+    friend std::ostream& operator<<(std::ostream& o, const locset& p) { return p.impl_->print(o); }
+    friend bool operator==(const locset& lhs, const locset& rhs) { return lhs.impl_->eq(*rhs.impl_.get()); }
 
     // The sum of two location sets.
     friend locset sum(locset, locset);
 
     template <typename ...Args>
-    friend locset sum(locset l, locset r, Args... args) {
-        return sum(sum(std::move(l), std::move(r)), std::move(args)...);
-    }
+    friend locset sum(locset l, locset r, Args... args) { return sum(sum(std::move(l), std::move(r)), std::move(args)...); }
 
     // The union of two location sets.
     friend locset join(locset, locset);
 
     template <typename ...Args>
-    friend locset join(locset l, locset r, Args... args) {
-        return join(join(std::move(l), std::move(r)), std::move(args)...);
-    }
+    friend locset join(locset l, locset r, Args... args) { return join(join(std::move(l), std::move(r)), std::move(args)...); }
 
 private:
     struct interface {
         virtual ~interface() {}
-        virtual std::unique_ptr<interface> clone() = 0;
-        virtual std::ostream& print(std::ostream&) = 0;
-        virtual mlocation_list thingify(const mprovider&) = 0;
+        virtual std::unique_ptr<interface> clone()        const = 0;
+        virtual std::ostream& print(std::ostream&)        const = 0;
+        virtual mlocation_list thingify(const mprovider&) const = 0;
+        virtual bool eq(const interface&)                 const = 0;
     };
 
     std::unique_ptr<interface> impl_;
@@ -91,16 +84,12 @@ private:
         explicit wrap(const Impl& impl): wrapped(impl) {}
         explicit wrap(Impl&& impl): wrapped(std::move(impl)) {}
 
-        virtual std::unique_ptr<interface> clone() override {
-            return std::unique_ptr<interface>(new wrap<Impl>(wrapped));
-        }
-
-        virtual mlocation_list thingify(const mprovider& m) override {
-            return thingify_(wrapped, m);
-        }
-
-        virtual std::ostream& print(std::ostream& o) override {
-            return o << wrapped;
+        virtual std::unique_ptr<interface> clone()          const override final { return std::make_unique<wrap<Impl>>(wrapped); }
+        virtual mlocation_list thingify(const mprovider& m) const override final { return thingify_(wrapped, m); }
+        virtual std::ostream& print(std::ostream& o)        const override final { return o << wrapped; }
+        virtual bool eq(const interface& other)      const override final {
+            if (auto ptr = dynamic_cast<const wrap*>(&other)) return wrapped == ptr->wrapped;
+            return false;
         }
 
         Impl wrapped;
@@ -167,6 +156,9 @@ ARB_ARBOR_API locset on_components(double relpos, region reg);
 ARB_ARBOR_API locset support(locset);
 
 } // namespace ls
+
+// Union of two locsets.
+ARB_ARBOR_API locset intersect(locset, locset);
 
 // Union of two locsets.
 ARB_ARBOR_API locset join(locset, locset);

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -58,8 +58,9 @@ struct ARB_SYMBOL_VISIBLE region {
     region(mcable_list);
 
     friend mextent thingify(const region& r, const mprovider& m) { return r.impl_->thingify(m); }
-
     friend std::ostream& operator<<(std::ostream& o, const region& p) { return p.impl_->print(o); }
+    friend bool operator==(const region& lhs, const region& rhs) { return lhs.impl_->eq(*rhs.impl_.get()); }
+
 
     // The union of regions.
     friend region join(region, region);
@@ -76,9 +77,10 @@ struct ARB_SYMBOL_VISIBLE region {
 private:
     struct interface {
         virtual ~interface() {}
-        virtual std::unique_ptr<interface> clone() = 0;
-        virtual std::ostream& print(std::ostream&) = 0;
-        virtual mextent thingify(const mprovider&) = 0;
+        virtual std::unique_ptr<interface> clone() const = 0;
+        virtual std::ostream& print(std::ostream&) const = 0;
+        virtual mextent thingify(const mprovider&) const = 0;
+        virtual bool eq(const interface&)          const = 0;
     };
 
     std::unique_ptr<interface> impl_;
@@ -87,9 +89,14 @@ private:
     struct wrap: interface {
         explicit wrap(const Impl& impl): wrapped(impl) {}
         explicit wrap(Impl&& impl): wrapped(std::move(impl)) {}
-        virtual std::unique_ptr<interface> clone() override { return std::make_unique<wrap<Impl>>(wrapped); }
-        virtual mextent thingify(const mprovider& m) override { return thingify_(wrapped, m); }
-        virtual std::ostream& print(std::ostream& o) override { return o << wrapped; }
+
+        virtual std::unique_ptr<interface> clone()   const override final { return std::make_unique<wrap<Impl>>(wrapped); }
+        virtual mextent thingify(const mprovider& m) const override final { return thingify_(wrapped, m); }
+        virtual std::ostream& print(std::ostream& o) const override final { return o << wrapped; }
+        virtual bool eq(const interface& other)      const override final {
+            if (auto ptr = dynamic_cast<const wrap*>(&other)) return wrapped == ptr->wrapped;
+            return false;
+        }
 
         Impl wrapped;
     };

--- a/arbor/include/arbor/morph/region.hpp
+++ b/arbor/include/arbor/morph/region.hpp
@@ -77,6 +77,7 @@ struct ARB_SYMBOL_VISIBLE region {
 private:
     struct interface {
         virtual ~interface() {}
+        virtual const void* type()                 const = 0;
         virtual std::unique_ptr<interface> clone() const = 0;
         virtual std::ostream& print(std::ostream&) const = 0;
         virtual mextent thingify(const mprovider&) const = 0;
@@ -90,11 +91,17 @@ private:
         explicit wrap(const Impl& impl): wrapped(impl) {}
         explicit wrap(Impl&& impl): wrapped(std::move(impl)) {}
 
-        virtual std::unique_ptr<interface> clone()   const override final { return std::make_unique<wrap<Impl>>(wrapped); }
-        virtual mextent thingify(const mprovider& m) const override final { return thingify_(wrapped, m); }
-        virtual std::ostream& print(std::ostream& o) const override final { return o << wrapped; }
-        virtual bool eq(const interface& other)      const override final {
-            if (auto ptr = dynamic_cast<const wrap*>(&other)) return wrapped == ptr->wrapped;
+        // we keep this instead of using RTTI
+        static inline const int tag{};
+        const void* type()                   const override final { return &tag; }
+        std::unique_ptr<interface> clone()   const override final { return std::make_unique<wrap<Impl>>(wrapped); }
+        mextent thingify(const mprovider& m) const override final { return thingify_(wrapped, m); }
+        std::ostream& print(std::ostream& o) const override final { return o << wrapped; }
+        bool eq(const interface& other)      const override final {
+            if (other.type() == type()) {
+                auto ptr = dynamic_cast<const wrap*>(&other);
+                return wrapped == ptr->wrapped;
+            }
             return false;
         }
 

--- a/arbor/morph/locset.cpp
+++ b/arbor/morph/locset.cpp
@@ -24,29 +24,20 @@ namespace ls {
 
 // Throw on invalid mlocation.
 void assert_valid(const mlocation& x) {
-    if (!test_invariants(x)) {
-        throw invalid_mlocation(x);
-    }
+    if (!test_invariants(x)) throw invalid_mlocation(x);
 }
+
+bool operator==(const locset_tag&, const locset_tag&) { return false; }
 
 // Empty locset.
-
 struct nil_: locset_tag {};
 
-ARB_ARBOR_API locset nil() {
-    return locset{nil_{}};
-}
-
-mlocation_list thingify_(const nil_& x, const mprovider&) {
-    return {};
-}
-
-std::ostream& operator<<(std::ostream& o, const nil_& x) {
-    return o << "(locset-nil)";
-}
+ARB_ARBOR_API locset nil() { return locset{nil_{}}; }
+mlocation_list thingify_(const nil_& x, const mprovider&) { return {}; }
+std::ostream& operator<<(std::ostream& o, const nil_& x) { return o << "(locset-nil)"; }
+bool operator==(const nil_&, const nil_&) { return true; }
 
 // An explicit location.
-
 struct location_: locset_tag {
     explicit location_(mlocation loc): loc(loc) {}
     mlocation loc;
@@ -66,20 +57,16 @@ mlocation_list thingify_(const location_& x, const mprovider& p) {
     return {x.loc};
 }
 
-std::ostream& operator<<(std::ostream& o, const location_& x) {
-    return o << "(location " << x.loc.branch << " " << x.loc.pos << ")";
-}
+std::ostream& operator<<(std::ostream& o, const location_& x) { return o << "(location " << x.loc.branch << " " << x.loc.pos << ")"; }
+bool operator==(const location_& lhs, const location_& rhs) { return lhs.loc == rhs.loc; }
 
 // Wrap mlocation_list (not part of public API).
-
 struct location_list_: locset_tag {
     explicit location_list_(mlocation_list ll): ll(std::move(ll)) {}
     mlocation_list ll;
 };
 
-locset location_list(mlocation_list ll) {
-    return locset{location_list_{std::move(ll)}};
-}
+locset location_list(mlocation_list ll) { return locset{location_list_{std::move(ll)}}; }
 
 mlocation_list thingify_(const location_list_& x, const mprovider& p) {
     auto n_branch = p.morphology().num_branches();
@@ -97,25 +84,29 @@ std::ostream& operator<<(std::ostream& o, const location_list_& x) {
     return o << ')';
 }
 
-// Set of terminal points (most distal points).
+bool operator==(const location_list_& lhs, const location_list_& rhs) {
+    if (lhs.ll.size() != rhs.ll.size()) return false;
+    for (size_t ix = 0; ix < lhs.ll.size(); ++ix) {
+        if (lhs.ll[ix] != rhs.ll[ix]) return false;
+    }
+    return true;
+}
 
+// Set of terminal points (most distal points).
 struct terminal_: locset_tag {};
 
-ARB_ARBOR_API locset terminal() {
-    return locset{terminal_{}};
-}
+ARB_ARBOR_API locset terminal() { return locset{terminal_{}}; }
 
 mlocation_list thingify_(const terminal_&, const mprovider& p) {
     mlocation_list locs;
-    util::assign(locs, util::transform_view(p.morphology().terminal_branches(),
-        [](msize_t bid) { return mlocation{bid, 1.}; }));
-
+    util::assign(locs,
+                 util::transform_view(p.morphology().terminal_branches(),
+                                      [](msize_t bid) { return mlocation{bid, 1.}; }));
     return locs;
 }
 
-std::ostream& operator<<(std::ostream& o, const terminal_& x) {
-    return o << "(terminal)";
-}
+std::ostream& operator<<(std::ostream& o, const terminal_& x) { return o << "(terminal)"; }
+bool operator==(const terminal_& lhs, const terminal_& rhs) { return true; }
 
 // Translate locations in locset distance μm in the proximal direction
 struct proximal_translate_: locset_tag {
@@ -123,6 +114,10 @@ struct proximal_translate_: locset_tag {
     locset start;
     double distance;
 };
+
+bool operator==(const proximal_translate_& lhs, const proximal_translate_& rhs) {
+    return (lhs.start == rhs.start) && (lhs.distance == rhs.distance);
+}
 
 mlocation_list thingify_(const proximal_translate_& dt, const mprovider& p) {
     const auto& m = p.morphology();
@@ -162,13 +157,8 @@ mlocation_list thingify_(const proximal_translate_& dt, const mprovider& p) {
     return L;
 }
 
-ARB_ARBOR_API locset proximal_translate(locset ls, double distance) {
-    return locset(proximal_translate_{std::move(ls), distance});
-}
-
-std::ostream& operator<<(std::ostream& o, const proximal_translate_& l) {
-    return o << "(proximal-translate " << l.start << " " << l.distance << ")";
-}
+ARB_ARBOR_API locset proximal_translate(locset ls, double distance) { return locset(proximal_translate_{std::move(ls), distance}); }
+std::ostream& operator<<(std::ostream& o, const proximal_translate_& l) { return o << "(proximal-translate " << l.start << " " << l.distance << ")"; }
 
 // Translate locations in locset distance μm in the distal direction
 struct distal_translate_: locset_tag {
@@ -177,9 +167,11 @@ struct distal_translate_: locset_tag {
     double distance;
 };
 
-ARB_ARBOR_API locset distal_translate(locset ls, double distance) {
-    return locset(distal_translate_{std::move(ls), distance});
+bool operator==(const distal_translate_& lhs, const distal_translate_& rhs) {
+    return (lhs.start == rhs.start) && (lhs.distance == rhs.distance);
 }
+
+ARB_ARBOR_API locset distal_translate(locset ls, double distance) { return locset(distal_translate_{std::move(ls), distance}); }
 
 mlocation_list thingify_(const distal_translate_& dt, const mprovider& p) {
     const auto& m = p.morphology();
@@ -245,42 +237,24 @@ mlocation_list thingify_(const distal_translate_& dt, const mprovider& p) {
     return L;
 }
 
-std::ostream& operator<<(std::ostream& o, const distal_translate_& l) {
-    return o << "(distal-translate " << l.start << " " << l.distance << ")";
-}
+std::ostream& operator<<(std::ostream& o, const distal_translate_& l) { return o << "(distal-translate " << l.start << " " << l.distance << ")"; }
 
 // Root location (most proximal point).
-
 struct root_: locset_tag {};
 
-ARB_ARBOR_API locset root() {
-    return locset{root_{}};
-}
+ARB_ARBOR_API locset root() { return locset{root_{}}; }
+mlocation_list thingify_(const root_&, const mprovider& p) { return {mlocation{0, 0.}}; }
+std::ostream& operator<<(std::ostream& o, const root_& x) { return o << "(root)"; }
+bool operator==(const root_& lhs, const root_& rhs) { return true; }
 
-mlocation_list thingify_(const root_&, const mprovider& p) {
-    return {mlocation{0, 0.}};
-}
-
-std::ostream& operator<<(std::ostream& o, const root_& x) {
-    return o << "(root)";
-}
 
 // Locations that mark interface between segments.
-
 struct segments_: locset_tag {};
 
-ARB_ARBOR_API locset segment_boundaries() {
-    return locset{segments_{}};
-}
-
-mlocation_list thingify_(const segments_&, const mprovider& p) {
-    return p.embedding().segment_ends();
-}
-
-std::ostream& operator<<(std::ostream& o, const segments_& x) {
-    return o << "(segment-boundaries)";
-}
-
+ARB_ARBOR_API locset segment_boundaries() { return locset{segments_{}}; }
+mlocation_list thingify_(const segments_&, const mprovider& p) { return p.embedding().segment_ends(); }
+std::ostream& operator<<(std::ostream& o, const segments_& x) { return o << "(segment-boundaries)"; }
+bool operator==(const segments_& lhs, const segments_& rhs) { return true; }
 
 // Proportional location on every branch.
 
@@ -289,43 +263,32 @@ struct on_branches_: locset_tag {
     double pos;
 };
 
-ARB_ARBOR_API locset on_branches(double pos) {
-    return locset{on_branches_{pos}};
-}
+ARB_ARBOR_API locset on_branches(double pos) { return locset{on_branches_{pos}}; }
 
 mlocation_list thingify_(const on_branches_& ob, const mprovider& p) {
     msize_t n_branch = p.morphology().num_branches();
 
     mlocation_list locs;
     locs.reserve(n_branch);
-    for (msize_t b = 0; b<n_branch; ++b) {
+    for (msize_t b = 0; b < n_branch; ++b) {
         locs.push_back({b, ob.pos});
     }
     return locs;
 }
 
-std::ostream& operator<<(std::ostream& o, const on_branches_& x) {
-    return o << "(on_branches " << x.pos << ")";
-}
+std::ostream& operator<<(std::ostream& o, const on_branches_& x) { return o << "(on_branches " << x.pos << ")"; }
+bool operator==(const on_branches_& lhs, const on_branches_& rhs) { return lhs.pos == rhs.pos; }
 
 // Named locset.
-
 struct named_: locset_tag {
     explicit named_(std::string name): name(std::move(name)) {}
     std::string name;
 };
 
-ARB_ARBOR_API locset named(std::string name) {
-    return locset(named_{std::move(name)});
-}
-
-mlocation_list thingify_(const named_& n, const mprovider& p) {
-    return p.locset(n.name);
-}
-
-std::ostream& operator<<(std::ostream& o, const named_& x) {
-    return o << "(locset \"" << x.name << "\")";
-}
+ARB_ARBOR_API locset named(std::string name) { return locset(named_{std::move(name)}); }
+mlocation_list thingify_(const named_& n, const mprovider& p) { return p.locset(n.name); }
+std::ostream& operator<<(std::ostream& o, const named_& x) { return o << "(locset \"" << x.name << "\")"; }
+bool operator==(const named_& lhs, const named_& rhs) { return lhs.name == rhs.name; }
 
 // Most distal points of a region
 
@@ -334,9 +297,9 @@ struct most_distal_: locset_tag {
     region reg;
 };
 
-ARB_ARBOR_API locset most_distal(region reg) {
-    return locset(most_distal_{std::move(reg)});
-}
+bool operator==(const most_distal_& lhs, const most_distal_& rhs) { return lhs.reg == rhs.reg; }
+
+ARB_ARBOR_API locset most_distal(region reg) { return locset(most_distal_{std::move(reg)}); }
 
 mlocation_list thingify_(const most_distal_& n, const mprovider& p) {
     // Make a list of the distal ends of each cable segment.
@@ -347,20 +310,15 @@ mlocation_list thingify_(const most_distal_& n, const mprovider& p) {
     return maxset(p.morphology(), L);
 }
 
-std::ostream& operator<<(std::ostream& o, const most_distal_& x) {
-    return o << "(distal " << x.reg << ")";
-}
+std::ostream& operator<<(std::ostream& o, const most_distal_& x) { return o << "(distal " << x.reg << ")"; }
 
 // Most proximal points of a region
-
 struct most_proximal_: locset_tag {
     explicit most_proximal_(region reg): reg(std::move(reg)) {}
     region reg;
 };
 
-ARB_ARBOR_API locset most_proximal(region reg) {
-    return locset(most_proximal_{std::move(reg)});
-}
+ARB_ARBOR_API locset most_proximal(region reg) { return locset(most_proximal_{std::move(reg)}); }
 
 mlocation_list thingify_(const most_proximal_& n, const mprovider& p) {
     // Make a list of the proximal ends of each cable segment.
@@ -372,29 +330,24 @@ mlocation_list thingify_(const most_proximal_& n, const mprovider& p) {
     return minset(p.morphology(), L);
 }
 
-std::ostream& operator<<(std::ostream& o, const most_proximal_& x) {
-    return o << "(proximal " << x.reg << ")";
-}
+bool operator==(const most_proximal_& lhs, const most_proximal_& rhs) { return lhs.reg == rhs.reg; }
+std::ostream& operator<<(std::ostream& o, const most_proximal_& x) { return o << "(proximal " << x.reg << ")"; }
 
 // Boundary points of a region.
 //
 // The boundary points of a region R are defined as the most proximal
 // and most distal locations in the components of R.
-
 struct boundary_: locset_tag {
     explicit boundary_(region reg): reg(std::move(reg)) {}
     region reg;
 };
 
-ARB_ARBOR_API locset boundary(region reg) {
-    return locset(boundary_(std::move(reg)));
-};
+ARB_ARBOR_API locset boundary(region reg) { return locset(boundary_(std::move(reg))); };
 
 mlocation_list thingify_(const boundary_& n, const mprovider& p) {
     std::vector<mextent> comps = components(p.morphology(), thingify(n.reg, p));
 
     mlocation_list L;
-
     for (const mextent& comp: comps) {
         arb_assert(!comp.empty());
         arb_assert(thingify_(most_proximal_{region{comp}}, p).size()==1u);
@@ -408,9 +361,8 @@ mlocation_list thingify_(const boundary_& n, const mprovider& p) {
     return support(std::move(L));
 }
 
-std::ostream& operator<<(std::ostream& o, const boundary_& x) {
-    return o << "(boundary " << x.reg << ")";
-}
+std::ostream& operator<<(std::ostream& o, const boundary_& x) { return o << "(boundary " << x.reg << ")"; }
+bool operator==(const boundary_& lhs, const boundary_& rhs) { return lhs.reg == rhs.reg; }
 
 // Completed boundary points of a region.
 //
@@ -422,15 +374,12 @@ struct cboundary_: locset_tag {
     region reg;
 };
 
-ARB_ARBOR_API locset cboundary(region reg) {
-    return locset(cboundary_(std::move(reg)));
-};
+ARB_ARBOR_API locset cboundary(region reg) { return locset(cboundary_(std::move(reg))); };
 
 mlocation_list thingify_(const cboundary_& n, const mprovider& p) {
     std::vector<mextent> comps = components(p.morphology(), thingify(n.reg, p));
 
     mlocation_list L;
-
     for (const mextent& comp: comps) {
         mextent ccomp = thingify(reg::complete(comp), p);
 
@@ -449,12 +398,10 @@ mlocation_list thingify_(const cboundary_& n, const mprovider& p) {
     return support(std::move(L));
 }
 
-std::ostream& operator<<(std::ostream& o, const cboundary_& x) {
-    return o << "(cboundary " << x.reg << ")";
-}
+std::ostream& operator<<(std::ostream& o, const cboundary_& x) { return o << "(cboundary " << x.reg << ")"; }
+bool operator==(const cboundary_& lhs, const cboundary_& rhs) { return lhs.reg == rhs.reg; }
 
 // Proportional on components of a region.
-
 struct on_components_: locset_tag {
     explicit on_components_(double relpos, region reg):
         relpos(relpos), reg(std::move(reg)) {}
@@ -462,14 +409,14 @@ struct on_components_: locset_tag {
     region reg;
 };
 
-ARB_ARBOR_API locset on_components(double relpos, region reg) {
-    return locset(on_components_(relpos, std::move(reg)));
+ARB_ARBOR_API locset on_components(double relpos, region reg) { return locset(on_components_(relpos, std::move(reg))); }
+
+bool operator==(const on_components_& lhs, const on_components_& rhs) {
+    return (lhs.reg == rhs.reg) && (lhs.relpos == rhs.relpos);
 }
 
 mlocation_list thingify_(const on_components_& n, const mprovider& p) {
-    if (n.relpos<0 || n.relpos>1) {
-        return {};
-    }
+    if (n.relpos<0 || n.relpos>1) return {};
 
     std::vector<mextent> comps = components(p.morphology(), thingify(n.reg, p));
     std::vector<mlocation> L;
@@ -525,9 +472,7 @@ mlocation_list thingify_(const on_components_& n, const mprovider& p) {
     return L;
 }
 
-std::ostream& operator<<(std::ostream& o, const on_components_& x) {
-    return o << "(on-components " << x.relpos << " " << x.reg << ")";
-}
+std::ostream& operator<<(std::ostream& o, const on_components_& x) { return o << "(on-components " << x.relpos << " " << x.reg << ")"; }
 
 // Uniform locset.
 
@@ -540,6 +485,10 @@ struct uniform_: locset_tag {
     unsigned right;
     uint64_t seed;
 };
+
+bool operator==(const uniform_& lhs, const uniform_& rhs) {
+    return (lhs.reg == rhs.reg) && (lhs.left == rhs.left) && (lhs.right == rhs.right) && (lhs.seed == rhs.seed);
+}
 
 ARB_ARBOR_API locset uniform(arb::region reg, unsigned left, unsigned right, uint64_t seed) {
     return locset(uniform_{std::move(reg), left, right, seed});
@@ -588,92 +537,70 @@ mlocation_list thingify_(const uniform_& u, const mprovider& p) {
     return L;
 }
 
-std::ostream& operator<<(std::ostream& o, const uniform_& u) {
-    return o << "(uniform " << u.reg << " " << u.left << " " << u.right << " " << u.seed << ")";
-}
+std::ostream& operator<<(std::ostream& o, const uniform_& u) { return o << "(uniform " << u.reg << " " << u.left << " " << u.right << " " << u.seed << ")"; }
 
 // Intersection of two point sets.
-
 struct land: locset_tag {
     locset lhs;
     locset rhs;
     land(locset lhs, locset rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
 };
 
-mlocation_list thingify_(const land& P, const mprovider& p) {
-    return intersection(thingify(P.lhs, p), thingify(P.rhs, p));
-}
+mlocation_list thingify_(const land& P, const mprovider& p) { return intersection(thingify(P.lhs, p), thingify(P.rhs, p)); }
+std::ostream& operator<<(std::ostream& o, const land& x) { return o << "(intersect " << x.lhs << " " << x.rhs << ")"; }
+bool operator==(const land& lhs, const land& rhs) { return (lhs.lhs == rhs.lhs) && (lhs.rhs == rhs.rhs); }
 
-std::ostream& operator<<(std::ostream& o, const land& x) {
-    return o << "(intersect " << x.lhs << " " << x.rhs << ")";
-}
 
 // Union of two point sets.
-
 struct lor: locset_tag {
     locset lhs;
     locset rhs;
     lor(locset lhs, locset rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
 };
 
-mlocation_list thingify_(const lor& P, const mprovider& p) {
-    return join(thingify(P.lhs, p), thingify(P.rhs, p));
-}
-
-std::ostream& operator<<(std::ostream& o, const lor& x) {
-    return o << "(join " << x.lhs << " " << x.rhs << ")";
-}
+mlocation_list thingify_(const lor& P, const mprovider& p) { return join(thingify(P.lhs, p), thingify(P.rhs, p)); }
+std::ostream& operator<<(std::ostream& o, const lor& x) { return o << "(join " << x.lhs << " " << x.rhs << ")"; }
+bool operator==(const lor& lhs, const lor& rhs) { return (lhs.lhs == rhs.lhs) && (lhs.rhs == rhs.rhs); }
 
 // Sum of two point sets.
-
 struct lsum: locset_tag {
     locset lhs;
     locset rhs;
     lsum(locset lhs, locset rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
 };
 
-mlocation_list thingify_(const lsum& P, const mprovider& p) {
-    return sum(thingify(P.lhs, p), thingify(P.rhs, p));
-}
-
-std::ostream& operator<<(std::ostream& o, const lsum& x) {
-    return o << "(sum " << x.lhs << " " << x.rhs << ")";
-}
+mlocation_list thingify_(const lsum& P, const mprovider& p) { return sum(thingify(P.lhs, p), thingify(P.rhs, p)); }
+std::ostream& operator<<(std::ostream& o, const lsum& x) { return o << "(sum " << x.lhs << " " << x.rhs << ")"; }
+bool operator==(const lsum& lhs, const lsum& rhs) { return (lhs.lhs == rhs.lhs) && (lhs.rhs == rhs.rhs); }
 
 // Support of point set.
-
 struct lsup_: locset_tag {
     locset arg;
     lsup_(locset arg): arg(std::move(arg)) {}
 };
 
-ARB_ARBOR_API locset support(locset arg) {
-    return locset{lsup_{std::move(arg)}};
-}
+ARB_ARBOR_API locset support(locset arg) { return locset{lsup_{std::move(arg)}}; }
+mlocation_list thingify_(const lsup_& P, const mprovider& p) { return support(thingify(P.arg, p)); };
+std::ostream& operator<<(std::ostream& o, const lsup_& x) { return o << "(support " << x.arg << ")"; }
+bool operator==(const lsup_& lhs, const lsup_& rhs) { return lhs.arg == rhs.arg; }
 
-mlocation_list thingify_(const lsup_& P, const mprovider& p) {
-    return support(thingify(P.arg, p));
-};
-
-std::ostream& operator<<(std::ostream& o, const lsup_& x) {
-    return o << "(support " << x.arg << ")";
-}
 
 // Restrict a locset on to a region: returns all locations in the locset that
 // are also in the region.
-
 struct lrestrict_: locset_tag {
     explicit lrestrict_(const locset& l, const region& r): ls{l}, reg{r} {}
     locset ls;
     region reg;
 };
 
+bool operator==(const lrestrict_& lhs, const lrestrict_& rhs) {
+    return (lhs.ls == rhs.ls) && (lhs.reg == rhs.reg);
+}
+
 mlocation_list thingify_(const lrestrict_& P, const mprovider& p) {
     mlocation_list L;
-
     auto cables = thingify(P.reg, p).cables();
     auto ends = util::transform_view(cables, [](const auto& c){return mlocation{c.branch, c.dist_pos};});
-
     for (auto l: thingify(P.ls, p)) {
         auto it = std::lower_bound(ends.begin(), ends.end(), l);
         if (it==ends.end()) continue;
@@ -682,48 +609,25 @@ mlocation_list thingify_(const lrestrict_& P, const mprovider& p) {
             L.push_back(l);
         }
     }
-
     return L;
 }
 
-ARB_ARBOR_API locset restrict_to(locset ls, region reg) {
-    return locset{lrestrict_{std::move(ls), std::move(reg)}};
-}
-
-std::ostream& operator<<(std::ostream& o, const lrestrict_& x) {
-    return o << "(restrict-to " << x.ls << " " << x.reg << ")";
-}
+ARB_ARBOR_API locset restrict_to(locset ls, region reg) { return locset{lrestrict_{std::move(ls), std::move(reg)}}; }
+std::ostream& operator<<(std::ostream& o, const lrestrict_& x) { return o << "(restrict-to " << x.ls << " " << x.reg << ")"; }
 
 } // namespace ls
 
 // The intersect and join operations in the arb:: namespace with locset so that
 // ADL allows for construction of expressions with locsets without having
 // to namespace qualify the intersect/join.
-
-locset intersect(locset lhs, locset rhs) {
-    return locset(ls::land(std::move(lhs), std::move(rhs)));
-}
-
-ARB_ARBOR_API locset join(locset lhs, locset rhs) {
-    return locset(ls::lor(std::move(lhs), std::move(rhs)));
-}
-
-ARB_ARBOR_API locset sum(locset lhs, locset rhs) {
-    return locset(ls::lsum(std::move(lhs), std::move(rhs)));
-}
+ARB_ARBOR_API locset intersect(locset lhs, locset rhs) { return locset(ls::land(std::move(lhs), std::move(rhs))); }
+ARB_ARBOR_API locset join(locset lhs, locset rhs) { return locset(ls::lor(std::move(lhs), std::move(rhs))); }
+ARB_ARBOR_API locset sum(locset lhs, locset rhs) { return locset(ls::lsum(std::move(lhs), std::move(rhs))); }
 
 // Implicit constructors.
 
-locset::locset() {
-    *this = ls::nil();
-}
-
-locset::locset(mlocation loc) {
-    *this = ls::location(loc.branch, loc.pos);
-}
-
-locset::locset(mlocation_list ll) {
-    *this = ls::location_list(std::move(ll));
-}
+locset::locset() { *this = ls::nil(); }
+locset::locset(mlocation loc) { *this = ls::location(loc.branch, loc.pos); }
+locset::locset(mlocation_list ll) { *this = ls::location_list(std::move(ll)); }
 
 } // namespace arb

--- a/arbor/morph/region.cpp
+++ b/arbor/morph/region.cpp
@@ -21,29 +21,21 @@ namespace arb {
 namespace reg {
 
 std::optional<mcable> intersect(const mcable& a, const mcable& b) {
-    if (a.branch!=b.branch) return std::nullopt;
-
+    if (a.branch != b.branch) return std::nullopt;
     double prox = std::max(a.prox_pos, b.prox_pos);
     double dist = std::min(a.dist_pos, b.dist_pos);
     return prox<=dist? std::optional(mcable{a.branch, prox, dist}): std::nullopt;
 }
 
-// Empty region.
+bool operator==(const region_tag&, const region_tag&) { return false; }
 
+// Empty region.
 struct nil_: region_tag {};
 
-ARB_ARBOR_API region nil() {
-    return region{nil_{}};
-}
-
-mextent thingify_(const nil_& x, const mprovider&) {
-    return mextent{};
-}
-
-std::ostream& operator<<(std::ostream& o, const nil_& x) {
-    return o << "(region-nil)";
-}
-
+ARB_ARBOR_API region nil() { return region{nil_{}}; }
+mextent thingify_(const nil_& x, const mprovider&) { return mextent{}; }
+std::ostream& operator<<(std::ostream& o, const nil_& x) { return o << "(region-nil)"; }
+bool operator==(const nil_&, const nil_&) { return true; }
 
 // Explicit cable section.
 
@@ -54,26 +46,19 @@ struct cable_: region_tag {
 
 ARB_ARBOR_API region cable(msize_t id, double prox, double dist) {
     mcable c{id, prox, dist};
-    if (!test_invariants(c)) {
-        throw invalid_mcable(c);
-    }
+    if (!test_invariants(c)) throw invalid_mcable(c);
     return region(cable_{c});
 }
 
-ARB_ARBOR_API region branch(msize_t bid) {
-    return cable(bid, 0, 1);
-}
+ARB_ARBOR_API region branch(msize_t bid) { return cable(bid, 0, 1); }
 
 mextent thingify_(const cable_& reg, const mprovider& p) {
-    if (reg.cable.branch>=p.morphology().num_branches()) {
-        throw no_such_branch(reg.cable.branch);
-    }
+    if (reg.cable.branch>=p.morphology().num_branches()) throw no_such_branch(reg.cable.branch);
     return mextent(mcable_list{{reg.cable}});
 }
 
-std::ostream& operator<<(std::ostream& o, const cable_& c) {
-    return o << c.cable;
-}
+std::ostream& operator<<(std::ostream& o, const cable_& c) { return o << c.cable; }
+bool operator==(const cable_& lhs, const cable_& rhs) { return lhs.cable == rhs.cable; }
 
 // Exlicit list of cables.
 // (Not part of front-end API: used by region ctor.)
@@ -89,14 +74,9 @@ region cable_list(mcable_list cs) {
 }
 
 mextent thingify_(const cable_list_& reg, const mprovider& p) {
-    if (reg.cables.empty()) {
-        return mextent{};
-    }
-
+    if (reg.cables.empty()) return mextent{};
     auto last_branch = reg.cables.back().branch;
-    if (last_branch>=p.morphology().num_branches()) {
-        throw no_such_branch(last_branch);
-    }
+    if (last_branch >= p.morphology().num_branches()) throw no_such_branch(last_branch);
     return mextent(reg.cables);
 }
 
@@ -106,9 +86,16 @@ std::ostream& operator<<(std::ostream& o, const cable_list_& x) {
     return o << ')';
 }
 
+bool operator==(const cable_list_& lhs, const cable_list_& rhs) {
+    if (lhs.cables.size() != rhs.cables.size()) return false;
+    for (size_t ix = 0; ix < lhs.cables.size(); ++ix) {
+        if (lhs.cables[ix] != rhs.cables[ix]) return false;
+    }
+    return true;
+}
+
 // Explicit extent.
 // (Not part of front-end API: used by region ctor.)
-
 struct extent_: region_tag {
     explicit extent_(mextent x): extent(std::move(x)) {}
     mextent extent;
@@ -130,16 +117,15 @@ std::ostream& operator<<(std::ostream& o, const extent_& x) {
     return o << ')';
 }
 
-// Region with all segments with the same numeric tag.
+bool operator==(const extent_& lhs, const extent_& rhs) { return lhs.extent == rhs.extent; }
 
+// Region with all segments with the same numeric tag.
 struct tagged_: region_tag {
     explicit tagged_(int tag): tag(tag) {}
     int tag;
 };
 
-ARB_ARBOR_API region tagged(int id) {
-    return region(tagged_{id});
-}
+ARB_ARBOR_API region tagged(int id) { return region(tagged_{id}); }
 
 mextent thingify_(const tagged_& reg, const mprovider& p) {
     const auto& e = p.embedding();
@@ -160,20 +146,16 @@ mextent thingify_(const tagged_& reg, const mprovider& p) {
     return mextent(cables);
 }
 
-std::ostream& operator<<(std::ostream& o, const tagged_& t) {
-    return o << "(tag " << t.tag << ")";
-}
+std::ostream& operator<<(std::ostream& o, const tagged_& t) { return o << "(tag " << t.tag << ")"; }
+bool operator==(const tagged_& lhs, const tagged_& rhs) { return lhs.tag == rhs.tag; }
 
 // Region comprising a single segment.
-
 struct segment_: region_tag {
     explicit segment_(int id): id(id) {}
     int id;
 };
 
-ARB_ARBOR_API region segment(int id) {
-    return region(segment_{id});
-}
+ARB_ARBOR_API region segment(int id) { return region(segment_{id}); }
 
 mextent thingify_(const segment_& reg, const mprovider& p) {
     const auto& e = p.embedding();
@@ -187,17 +169,13 @@ mextent thingify_(const segment_& reg, const mprovider& p) {
     return mextent(cables);
 }
 
-std::ostream& operator<<(std::ostream& o, const segment_& reg) {
-    return o << "(segment " << reg.id << ")";
-}
+std::ostream& operator<<(std::ostream& o, const segment_& reg) { return o << "(segment " << reg.id << ")"; }
+bool operator==(const segment_& lhs, const segment_& rhs) { return lhs.id == rhs.id; }
 
 // Region comprising whole morphology.
-
 struct all_: region_tag {};
 
-ARB_ARBOR_API region all() {
-    return region(all_{});
-}
+ARB_ARBOR_API region all() { return region(all_{}); }
 
 mextent thingify_(const all_&, const mprovider& p) {
     auto nb = p.morphology().num_branches();
@@ -209,9 +187,8 @@ mextent thingify_(const all_&, const mprovider& p) {
     return mextent(branches);
 }
 
-std::ostream& operator<<(std::ostream& o, const all_& t) {
-    return o << "(all)";
-}
+std::ostream& operator<<(std::ostream& o, const all_& t) { return o << "(all)"; }
+bool operator==(const all_&, const all_&) { return true; }
 
 // Region comprising points up to `distance` distal to a point in `start`.
 
@@ -221,9 +198,11 @@ struct distal_interval_: region_tag {
     double distance; //um
 };
 
-ARB_ARBOR_API region distal_interval(locset start, double distance) {
-    return region(distal_interval_{std::move(start), distance});
+bool operator==(const distal_interval_& lhs, const distal_interval_& rhs) {
+    return (lhs.start == rhs.start) && (lhs.distance == rhs.distance);
 }
+
+ARB_ARBOR_API region distal_interval(locset start, double distance) { return region(distal_interval_{std::move(start), distance}); }
 
 mextent thingify_(const distal_interval_& reg, const mprovider& p) {
     const auto& m = p.morphology();
@@ -296,8 +275,10 @@ struct proximal_interval_: region_tag {
     double distance; //um
 };
 
-ARB_ARBOR_API region proximal_interval(locset end, double distance) {
-    return region(proximal_interval_{std::move(end), distance});
+ARB_ARBOR_API region proximal_interval(locset end, double distance) { return region(proximal_interval_{std::move(end), distance}); }
+
+bool operator==(const proximal_interval_& lhs, const proximal_interval_& rhs) {
+    return (lhs.end == rhs.end) && (lhs.distance == rhs.distance);
 }
 
 mextent thingify_(const proximal_interval_& reg, const mprovider& p) {
@@ -366,17 +347,10 @@ struct radius_lt_: region_tag {
     double val; //um
 };
 
-ARB_ARBOR_API region radius_lt(region reg, double val) {
-    return region(radius_lt_{std::move(reg), val});
-}
-
-mextent thingify_(const radius_lt_& r, const mprovider& p) {
-    return radius_cmp(p, r.reg, r.val, comp_op::lt);
-}
-
-std::ostream& operator<<(std::ostream& o, const radius_lt_& r) {
-    return o << "(radius-lt " << r.reg << " " << r.val << ")";
-}
+bool operator==(const radius_lt_& lhs, const radius_lt_& rhs) { return (lhs.reg == rhs.reg) && (lhs.val == rhs.val); }
+ARB_ARBOR_API region radius_lt(region reg, double val) { return region(radius_lt_{std::move(reg), val}); }
+mextent thingify_(const radius_lt_& r, const mprovider& p) { return radius_cmp(p, r.reg, r.val, comp_op::lt); }
+std::ostream& operator<<(std::ostream& o, const radius_lt_& r) { return o << "(radius-lt " << r.reg << " " << r.val << ")"; }
 
 // Region with all segments with radius less than r
 struct radius_le_: region_tag {
@@ -385,17 +359,10 @@ struct radius_le_: region_tag {
     double val; //um
 };
 
-ARB_ARBOR_API region radius_le(region reg, double val) {
-    return region(radius_le_{std::move(reg), val});
-}
-
-mextent thingify_(const radius_le_& r, const mprovider& p) {
-    return radius_cmp(p, r.reg, r.val, comp_op::le);
-}
-
-std::ostream& operator<<(std::ostream& o, const radius_le_& r) {
-    return o << "(radius-le " << r.reg << " " << r.val << ")";
-}
+bool operator==(const radius_le_& lhs, const radius_le_& rhs) { return (lhs.reg == rhs.reg) && (lhs.val == rhs.val); }
+ARB_ARBOR_API region radius_le(region reg, double val) { return region(radius_le_{std::move(reg), val}); }
+mextent thingify_(const radius_le_& r, const mprovider& p) { return radius_cmp(p, r.reg, r.val, comp_op::le); }
+std::ostream& operator<<(std::ostream& o, const radius_le_& r) { return o << "(radius-le " << r.reg << " " << r.val << ")"; }
 
 // Region with all segments with radius greater than r
 struct radius_gt_: region_tag {
@@ -404,17 +371,10 @@ struct radius_gt_: region_tag {
     double val; //um
 };
 
-ARB_ARBOR_API region radius_gt(region reg, double val) {
-    return region(radius_gt_{std::move(reg), val});
-}
-
-mextent thingify_(const radius_gt_& r, const mprovider& p) {
-    return radius_cmp(p, r.reg, r.val, comp_op::gt);
-}
-
-std::ostream& operator<<(std::ostream& o, const radius_gt_& r) {
-    return o << "(radius-gt " << r.reg << " " << r.val << ")";
-}
+ARB_ARBOR_API region radius_gt(region reg, double val) { return region(radius_gt_{std::move(reg), val}); }
+mextent thingify_(const radius_gt_& r, const mprovider& p) { return radius_cmp(p, r.reg, r.val, comp_op::gt); }
+std::ostream& operator<<(std::ostream& o, const radius_gt_& r) { return o << "(radius-gt " << r.reg << " " << r.val << ")"; }
+bool operator==(const radius_gt_& lhs, const radius_gt_& rhs) { return (lhs.reg == rhs.reg) && (lhs.val == rhs.val); }
 
 // Region with all segments with radius greater than or equal to r
 struct radius_ge_: region_tag {
@@ -423,17 +383,10 @@ struct radius_ge_: region_tag {
     double val; //um
 };
 
-ARB_ARBOR_API region radius_ge(region reg, double val) {
-    return region(radius_ge_{std::move(reg), val});
-}
-
-mextent thingify_(const radius_ge_& r, const mprovider& p) {
-    return radius_cmp(p, r.reg, r.val, comp_op::ge);
-}
-
-std::ostream& operator<<(std::ostream& o, const radius_ge_& r) {
-    return o << "(radius-ge " << r.reg << " " << r.val << ")";
-}
+ARB_ARBOR_API region radius_ge(region reg, double val) { return region(radius_ge_{std::move(reg), val}); }
+mextent thingify_(const radius_ge_& r, const mprovider& p) { return radius_cmp(p, r.reg, r.val, comp_op::ge); }
+std::ostream& operator<<(std::ostream& o, const radius_ge_& r) { return o << "(radius-ge " << r.reg << " " << r.val << ")"; }
+bool operator==(const radius_ge_& lhs, const radius_ge_& rhs) { return (lhs.reg == rhs.reg) && (lhs.val == rhs.val); }
 
 mextent projection_cmp(const mprovider& p, double v, comp_op op) {
     const auto& m = p.morphology();
@@ -453,17 +406,10 @@ struct projection_lt_: region_tag {
     double val; //um
 };
 
-region projection_lt(double val) {
-    return region(projection_lt_{val});
-}
-
-mextent thingify_(const projection_lt_& r, const mprovider& p) {
-    return projection_cmp(p, r.val, comp_op::lt);
-}
-
-std::ostream& operator<<(std::ostream& o, const projection_lt_& r) {
-    return o << "(projection-lt " << r.val << ")";
-}
+region projection_lt(double val) { return region(projection_lt_{val}); }
+mextent thingify_(const projection_lt_& r, const mprovider& p) { return projection_cmp(p, r.val, comp_op::lt); }
+std::ostream& operator<<(std::ostream& o, const projection_lt_& r) { return o << "(projection-lt " << r.val << ")"; }
+bool operator==(const projection_lt_& lhs, const projection_lt_& rhs) { return lhs.val == rhs.val; }
 
 // Region with all segments with projection less than or equal to val
 struct projection_le_: region_tag {
@@ -471,17 +417,10 @@ struct projection_le_: region_tag {
     double val; //um
 };
 
-region projection_le(double val) {
-    return region(projection_le_{val});
-}
-
-mextent thingify_(const projection_le_& r, const mprovider& p) {
-    return projection_cmp(p, r.val, comp_op::le);
-}
-
-std::ostream& operator<<(std::ostream& o, const projection_le_& r) {
-    return o << "(projection-le " << r.val << ")";
-}
+region projection_le(double val) { return region(projection_le_{val}); }
+mextent thingify_(const projection_le_& r, const mprovider& p) {return projection_cmp(p, r.val, comp_op::le); }
+std::ostream& operator<<(std::ostream& o, const projection_le_& r) { return o << "(projection-le " << r.val << ")"; }
+bool operator==(const projection_le_& lhs, const projection_le_& rhs) { return lhs.val == rhs.val; }
 
 // Region with all segments with projection greater than val
 struct projection_gt_: region_tag {
@@ -489,17 +428,10 @@ struct projection_gt_: region_tag {
     double val; //um
 };
 
-region projection_gt(double val) {
-    return region(projection_gt_{val});
-}
-
-mextent thingify_(const projection_gt_& r, const mprovider& p) {
-    return projection_cmp(p, r.val, comp_op::gt);
-}
-
-std::ostream& operator<<(std::ostream& o, const projection_gt_& r) {
-    return o << "(projection-gt " << r.val << ")";
-}
+region projection_gt(double val) { return region(projection_gt_{val}); }
+mextent thingify_(const projection_gt_& r, const mprovider& p) { return projection_cmp(p, r.val, comp_op::gt); }
+std::ostream& operator<<(std::ostream& o, const projection_gt_& r) { return o << "(projection-gt " << r.val << ")"; }
+bool operator==(const projection_gt_& lhs, const projection_gt_& rhs) { return lhs.val == rhs.val; }
 
 // Region with all segments with projection greater than val
 struct projection_ge_: region_tag {
@@ -507,22 +439,13 @@ struct projection_ge_: region_tag {
     double val; //um
 };
 
-region projection_ge(double val) {
-    return region(projection_ge_{val});
-}
-
-mextent thingify_(const projection_ge_& r, const mprovider& p) {
-    return projection_cmp(p, r.val, comp_op::ge);
-}
-
-std::ostream& operator<<(std::ostream& o, const projection_ge_& r) {
-    return o << "(projection-ge " << r.val << ")";
-}
+region projection_ge(double val) { return region(projection_ge_{val}); }
+mextent thingify_(const projection_ge_& r, const mprovider& p) { return projection_cmp(p, r.val, comp_op::ge); }
+std::ostream& operator<<(std::ostream& o, const projection_ge_& r) { return o << "(projection-ge " << r.val << ")"; }
+bool operator==(const projection_ge_& lhs, const projection_ge_& rhs) { return lhs.val == rhs.val; }
 
 ARB_ARBOR_API region z_dist_from_root_lt(double r0) {
-    if (r0 == 0) {
-        return {};
-    }
+    if (r0 == 0) return {};
     region lt = reg::projection_lt(r0);
     region gt = reg::projection_gt(-r0);
     return intersect(lt, gt);
@@ -552,17 +475,10 @@ struct named_: region_tag {
     std::string name;
 };
 
-ARB_ARBOR_API region named(std::string name) {
-    return region(named_{std::move(name)});
-}
-
-mextent thingify_(const named_& n, const mprovider& p) {
-    return p.region(n.name);
-}
-
-std::ostream& operator<<(std::ostream& o, const named_& x) {
-    return o << "(region \"" << x.name << "\")";
-}
+bool operator==(const named_& lhs, const named_& rhs) { return lhs.name == rhs.name; }
+ARB_ARBOR_API region named(std::string name) { return region(named_{std::move(name)}); }
+mextent thingify_(const named_& n, const mprovider& p) { return p.region(n.name); }
+std::ostream& operator<<(std::ostream& o, const named_& x) { return o << "(region \"" << x.name << "\")"; }
 
 // Adds all cover points to a region.
 // Ensures that all valid representations of all fork points in the region are included.
@@ -571,9 +487,8 @@ struct super_: region_tag {
     region reg;
 };
 
-ARB_ARBOR_API region complete(region r) {
-    return region(super_{std::move(r)});
-}
+ARB_ARBOR_API region complete(region r) { return region(super_{std::move(r)}); }
+bool operator==(const super_& lhs, const super_& rhs) { return lhs.reg == rhs.reg; }
 
 mextent thingify_(const super_& r, const mprovider& p) {
     const auto& m = p.morphology();
@@ -584,12 +499,8 @@ mextent thingify_(const super_& r, const mprovider& p) {
     for (auto& c: cables) {
         mcable* prev = cs.empty()? nullptr: &cs.back();
 
-        if (c.prox_pos==0) {
-            branch_tails.insert(m.branch_parent(c.branch));
-        }
-        if (c.dist_pos==1) {
-            branch_tails.insert(c.branch);
-        }
+        if (c.prox_pos==0) branch_tails.insert(m.branch_parent(c.branch));
+        if (c.dist_pos==1) branch_tails.insert(c.branch);
 
         if (prev && prev->branch==c.branch && prev->dist_pos>=c.prox_pos) {
             prev->dist_pos = std::max(prev->dist_pos, c.dist_pos);
@@ -615,7 +526,7 @@ mextent thingify_(const super_& r, const mprovider& p) {
         a.swap(cs);
 
         for (auto c: util::merge_view(a, fork_covers)) {
-            mcable* prev = cs.empty()? nullptr: &cs.back();
+            mcable* prev = cs.empty() ? nullptr : &cs.back();
 
             if (prev && prev->branch==c.branch && prev->dist_pos>=c.prox_pos) {
                 prev->dist_pos = std::max(prev->dist_pos, c.dist_pos);
@@ -629,51 +540,39 @@ mextent thingify_(const super_& r, const mprovider& p) {
     return {cs};
 }
 
-std::ostream& operator<<(std::ostream& o, const super_& r) {
-    return o << "(complete " << r.reg << ")";
-}
-
+std::ostream& operator<<(std::ostream& o, const super_& r) { return o << "(complete " << r.reg << ")"; }
 
 // Intersection of two regions.
-
 struct reg_and: region_tag {
     region lhs;
     region rhs;
     reg_and(region lhs, region rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
 };
 
-mextent thingify_(const reg_and& P, const mprovider& p) {
-    return intersect(thingify(P.lhs, p), thingify(P.rhs, p));
-}
-
-std::ostream& operator<<(std::ostream& o, const reg_and& x) {
-    return o << "(intersect " << x.lhs << " " << x.rhs << ")";
-}
-
+mextent thingify_(const reg_and& P, const mprovider& p) { return intersect(thingify(P.lhs, p), thingify(P.rhs, p)); }
+std::ostream& operator<<(std::ostream& o, const reg_and& x) { return o << "(intersect " << x.lhs << " " << x.rhs << ")"; }
+bool operator==(const reg_and& lhs, const reg_and& rhs) { return (lhs.lhs == rhs.lhs) && (lhs.rhs == rhs.rhs); }
 
 // Union of two regions.
-
 struct reg_or: region_tag {
     region lhs;
     region rhs;
     reg_or(region lhs, region rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
 };
 
-mextent thingify_(const reg_or& P, const mprovider& p) {
-    return join(thingify(P.lhs, p), thingify(P.rhs, p));
+mextent thingify_(const reg_or& P, const mprovider& p) { return join(thingify(P.lhs, p), thingify(P.rhs, p)); }
+bool operator==(const reg_or& lhs, const reg_or& rhs) {
+    return (lhs.lhs == rhs.lhs) && (lhs.rhs == rhs.rhs);
 }
-
-std::ostream& operator<<(std::ostream& o, const reg_or& x) {
-    return o << "(join " << x.lhs << " " << x.rhs << ")";
-}
-
+std::ostream& operator<<(std::ostream& o, const reg_or& x) { return o << "(join " << x.lhs << " " << x.rhs << ")"; }
 
 // Complement of a region.
-
 struct reg_not: region_tag {
     region r;
     explicit reg_not(region r): r(std::move(r)) {}
 };
+
+bool operator==(const reg_not& lhs, const reg_not& rhs) { return lhs.r == rhs.r; }
 
 mextent thingify_(const reg_not& P, const mprovider& p) {
     auto nb = p.morphology().num_branches();
@@ -704,65 +603,34 @@ mextent thingify_(const reg_not& P, const mprovider& p) {
     return mextent(result);
 }
 
-std::ostream& operator<<(std::ostream& o, const reg_not& x) {
-    return o << "(complement " << x.r << ")";
-}
-
+std::ostream& operator<<(std::ostream& o, const reg_not& x) { return o << "(complement " << x.r << ")"; }
 
 // Closed set difference of two regions.
-
 struct reg_minus: region_tag {
     region lhs;
     region rhs;
     reg_minus(region lhs, region rhs): lhs(std::move(lhs)), rhs(std::move(rhs)) {}
 };
 
-mextent thingify_(const reg_minus& P, const mprovider& p) {
-    return thingify(intersect(P.lhs, complement(P.rhs)), p);
-}
-
-std::ostream& operator<<(std::ostream& o, const reg_minus& x) {
-    return o << "(difference " << x.lhs << " " << x.rhs << ")";
-}
+mextent thingify_(const reg_minus& P, const mprovider& p) { return thingify(intersect(P.lhs, complement(P.rhs)), p); }
+std::ostream& operator<<(std::ostream& o, const reg_minus& x) { return o << "(difference " << x.lhs << " " << x.rhs << ")"; }
+bool operator==(const reg_minus& lhs, const reg_minus& rhs) { return (lhs.lhs == rhs.lhs) && (lhs.rhs == rhs.rhs); }
 
 } // namespace reg
 
 // The intersect, join, complement and difference operations are in the arb::
 // namespace with region so that ADL allows for construction of expressions
 // with regions without having to namespace qualify these operations.
+ARB_ARBOR_API region intersect(region l, region r) { return region{reg::reg_and(std::move(l), std::move(r))}; }
+ARB_ARBOR_API region join(region l, region r) { return region{reg::reg_or(std::move(l), std::move(r))}; }
+ARB_ARBOR_API region complement(region r) { return region{reg::reg_not(std::move(r))}; }
+ARB_ARBOR_API region difference(region l, region r) { return region{reg::reg_minus(std::move(l), std::move(r))}; }
 
-ARB_ARBOR_API region intersect(region l, region r) {
-    return region{reg::reg_and(std::move(l), std::move(r))};
-}
-
-ARB_ARBOR_API region join(region l, region r) {
-    return region{reg::reg_or(std::move(l), std::move(r))};
-}
-
-ARB_ARBOR_API region complement(region r) {
-    return region{reg::reg_not(std::move(r))};
-}
-
-ARB_ARBOR_API region difference(region l, region r) {
-    return region{reg::reg_minus(std::move(l), std::move(r))};
-}
-
-region::region() {
-    *this = reg::nil();
-}
+region::region() { *this = reg::nil(); }
 
 // Implicit constructors/converters.
-
-region::region(mcable c) {
-    *this = reg::cable(c.branch, c.prox_pos, c.dist_pos);
-}
-
-region::region(mcable_list cl) {
-    *this = reg::cable_list(std::move(cl));
-}
-
-region::region(mextent x) {
-    *this = reg::extent(std::move(x));
-}
+region::region(mcable c) { *this = reg::cable(c.branch, c.prox_pos, c.dist_pos); }
+region::region(mcable_list cl) { *this = reg::cable_list(std::move(cl)); }
+region::region(mextent x) { *this = reg::extent(std::move(x)); }
 
 } // namespace arb

--- a/arborio/label_parse.cpp
+++ b/arborio/label_parse.cpp
@@ -113,7 +113,8 @@ std::unordered_multimap<std::string, evaluator> eval_map {
                  "'join' with at least 2 arguments: (locset locset [...locset])")},
     {"sum", make_fold<arb::locset>(static_cast<arb::locset(*)(arb::locset, arb::locset)>(arb::sum),
                 "'sum' with at least 2 arguments: (locset locset [...locset])")},
-
+    {"intersect", make_fold<arb::locset>(static_cast<arb::locset(*)(arb::locset, arb::locset)>(arb::intersect),
+                      "'intersect' with at least 2 arguments: (locset locset [...locset])")},
 
     // iexpr
     {"iexpr", make_call<std::string>(arb::iexpr::named, "iexpr with 1 argument: (value:string)")},

--- a/doc/concepts/labels.rst
+++ b/doc/concepts/labels.rst
@@ -368,8 +368,25 @@ Locset expressions
 
         (restrict-to (terminal) (tag 3))
 
-
 .. label:: (join lhs:locset rhs:locset [...locset])
+
+    Union of two locsets, where A and B are multisets of locations. This is
+    equivalent to concatenating the two lists, with duplicates removed and
+    results sorted.
+
+    .. code-block:: lisp
+
+        (join
+            (join (location 1 0.5) (location 2 0.1) (location 1 0.2))
+            (join (location 1 0.5) (location 4 0)))
+
+    Gives the following:
+
+    .. code-block:: lisp
+
+        (join (location 1 0.5) (location 2 0.1) (location 1 0.2) (location 4 0))
+
+.. label:: (interset lhs:locset rhs:locset [...locset])
 
     Set intersection for two locsets, with duplicates removed and results sorted.
     For example, the following:
@@ -687,7 +704,7 @@ Inhomogeneous Expressions
 
 .. label:: (distance scale:real loc:locset)
 
-    The minimum distance to points within the locset ``loc``. The scaling parameter  ``scale`` has unit :math:`{\mu m}^{-1}` 
+    The minimum distance to points within the locset ``loc``. The scaling parameter  ``scale`` has unit :math:`{\mu m}^{-1}`
     and is multiplied by the distance, such that the result is unitless.
 
     .. figure:: ../images/iexpr_distance.svg
@@ -703,7 +720,7 @@ Inhomogeneous Expressions
 
 .. label:: (distance scale:real reg:region)
 
-    The minimum distance to the region ``reg``. Evaluates to zero within the region. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}` 
+    The minimum distance to the region ``reg``. Evaluates to zero within the region. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}`
     and is multiplied by the distance, such that the result is unitless.
 
 .. label:: (distance reg:region)
@@ -712,7 +729,7 @@ Inhomogeneous Expressions
 
 .. label:: (proximal-distance scale:real loc:locset)
 
-    The minimum distance in proximal direction from the points within the locset ``loc``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}` 
+    The minimum distance in proximal direction from the points within the locset ``loc``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}`
     and is multiplied by the distance, such that the result is unitless.
 
     .. figure:: ../gen-images/iexpr_prox_dis.svg
@@ -727,7 +744,7 @@ Inhomogeneous Expressions
 
 .. label:: (proximal-distance scale:real reg:region)
 
-    The minimum distance in proximal direction from the region ``reg``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}` 
+    The minimum distance in proximal direction from the region ``reg``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}`
     and is multiplied by the distance, such that the result is unitless.
 
 .. label:: (proximal-distance reg:region)
@@ -736,7 +753,7 @@ Inhomogeneous Expressions
 
 .. label:: (distal-distance scale:real loc:locset)
 
-    The minimum distance in the distal direction from the points within the locset ``loc``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}` 
+    The minimum distance in the distal direction from the points within the locset ``loc``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}`
     and is multiplied by the distance, such that the result is unitless.
 
     .. figure:: ../gen-images/iexpr_dist_dis.svg
@@ -751,7 +768,7 @@ Inhomogeneous Expressions
 
 .. label:: (distal-distance scale:real reg:region)
 
-    The minimum distance in distal direction from the region ``reg``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}` 
+    The minimum distance in distal direction from the region ``reg``. The scaling parameter ``scale`` has unit :math:`{\mu m}^{-1}`
     and is multiplied by the distance, such that the result is unitless.
 
 .. label:: (distal-distance reg:region)
@@ -760,7 +777,7 @@ Inhomogeneous Expressions
 
 .. label:: (interpolation prox_value:real prox_loc:locset dist_value:real dist_loc:locset)
 
-    Interpolates between the closest point in the proximal direction in locset ``prox_loc`` and the closest point in 
+    Interpolates between the closest point in the proximal direction in locset ``prox_loc`` and the closest point in
     distal direction ``dist_loc`` with the assosiated unitless values ``prox_value`` and ``dist_value``.
     Evaluates to zero if no point is located in each required direction.
 

--- a/doc/cpp/labels.rst
+++ b/doc/cpp/labels.rst
@@ -17,15 +17,15 @@ Cable cell labels
 
       Add all definitions from ``other``, optionally adding a prefix.
           
-   .. cpp:function:: const std::unordered_map<std::string, arb::region>& regions() const
+   .. cpp:function:: const std::unordered_map<std::string, region>& regions() const
 
       The region definitions in the dictionary.
 
-   .. cpp:function:: const std::unordered_map<std::string, arb::locset>& locsets() const
+   .. cpp:function:: const std::unordered_map<std::string, locset>& locsets() const
 
       The locset definitions in the dictionary.
 
-   .. cpp:function:: const std::unordered_map<std::string, arb::iexpr>& iexpressions() const
+   .. cpp:function:: const std::unordered_map<std::string, iexpr>& iexpressions() const
 
       The iexpr definitions in the dictionary.
 
@@ -41,7 +41,7 @@ Cable cell labels
 
       Add iexpr under ``name``.
 
-   .. cpp:function:: add_swc_tags
+   .. cpp:function:: void add_swc_tags()
 
       Add SWC default regions
 
@@ -137,7 +137,8 @@ two labels refer to one another:
    applied to a morphology, and the cyclic dependency is detected when
    thingifying the locations in the locsets and the cable segments in the
    regions.
-=======
+   
+
 Cable Cell Morphology Expressions
 =================================
 

--- a/doc/cpp/mechanisms.rst
+++ b/doc/cpp/mechanisms.rst
@@ -92,23 +92,19 @@ behaviour, can be specified for cells or the whole model.
         print(ions['k'].read_rev_pot)
         # True
 
-    .. cpp:attribute:: write_int_con
-        :type: bool
+    .. cpp:member:: bool write_int_con
 
         If the mechanism contributes to the internal concentration of the ion species.
 
-    .. cpp:attribute:: write_ext_con
-        :type: bool
+    .. cpp:member:: bool write_ext_con
 
         If the mechanism contributes to the external concentration of the ion species.
 
-    .. cpp:attribute:: write_rev_pot
-        :type: bool
+    .. cpp:member:: bool write_rev_pot
 
         If the mechanism calculates the reversal potential of the ion species.
 
-    .. cpp:attribute:: read_rev_pot
-        :type: bool
+    .. cpp:member:: bool read_rev_pot
 
         If the mechanism depends on the reversal potential of the ion species.
 
@@ -117,23 +113,19 @@ behaviour, can be specified for cells or the whole model.
 
     Metadata about a specific field of a mechanism is presented as read-only attributes.
 
-    .. cpp:attribute:: units
-        :type: string
+    .. cpp:member:: std::string units
 
         The units of the field.
 
-    .. cpp:attribute:: default
-        :type: float
+    .. cpp:member:: float default_value
 
         The default value of the field.
 
-    .. cpp:attribute:: min
-        :type: float
+    .. cpp:member:: float min
 
         The minimum permissible value of the field.
 
-    .. cpp:attribute:: max
-        :type: float
+    .. cpp:member:: float max
 
         The maximum permissible value of the field.
 
@@ -145,7 +137,7 @@ Mechanism catalogues
 
 .. cpp:namespace:: arb
 
-.. cpp:class:: catalogue
+.. cpp:class:: mechanism_catalogue
 
     A *mechanism catalogue* is a collection of mechanisms that maintains:
 
@@ -157,33 +149,33 @@ Mechanism catalogues
 
         Create an empty, copied or moved catalogue.
 
-    .. cpp:method:: bool has(const std::string& name)
+    .. cpp:function:: bool has(const std::string& name)
 
         Test if mechanism with *name* is in the catalogue.
 
-    .. cpp:method:: is_derived(name)
+    .. cpp:function:: bool is_derived(const std::string& name)
 
         Is *name* a derived mechanism or can it be implicitly derived?
 
-    .. cpp:method:: mechanism_info operator[](const std::string& name)
+    .. cpp:function:: mechanism_info operator[](const std::string& name)
 
         Look up mechanism metadata with *name*.
 
-    .. cpp:method:: void add(const std::string& name, mechanism_info)
+    .. cpp:function:: void add(const std::string& name, mechanism_info)
 
          Add mechanism metadata with *name*.
 
 
-    .. cpp:method:: std::vector<std::string> mechanism_names() const
+    .. cpp:function:: std::vector<std::string> mechanism_names() const
 
         Return a list of names of all the mechanisms in the catalogue.
 
-   .. cpp:method:: extend(other, prefix="")
+    .. cpp:function:: void extend(const mechanism_catalogue& other, std::string prefix="")
 
         Import another catalogue, possibly with a prefix. Will raise an exception
         in case of name collisions.
 
-    .. cpp:method:: void derive(const std::string& name, const std::string& parent, const std::vector<std::pair<std::string, double>>& global_params, const std::vector<std::pair<std::string, std::string>>& ion_remap = {});
+    .. cpp:function:: void derive(const std::string& name, const std::string& parent, const std::vector<std::pair<std::string, double>>& global_params, const std::vector<std::pair<std::string, std::string>>& ion_remap = {});
 
         Derive a new mechanism with *name* from the mechanism *parent*.
 

--- a/doc/cpp/probe_sample.rst
+++ b/doc/cpp/probe_sample.rst
@@ -18,7 +18,7 @@ The sample data associated with a cable cell probe will either be a ``double``
 for scalar probes, or a ``cable_sample_range`` describing a half-open range of
 ``double`` values:
 
-.. code::
+.. code:: c++
 
    using cable_sample_range = std::pair<const double*, const double*>
 
@@ -34,7 +34,7 @@ The probe metadata passed to the sampler will be a const pointer to:
 
 The type ``cable_probe_point_info`` holds metadata for a single target on a cell:
 
-.. code::
+.. code:: c++
 
     struct cable_probe_point_info {
         // Target number of point process instance on cell.

--- a/doc/python/morphology.rst
+++ b/doc/python/morphology.rst
@@ -606,19 +606,19 @@ region.
 
 .. py:class:: loaded_morphology
 
-   .. py:attr:: segment_tree
+   .. py:attribute:: segment_tree
 
     Raw segment tree, identical to morphology.
 
-   .. py:attr:: morphology
+   .. py:attribute:: morphology
 
     Morphology constructed from description.
 
-   .. py:attr:: labels
+   .. py:attribute:: labels
 
     Regions and locsets defined in the description as ``label_dict``
 
-   .. py:attr:: metadata
+   .. py:attribute:: metadata
 
     Loader specific metadata, see below in the individual sections.
 

--- a/test/unit/test_morph_expr.cpp
+++ b/test/unit/test_morph_expr.cpp
@@ -979,3 +979,136 @@ TEST(region, thingify_complex_morphologies) {
         EXPECT_TRUE(region_eq(mp, join(z_dist_from_root_le(50), z_dist_from_root_gt(50)), all()));
     }
 }
+
+TEST(region, eq) {
+    std::vector regs {
+        arb::reg::nil(),
+        arb::reg::cable(42, 0.50, 0.85),
+        arb::reg::cable(41, 0.50, 0.85),
+        arb::reg::cable(42, 0.25, 0.85),
+        arb::reg::cable(42, 0.25, 0.90),
+        arb::reg::branch(13),
+        arb::reg::branch(12),
+        arb::reg::tagged(1),
+        arb::reg::tagged(2),
+        arb::reg::segment(23),
+        arb::reg::segment(31),
+        arb::reg::all(),
+        arb::reg::distal_interval(arb::ls::root(), 0.50),
+        arb::reg::distal_interval(arb::ls::root(), 0.25),
+        arb::reg::distal_interval(arb::ls::terminal(), 0.25),
+        arb::reg::proximal_interval(arb::ls::root(), 0.50),
+        arb::reg::proximal_interval(arb::ls::root(), 0.25),
+        arb::reg::proximal_interval(arb::ls::terminal(), 0.25),
+        arb::reg::radius_lt(arb::reg::all(), 0.42),
+        arb::reg::radius_le(arb::reg::all(), 0.42),
+        arb::reg::radius_gt(arb::reg::all(), 0.42),
+        arb::reg::radius_ge(arb::reg::all(), 0.42),
+        arb::reg::radius_lt(arb::reg::all(), 0.23),
+        arb::reg::radius_le(arb::reg::all(), 0.23),
+        arb::reg::radius_gt(arb::reg::all(), 0.23),
+        arb::reg::radius_ge(arb::reg::all(), 0.23),
+        arb::reg::radius_lt(arb::reg::nil(), 0.42),
+        arb::reg::radius_le(arb::reg::nil(), 0.42),
+        arb::reg::radius_gt(arb::reg::nil(), 0.42),
+        arb::reg::radius_ge(arb::reg::nil(), 0.42),
+        arb::reg::radius_lt(arb::reg::nil(), 0.23),
+        arb::reg::radius_le(arb::reg::nil(), 0.23),
+        arb::reg::radius_gt(arb::reg::nil(), 0.23),
+        arb::reg::radius_ge(arb::reg::nil(), 0.23),
+        arb::reg::z_dist_from_root_lt(0.42),
+        arb::reg::z_dist_from_root_le(0.42),
+        arb::reg::z_dist_from_root_gt(0.42),
+        arb::reg::z_dist_from_root_ge(0.42),
+        arb::reg::z_dist_from_root_lt(0.23),
+        arb::reg::z_dist_from_root_le(0.23),
+        arb::reg::z_dist_from_root_gt(0.23),
+        arb::reg::z_dist_from_root_ge(0.23),
+        arb::reg::named("foo"),
+        arb::reg::named("bar"),
+        arb::reg::complete(arb::reg::all()),
+        arb::reg::complete(arb::reg::nil()),
+        intersect(arb::reg::all(), arb::reg::all()),
+        intersect(arb::reg::nil(), arb::reg::nil()),
+        join(arb::reg::all(), arb::reg::all()),
+        join(arb::reg::nil(), arb::reg::nil()),
+        complement(arb::reg::nil()),
+        complement(arb::reg::all()),
+        difference(arb::reg::all(), arb::reg::all()),
+        difference(arb::reg::nil(), arb::reg::nil()),
+    };
+
+    for (size_t ix = 0; ix < regs.size(); ++ix) {
+        for (size_t iy = 0; iy < regs.size(); ++iy) {
+            if (ix == iy) {
+                EXPECT_EQ(regs[ix], regs[iy]);
+            }
+            else {
+                EXPECT_NE(regs[ix], regs[iy]);
+            }
+
+        }
+    }
+}
+
+TEST(locset, eq) {
+    std::vector locs = {
+        arb::ls::nil(),
+        arb::ls::root(),
+        arb::ls::terminal(),
+        arb::ls::segment_boundaries(),
+        arb::ls::location(0, 0.25),
+        arb::ls::location(1, 0.25),
+        arb::ls::location(0, 0.45),
+        arb::ls::location(1, 0.45),
+        arb::ls::proximal_translate(arb::ls::terminal(), 0.35),
+        arb::ls::proximal_translate(arb::ls::terminal(), 0.25),
+        arb::ls::proximal_translate(arb::ls::nil(), 0.35),
+        arb::ls::proximal_translate(arb::ls::nil(), 0.25),
+        arb::ls::named("foo"),
+        arb::ls::named("bar"),
+        arb::ls::boundary(arb::reg::all()),
+        arb::ls::boundary(arb::reg::nil()),
+        arb::ls::cboundary(arb::reg::all()),
+        arb::ls::cboundary(arb::reg::nil()),
+        intersect(arb::ls::nil(), arb::ls::nil()),
+        intersect(arb::ls::root(), arb::ls::root()),
+        join(arb::ls::nil(), arb::ls::nil()),
+        join(arb::ls::root(), arb::ls::root()),
+        sum(arb::ls::nil(), arb::ls::nil()),
+        sum(arb::ls::root(), arb::ls::root()),
+        arb::ls::distal_translate(arb::ls::nil(), 0.25),
+        arb::ls::distal_translate(arb::ls::nil(), 0.45),
+        arb::ls::distal_translate(arb::ls::root(), 0.25),
+        arb::ls::distal_translate(arb::ls::root(), 0.45),
+        arb::ls::most_distal(arb::reg::nil()),
+        arb::ls::most_distal(arb::reg::all()),
+        arb::ls::most_proximal(arb::reg::nil()),
+        arb::ls::most_proximal(arb::reg::all()),
+        arb::ls::on_branches(0.24),
+        arb::ls::on_branches(0.42),
+        arb::ls::on_components(0.25, arb::reg::all()),
+        arb::ls::on_components(0.45, arb::reg::all()),
+        arb::ls::on_components(0.25, arb::reg::nil()),
+        arb::ls::on_components(0.45, arb::reg::nil()),
+        arb::ls::support(arb::ls::nil()),
+        arb::ls::support(arb::ls::root()),
+        arb::ls::restrict_to(arb::ls::nil(),  arb::reg::all()),
+        arb::ls::restrict_to(arb::ls::root(), arb::reg::all()),
+        arb::ls::restrict_to(arb::ls::nil(),  arb::reg::nil()),
+        arb::ls::restrict_to(arb::ls::root(), arb::reg::nil()),
+        arb::ls::uniform(arb::reg::all(), 23, 43, 1234),
+    };
+
+    for (size_t ix = 0; ix < locs.size(); ++ix) {
+        for (size_t iy = 0; iy < locs.size(); ++iy) {
+            if (ix == iy) {
+                EXPECT_EQ(locs[ix], locs[iy]);
+            }
+            else {
+                EXPECT_NE(locs[ix], locs[iy]);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
So far, to decide whether two region were equal, we had to rely on `str(A) == str(B)`.
This is slow, inconvenient, and somewhat misleading.
Thus, this PR introduces equality on those types under the following definition:
Two regions/locsets are equally iff they share the same construction.

Example:
```lisp
(tag 1) == (tag 1)
(tag 1) /= (region "soma") ;; even if "soma" is defined as (tag 1)
```
This is somewhat stricter than one might expect, but for a complete
definition, one would need to convert these expressions to their concrete
representations using the morphology and labels, which is not desirable
due to performance reasons. And could also end in surprise when
two unrelated expressions are equal given a very specific morphology.
