### PR TITLE
Method to retrieve Arbor configuration in C++ / cleanup of busyring example 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ commit.msg
 # Mac default files
 .DS_Store
 
+# Mac default files
+.vscode
+
 # generated documentation images
 doc/gen-images
 

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ commit.msg
 # Mac default files
 .DS_Store
 
-# Mac default files
+# VSCode files
 .vscode
 
 # generated documentation images

--- a/arbor/include/arbor/profile/profiler.hpp
+++ b/arbor/include/arbor/profile/profiler.hpp
@@ -2,6 +2,7 @@
 
 #include <ostream>
 #include <vector>
+#include <cstdint>
 
 #include <arbor/export.hpp>
 #include <arbor/context.hpp>

--- a/arbor/include/git-source-id
+++ b/arbor/include/git-source-id
@@ -45,6 +45,7 @@ cat << __end__
 #pragma once
 
 #include <arbor/export.hpp>
+#include <string>
 
 namespace arb {
 ARB_ARBOR_API extern const char* source_id;
@@ -52,6 +53,7 @@ ARB_ARBOR_API extern const char* arch;
 ARB_ARBOR_API extern const char* build_config;
 ARB_ARBOR_API extern const char* version;
 ARB_ARBOR_API extern const char* full_build_id;
+ARB_ARBOR_API extern std::string get_arbor_config_str();
 constexpr int version_major = ${version_major};
 constexpr int version_minor = ${version_minor};
 constexpr int version_patch = ${version_patch};

--- a/arbor/include/git-source-id
+++ b/arbor/include/git-source-id
@@ -54,6 +54,7 @@ ARB_ARBOR_API extern const char* build_config;
 ARB_ARBOR_API extern const char* version;
 ARB_ARBOR_API extern const char* full_build_id;
 ARB_ARBOR_API extern std::string get_arbor_config_str();
+ARB_ARBOR_API extern std::string get_arbor_config_json();
 constexpr int version_major = ${version_major};
 constexpr int version_minor = ${version_minor};
 constexpr int version_patch = ${version_patch};

--- a/arbor/version.cpp
+++ b/arbor/version.cpp
@@ -18,7 +18,7 @@ ARB_ARBOR_API const char* full_build_id = ARB_FULL_BUILD_ID;
 
 using config_map = std::map<std::string, std::variant<std::string, bool, int>>;
 
-// returns Arbor config map
+// returns Arbor configuration map
 ARB_ARBOR_API config_map get_arbor_config() {
     config_map config;
 
@@ -67,7 +67,7 @@ ARB_ARBOR_API config_map get_arbor_config() {
     return config;
 }
 
-// pretty-print function for the Arbor config map
+// return pretty-printed string representation of the Arbor configuration map
 ARB_ARBOR_API std::string get_arbor_config_str() {
     config_map config = get_arbor_config();
     std::string config_str = "";
@@ -78,10 +78,7 @@ ARB_ARBOR_API std::string get_arbor_config_str() {
         }
 
         std::string operator()(bool value) const {
-            if (value)
-                return "true";
-            else
-                return "false";
+            return value ? "true" : "false";
         }
 
         std::string operator()(int value) const {
@@ -99,4 +96,45 @@ ARB_ARBOR_API std::string get_arbor_config_str() {
 
     return config_str;
 }
+
+// return JSON representation of the Arbor configuration map
+ARB_ARBOR_API std::string get_arbor_config_json() {
+    config_map config = get_arbor_config();
+    std::string config_json_str = "{";
+
+    struct value_str {
+        std::string operator()(const std::string& value) const {
+            return "\"" + value + "\"";
+        }
+
+        std::string operator()(bool value) const {
+            return value ? "true" : "false";
+        }
+
+        std::string operator()(int value) const {
+            return std::to_string(value);
+        }
+    };
+
+    for (auto it = config.begin(); it != config.end(); ++it) {
+        config_json_str += "\"" + it->first + "\" : " + std::visit(value_str{}, it->second);
+
+        if (std::next(it) != config.end()) {
+            config_json_str += ", ";
+        }
+    }
+    config_json_str += "}";
+
+    return config_json_str;
+}
+
+// return JSON representation of the Arbor configuration map
+/*ARB_ARBOR_API std::string get_arbor_config_json() {
+    config_map config = get_arbor_config();
+    
+    nlohmann::json config_json = config;
+    std::string config_json_str = config_json.dump();
+
+    return config_json_str;
+}*/
 }

--- a/arbor/version.cpp
+++ b/arbor/version.cpp
@@ -1,6 +1,8 @@
 #include <arbor/version.hpp>
 #include <arbor/export.hpp>
 #include <string>
+#include <map>
+#include <variant>
 
 namespace arb {
 ARB_ARBOR_API const char* source_id = ARB_SOURCE_ID;
@@ -14,49 +16,87 @@ ARB_ARBOR_API const char* version_dev = "";
 #endif
 ARB_ARBOR_API const char* full_build_id = ARB_FULL_BUILD_ID;
 
-ARB_ARBOR_API std::string get_arbor_config_str() {
-    std::string config_str = "";
+using config_map = std::map<std::string, std::variant<std::string, bool, int>>;
+
+// returns Arbor config map
+ARB_ARBOR_API config_map get_arbor_config() {
+    config_map config;
+
     #ifdef ARB_MPI_ENABLED
-        config_str += std::string("mpi=true, ");
+        config["mpi"] = true;
     #else
-        config_str += std::string("mpi=false, ");
+        config["mpi"] = false;
     #endif
     #ifdef ARB_NVCC_ENABLED
-        config_str += std::string("cuda=true, ");
+        config["cuda"] = true;
     #endif
     #ifdef ARB_CUDA_CLANG_ENABLED
-        config_str += std::string("cuda-clang=true, ");
+        config["cuda-clang"] = true;
     #endif
     #ifdef ARB_HIP_ENABLED
-        config_str += std::string("hip=true, ");
+        config["hip"] = true;
     #endif
     #ifndef ARB_GPU_ENABLED
-        config_str += std::string("gpu=false, ");
+        config["gpu"] = true;
     #endif
     #ifdef ARB_VECTORIZE_ENABLED
-        config_str += std::string("vectorize=true, ");
+        config["vectorize"] = true;
     #else
-        config_str += std::string("vectorize=false, ");
+        config["vectorize"] = false;
     #endif
     #ifdef ARB_PROFILE_ENABLED
-        config_str += std::string("profiling=true, ");
+        config["profiiling"] = true;
     #else
-        config_str += std::string("profiling=false, ");
+        config["profiiling"] = false;
     #endif
     #ifdef ARB_NEUROML_ENABLED
-        config_str += std::string("neuroml=true, ");
+        config["neuroml"] = true;
     #else
-        config_str += std::string("neuroml=false, ");
+        config["neuroml"] = false;
     #endif
     #ifdef ARB_BUNDLED_ENABLED
-        config_str += std::string("bundled=true, ");
+        config["bundled"] = true;
     #else
-        config_str += std::string("bundled=false, ");
+        config["bundled"] = true;
     #endif
-    config_str += std::string("version='") + arb::version + "', " +
-                  std::string("source='") + arb::source_id + "', " +
-                  std::string("build_config='") + arb::build_config + "', " +
-                  std::string("arch='") + arb::arch + "'";
+    config["version"] = arb::version;
+    config["source"] = arb::source_id;
+    config["build_config"] = arb::build_config;
+    config["arch"] = arb::arch;
+
+    return config;
+}
+
+// pretty-print function for the Arbor config map
+ARB_ARBOR_API std::string get_arbor_config_str() {
+    config_map config = get_arbor_config();
+    std::string config_str = "";
+
+    struct value_str {
+        std::string operator()(const std::string& value) const {
+            return "'" + value + "'";
+        }
+
+        std::string operator()(bool value) const {
+            if (value)
+                return "true";
+            else
+                return "false";
+        }
+
+        std::string operator()(int value) const {
+            return std::to_string(value);
+        }
+    };
+
+    for (auto it = config.begin(); it != config.end(); ++it) {
+        config_str += it->first + "=" + std::visit(value_str{}, it->second);
+
+        if (std::next(it) != config.end()) {
+            config_str += ", ";
+        }
+    }
+
     return config_str;
 }
 }

--- a/arbor/version.cpp
+++ b/arbor/version.cpp
@@ -13,4 +13,50 @@ ARB_ARBOR_API const char* version_dev = ARB_VERSION_DEV;
 ARB_ARBOR_API const char* version_dev = "";
 #endif
 ARB_ARBOR_API const char* full_build_id = ARB_FULL_BUILD_ID;
+
+ARB_ARBOR_API std::string get_arbor_config_str() {
+    std::string config_str = "";
+    #ifdef ARB_MPI_ENABLED
+        config_str += std::string("mpi=true, ");
+    #else
+        config_str += std::string("mpi=false, ");
+    #endif
+    #ifdef ARB_NVCC_ENABLED
+        config_str += std::string("cuda=true, ");
+    #endif
+    #ifdef ARB_CUDA_CLANG_ENABLED
+        config_str += std::string("cuda-clang=true, ");
+    #endif
+    #ifdef ARB_HIP_ENABLED
+        config_str += std::string("hip=true, ");
+    #endif
+    #ifndef ARB_GPU_ENABLED
+        config_str += std::string("gpu=false, ");
+    #endif
+    #ifdef ARB_VECTORIZE_ENABLED
+        config_str += std::string("vectorize=true, ");
+    #else
+        config_str += std::string("vectorize=false, ");
+    #endif
+    #ifdef ARB_PROFILE_ENABLED
+        config_str += std::string("profiling=true, ");
+    #else
+        config_str += std::string("profiling=false, ");
+    #endif
+    #ifdef ARB_NEUROML_ENABLED
+        config_str += std::string("neuroml=true, ");
+    #else
+        config_str += std::string("neuroml=false, ");
+    #endif
+    #ifdef ARB_BUNDLED_ENABLED
+        config_str += std::string("bundled=true, ");
+    #else
+        config_str += std::string("bundled=false, ");
+    #endif
+    config_str += std::string("version='") + arb::version + "', " +
+                  std::string("source='") + arb::source_id + "', " +
+                  std::string("build_config='") + arb::build_config + "', " +
+                  std::string("arch='") + arb::arch + "'";
+    return config_str;
+}
 }

--- a/example/busyring/parameters.hpp
+++ b/example/busyring/parameters.hpp
@@ -24,7 +24,7 @@ struct cell_parameters {
     std::array<unsigned,2> compartments = {20, 2};  //  Compartment count on a branch.
     std::array<double,2> lengths = {200, 20};       //  Length of branch in μm.
 
-    // The number of additional, random synapses per cell.
+    // The number of synapses per cell (ring connection plus additional, random synapses).
     unsigned synapses = 1;
 };
 

--- a/example/busyring/ring.cpp
+++ b/example/busyring/ring.cpp
@@ -473,7 +473,7 @@ arb::cable_cell complex_cell(arb::cell_gid_type gid, const cell_parameters& para
     auto dend = tagged(3);
     auto apic = tagged(4);
     auto cntr = location(0, 0.5);
-    auto syns = arb::ls::uniform(rall, 0, params.synapses-1, gid);
+    auto syns = arb::ls::uniform(rall, 0, params.synapses-2, gid);
 
     arb::decor decor;
 
@@ -519,7 +519,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
 
     auto soma = tagged(1);
     auto dnds = join(tagged(3), tagged(4));
-    auto syns = arb::ls::uniform(arb::reg::all(), 0, params.synapses-1, gid);
+    auto syns = arb::ls::uniform(arb::reg::all(), 0, params.synapses-2, gid);
 
     arb::decor decor;
 

--- a/example/busyring/ring.cpp
+++ b/example/busyring/ring.cpp
@@ -199,53 +199,6 @@ struct cell_stats {
     }
 };
 
-// TODO remove this once a general function for the config output from C++ is provided
-std::string get_arbor_config_str() {
-    std::string config_str = "";
-    #ifdef ARB_MPI_ENABLED
-        config_str += std::string("mpi=true, ");
-    #else
-        config_str += std::string("mpi=false, ");
-    #endif
-    #ifdef ARB_NVCC_ENABLED
-        config_str += std::string("cuda=true, ");
-    #endif
-    #ifdef ARB_CUDA_CLANG_ENABLED
-        config_str += std::string("cuda-clang=true, ");
-    #endif
-    #ifdef ARB_HIP_ENABLED
-        config_str += std::string("hip=true, ");
-    #endif
-    #ifndef ARB_GPU_ENABLED
-        config_str += std::string("gpu=false, ");
-    #endif
-    #ifdef ARB_VECTORIZE_ENABLED
-        config_str += std::string("vectorize=true, ");
-    #else
-        config_str += std::string("vectorize=false, ");
-    #endif
-    #ifdef ARB_PROFILE_ENABLED
-        config_str += std::string("profiling=true, ");
-    #else
-        config_str += std::string("profiling=false, ");
-    #endif
-    #ifdef ARB_NEUROML_ENABLED
-        config_str += std::string("neuroml=true, ");
-    #else
-        config_str += std::string("neuroml=false, ");
-    #endif
-    #ifdef ARB_BUNDLED_ENABLED
-        config_str += std::string("bundled=true, ");
-    #else
-        config_str += std::string("bundled=false, ");
-    #endif
-    config_str += std::string("version='") + arb::version + "', " +
-                  std::string("source='") + arb::source_id + "', " +
-                  std::string("build_config='") + arb::build_config + "', " +
-                  std::string("arch='") + arb::arch + "'";
-    return config_str;
-}
-
 int main(int argc, char** argv) {
     try {
         bool root = true;
@@ -278,7 +231,7 @@ int main(int argc, char** argv) {
                       << "mpi:      " << (has_mpi(context)? "yes": "no") << "\n"
                       << "ranks:    " << num_ranks(context) << "\n"
                       << "stdp:     " << (params.cell.stdp  ? "yes": "no") << "\n"
-                      << "config:   " << (get_arbor_config_str()) << "\n"
+                      << "config:   " << (arb::get_arbor_config_str()) << "\n"
                       << std::endl;
         }
 


### PR DESCRIPTION
This PR introduces a method to get a string representation of the Arbor configuration in C++ (analogously to the `config()` method that has already been available for the Python frontend).

While the C++ function was already introduced by PR #2489 within the busyring example, this PR makes it globally available as a member of the `arb` class.

The PR further introduces small fixes for the busyring example (in the most recent version, the synapse number was off by 1) and for the profiler (missing header file).