### PR TITLE
Normalize only on linear systems.

### DIFF
--- a/arbor/profile/profiler.cpp
+++ b/arbor/profile/profiler.cpp
@@ -155,7 +155,7 @@ const accumulators_type& recorder::accumulators() const {
 std::string timer_stack_to_string(const timer_stack& ts, const std::vector<std::string>& names) {
     std::stringstream ss;
     for (auto ix = 0U; ix < ts.size(); ++ix) {
-        const auto timer = ts[ix];
+        const auto& timer = ts[ix];
         ss << names[timer];
         if (ix != ts.size() - 1) ss << ", ";
     }

--- a/modcc/solvers.cpp
+++ b/modcc/solvers.cpp
@@ -12,7 +12,9 @@
 #include "visitor.hpp"
 
 // normalize row iff system is larger than this
-constexpr int normalization_limit = 5;
+constexpr int nonlinear_normalization_limit =  5;
+constexpr int linear_normalization_limit    =  5;
+constexpr int sparse_normalization_limit    = 15;
 
 // Cnexp solver visitor implementation.
 
@@ -487,7 +489,7 @@ void SparseSolverVisitor::finalize() {
         }
 
         // If size of system > limit normalize the row updates
-        if (system_.size() > normalization_limit) {
+        if (system_.size() > sparse_normalization_limit) {
             auto norm_term = system_.generate_normalizing_term(block_scope_, row);
             auto norm_assigns = system_.generate_normalizing_assignments(norm_term.id->clone(), row);
 
@@ -726,7 +728,7 @@ void LinearSolverVisitor::finalize() {
         }
 
         // If size of system > limit normalize the row updates
-        if (system_.size() > normalization_limit) {
+        if (system_.size() > linear_normalization_limit) {
             auto norm_term = system_.generate_normalizing_term(block_scope_, row);
             auto norm_assigns = system_.generate_normalizing_assignments(norm_term.id->clone(), row);
 
@@ -949,7 +951,7 @@ void SparseNonlinearSolverVisitor::finalize() {
         }
 
         // If size of system > limit normalize the row updates
-        if (system_.size() > normalization_limit) {
+        if (system_.size() > nonlinear_normalization_limit) {
             auto norm_term = system_.generate_normalizing_term(block_scope_, row);
             auto norm_assigns = system_.generate_normalizing_assignments(norm_term.id->clone(), row);
 

--- a/python/example/single_cell_allen.py
+++ b/python/example/single_cell_allen.py
@@ -136,6 +136,7 @@ def make_cell(base, swc, fit):
     # (11) Create cell
     return A.cable_cell(morphology, decor, labels, cvp), offset
 
+
 context = A.context()
 if A.config()["profiling"]:
     A.profiler_initialize(context)

--- a/python/example/single_cell_allen.py
+++ b/python/example/single_cell_allen.py
@@ -136,6 +136,10 @@ def make_cell(base, swc, fit):
     # (11) Create cell
     return A.cable_cell(morphology, decor, labels, cvp), offset
 
+context = A.context()
+if A.config()["profiling"]:
+    A.profiler_initialize(context)
+
 
 # (12) Create cell, model
 cell, offset = make_cell(here, "single_cell_allen.swc", "single_cell_allen_fit.json")
@@ -149,6 +153,9 @@ model.properties.catalogue.extend(A.allen_catalogue())
 
 # (15) Run simulation
 model.run(tfinal=1.4 * U.s, dt=5 * U.us)
+
+if A.config()["profiling"]:
+    print(A.profiler_summary(1.0))
 
 # (16) Load and scale reference
 reference = (


### PR DESCRIPTION
Notice that normalization of rows in linear systems is only needed for the `LinearSolver`.
Roughly cuts the time to integrate the Allen cell example in half.