### PR TITLE
Fix round-robin GID membership

### DIFF
--- a/arbor/partition_load_balance.cpp
+++ b/arbor/partition_load_balance.cpp
@@ -29,7 +29,7 @@ struct gid_range {
 };
 
 // a (stepped) range contains all gids lo <= gid < hi that are multiples of the step
-bool contains_gid(const gid_range& gids, cell_gid_type gid) { return (gid >= gids.beg) && (gid < gids.end) && (gid % gids.dlt == 0); }
+bool contains_gid(const gid_range& gids, cell_gid_type gid) { return (gid >= gids.beg) && (gid < gids.end) && ((gid - gids.beg) % gids.dlt == 0); }
 
 // Build global GJ connectivity table such that
 // * table[gid] is the set of all gids connected to gid via a GJ


### PR DESCRIPTION
Fix the GID membership check used for strided ranges in round-robin load balancing.

The previous condition:

gid % gids.dlt == 0

only works for strided ranges starting at GID 0. In round-robin load balancing, ranges may start at a non-zero gids.beg.

For example, with four ranks, rank 1 owns the strided range:

1, 5, 9, 13, ...

In this case, GID 5 belongs to the range, but:

5 % 4 == 0

evaluates to false.

The membership check now takes the beginning of the range into account:

(gid - gids.beg) % gids.dlt == 0

This correctly handles round-robin strided GID ranges with non-zero starting offsets.